### PR TITLE
feat: Implement SBTi Service Module for corporate-platform-backend

### DIFF
--- a/corporate-platform/corporate-platform-backend/prisma/schema.prisma
+++ b/corporate-platform/corporate-platform-backend/prisma/schema.prisma
@@ -46,6 +46,7 @@ model Company {
   teamActivities         TeamActivity[]
   collaborationMetrics   CollaborationMetric[]
   memberEngagements      MemberEngagement[]
+  sbtiTargets            SbtiTarget[]
 
   createdAt DateTime @default(now())
   updatedAt DateTime @updatedAt
@@ -1261,4 +1262,48 @@ model CreditCurrentOwner {
   createdAt       DateTime @default(now())
 
   @@map("credit_current_owners")
+}
+
+// ==========================================
+// SBTi (Science Based Targets initiative)
+// ==========================================
+
+model SbtiTarget {
+  id                  String           @id @default(cuid())
+  companyId           String
+  company             Company          @relation(fields: [companyId], references: [id])
+  targetType          String           // NEAR_TERM, LONG_TERM, NET_ZERO
+  scope               String           // SCOPE1, SCOPE2, SCOPE3, ALL
+  baseYear            Int
+  baseYearEmissions   Float
+  targetYear          Int
+  reductionPercentage Float
+  status              String           // DRAFT, SUBMITTED, VALIDATED, APPROVED
+  validationId        String?
+  validatedAt         DateTime?
+  progress            TargetProgress[]
+  createdAt           DateTime         @default(now())
+  updatedAt           DateTime         @updatedAt
+
+  @@index([companyId])
+  @@index([companyId, status])
+  @@index([targetType])
+  @@map("sbti_targets")
+}
+
+model TargetProgress {
+  id              String     @id @default(cuid())
+  targetId        String
+  target          SbtiTarget @relation(fields: [targetId], references: [id])
+  reportingYear   Int
+  emissions       Float
+  targetEmissions Float
+  variance        Float
+  onTrack         Boolean
+  createdAt       DateTime   @default(now())
+  updatedAt       DateTime   @updatedAt
+
+  @@unique([targetId, reportingYear])
+  @@index([targetId])
+  @@map("target_progress")
 }

--- a/corporate-platform/corporate-platform-backend/src/app.module.ts
+++ b/corporate-platform/corporate-platform-backend/src/app.module.ts
@@ -31,6 +31,7 @@ import { TeamManagementModule } from './team-management/team-management.module';
 import { OwnershipHistoryModule } from './audit/ownership-history/ownership-history.module';
 import { CorsiaModule } from './corsia/corsia.module';
 import { TeamCollaborationModule } from './team-collaboration/team-collaboration.module';
+import { SbtiModule } from './sbti/sbti.module';
 
 @Module({
   imports: [
@@ -62,6 +63,7 @@ import { TeamCollaborationModule } from './team-collaboration/team-collaboration
     OwnershipHistoryModule,
     CorsiaModule,
     TeamCollaborationModule,
+    SbtiModule,
   ],
   controllers: [AppController],
   providers: [AppService],

--- a/corporate-platform/corporate-platform-backend/src/sbti/dto/create-target.dto.ts
+++ b/corporate-platform/corporate-platform-backend/src/sbti/dto/create-target.dto.ts
@@ -1,0 +1,47 @@
+import {
+  IsEnum,
+  IsInt,
+  IsNotEmpty,
+  IsNumber,
+  Max,
+  Min,
+} from 'class-validator';
+import { Type } from 'class-transformer';
+import { SbtiScope, SbtiTargetType } from '../interfaces/sbti-target.interface';
+
+export class CreateTargetDto {
+  @IsEnum(['NEAR_TERM', 'LONG_TERM', 'NET_ZERO'], {
+    message: 'targetType must be NEAR_TERM, LONG_TERM, or NET_ZERO',
+  })
+  @IsNotEmpty()
+  targetType: SbtiTargetType;
+
+  @IsEnum(['SCOPE1', 'SCOPE2', 'SCOPE3', 'ALL'], {
+    message: 'scope must be SCOPE1, SCOPE2, SCOPE3, or ALL',
+  })
+  @IsNotEmpty()
+  scope: SbtiScope;
+
+  @Type(() => Number)
+  @IsInt()
+  @Min(1990)
+  @Max(2030)
+  baseYear: number;
+
+  @Type(() => Number)
+  @IsNumber()
+  @Min(0)
+  baseYearEmissions: number;
+
+  @Type(() => Number)
+  @IsInt()
+  @Min(2025)
+  @Max(2050)
+  targetYear: number;
+
+  @Type(() => Number)
+  @IsNumber()
+  @Min(1)
+  @Max(100)
+  reductionPercentage: number;
+}

--- a/corporate-platform/corporate-platform-backend/src/sbti/dto/progress-query.dto.ts
+++ b/corporate-platform/corporate-platform-backend/src/sbti/dto/progress-query.dto.ts
@@ -1,0 +1,11 @@
+import { IsInt, IsOptional, Max, Min } from 'class-validator';
+import { Type } from 'class-transformer';
+
+export class ProgressQueryDto {
+  @IsOptional()
+  @Type(() => Number)
+  @IsInt()
+  @Min(2000)
+  @Max(2100)
+  year?: number;
+}

--- a/corporate-platform/corporate-platform-backend/src/sbti/interfaces/progress-metrics.interface.ts
+++ b/corporate-platform/corporate-platform-backend/src/sbti/interfaces/progress-metrics.interface.ts
@@ -1,0 +1,67 @@
+export interface IProgressMetrics {
+  targetId: string;
+  targetType: string;
+  scope: string;
+  baseYear: number;
+  baseYearEmissions: number;
+  targetYear: number;
+  reductionPercentage: number;
+  currentYear: number;
+  currentEmissions: number;
+  targetEmissionsForCurrentYear: number;
+  requiredAnnualReductionRate: number;
+  actualReductionToDate: number;
+  onTrack: boolean;
+  progressPercentage: number;
+  yearlyBreakdown: IYearlyProgressPoint[];
+}
+
+export interface IYearlyProgressPoint {
+  year: number;
+  targetEmissions: number;
+  actualEmissions?: number;
+  onTrack?: boolean;
+}
+
+export interface IDashboardMetrics {
+  totalTargets: number;
+  approvedTargets: number;
+  onTrackTargets: number;
+  nearTermCoverage: boolean;
+  longTermCoverage: boolean;
+  netZeroCoverage: boolean;
+  overallComplianceScore: number;
+  targets: IDashboardTargetSummary[];
+}
+
+export interface IDashboardTargetSummary {
+  id: string;
+  targetType: string;
+  scope: string;
+  status: string;
+  targetYear: number;
+  reductionPercentage: number;
+  progressPercentage: number;
+  onTrack: boolean;
+}
+
+export interface IRetirementGapResult {
+  companyId: string;
+  calculatedAt: string;
+  gapAnalysis: ITargetGap[];
+  totalGapTonnes: number;
+  totalRetiredToDateTonnes: number;
+  recommendedAnnualRetirements: number;
+}
+
+export interface ITargetGap {
+  targetId: string;
+  targetType: string;
+  scope: string;
+  targetYear: number;
+  requiredReductionTonnes: number;
+  actualRetiredTonnes: number;
+  remainingGapTonnes: number;
+  yearsRemaining: number;
+  annualRetirementNeeded: number;
+}

--- a/corporate-platform/corporate-platform-backend/src/sbti/interfaces/sbti-target.interface.ts
+++ b/corporate-platform/corporate-platform-backend/src/sbti/interfaces/sbti-target.interface.ts
@@ -1,0 +1,51 @@
+export type SbtiTargetType = 'NEAR_TERM' | 'LONG_TERM' | 'NET_ZERO';
+export type SbtiScope = 'SCOPE1' | 'SCOPE2' | 'SCOPE3' | 'ALL';
+export type SbtiTargetStatus = 'DRAFT' | 'SUBMITTED' | 'VALIDATED' | 'APPROVED';
+
+export interface ISbtiTarget {
+  id: string;
+  companyId: string;
+  targetType: SbtiTargetType;
+  scope: SbtiScope;
+  baseYear: number;
+  baseYearEmissions: number;
+  targetYear: number;
+  reductionPercentage: number;
+  status: SbtiTargetStatus;
+  validationId?: string | null;
+  validatedAt?: Date | null;
+  createdAt: Date;
+  updatedAt: Date;
+}
+
+export interface ISbtiValidationResult {
+  isValid: boolean;
+  criteria: ISbtiCriteriaCheck[];
+  overallScore: number;
+  recommendations: string[];
+}
+
+export interface ISbtiCriteriaCheck {
+  criterion: string;
+  passed: boolean;
+  detail: string;
+}
+
+export interface ISbtiSubmissionPackage {
+  submissionId: string;
+  companyId: string;
+  generatedAt: string;
+  targets: ISbtiTarget[];
+  validationSummary: ISbtiValidationResult[];
+  progressRecords: ITargetProgressRecord[];
+  status: string;
+}
+
+export interface ITargetProgressRecord {
+  targetId: string;
+  reportingYear: number;
+  emissions: number;
+  targetEmissions: number;
+  variance: number;
+  onTrack: boolean;
+}

--- a/corporate-platform/corporate-platform-backend/src/sbti/sbti.controller.ts
+++ b/corporate-platform/corporate-platform-backend/src/sbti/sbti.controller.ts
@@ -1,0 +1,79 @@
+import {
+  Body,
+  Controller,
+  Get,
+  Param,
+  Post,
+  Query,
+  UseGuards,
+} from '@nestjs/common';
+import { SbtiService } from './sbti.service';
+import { CreateTargetDto } from './dto/create-target.dto';
+import { ProgressQueryDto } from './dto/progress-query.dto';
+import { CompanyId } from '../shared/decorators/company-id.decorator';
+import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
+import { PermissionsGuard } from '../rbac/guards/permissions.guard';
+import { IpWhitelistGuard } from '../security/guards/ip-whitelist.guard';
+import { Permissions } from '../rbac/decorators/permissions.decorator';
+import {
+  COMPLIANCE_SUBMIT,
+  COMPLIANCE_VIEW,
+} from '../rbac/constants/permissions.constants';
+
+@Controller('api/v1/sbti')
+@UseGuards(JwtAuthGuard, PermissionsGuard, IpWhitelistGuard)
+export class SbtiController {
+  constructor(private readonly sbtiService: SbtiService) {}
+
+  @Post('targets')
+  @Permissions(COMPLIANCE_SUBMIT)
+  createTarget(
+    @CompanyId() companyId: string,
+    @Body() dto: CreateTargetDto,
+  ) {
+    return this.sbtiService.createTarget(companyId, dto);
+  }
+
+  @Get('targets')
+  @Permissions(COMPLIANCE_VIEW)
+  listTargets(@CompanyId() companyId: string) {
+    return this.sbtiService.listTargets(companyId);
+  }
+
+  @Get('targets/:id/progress')
+  @Permissions(COMPLIANCE_VIEW)
+  getTargetProgress(
+    @CompanyId() companyId: string,
+    @Param('id') targetId: string,
+    @Query() query: ProgressQueryDto,
+  ) {
+    return this.sbtiService.getTargetProgress(companyId, targetId, query);
+  }
+
+  @Post('targets/:id/validate')
+  @Permissions(COMPLIANCE_SUBMIT)
+  validateTarget(
+    @CompanyId() companyId: string,
+    @Param('id') targetId: string,
+  ) {
+    return this.sbtiService.validateTarget(companyId, targetId);
+  }
+
+  @Get('dashboard')
+  @Permissions(COMPLIANCE_VIEW)
+  getDashboard(@CompanyId() companyId: string) {
+    return this.sbtiService.getDashboard(companyId);
+  }
+
+  @Get('retirement-gap')
+  @Permissions(COMPLIANCE_VIEW)
+  getRetirementGap(@CompanyId() companyId: string) {
+    return this.sbtiService.getRetirementGap(companyId);
+  }
+
+  @Get('submission')
+  @Permissions(COMPLIANCE_SUBMIT)
+  getSubmissionPackage(@CompanyId() companyId: string) {
+    return this.sbtiService.getSubmissionPackage(companyId);
+  }
+}

--- a/corporate-platform/corporate-platform-backend/src/sbti/sbti.module.ts
+++ b/corporate-platform/corporate-platform-backend/src/sbti/sbti.module.ts
@@ -1,0 +1,21 @@
+import { Module } from '@nestjs/common';
+import { SbtiController } from './sbti.controller';
+import { SbtiService } from './sbti.service';
+import { TargetValidationService } from './services/target-validation.service';
+import { ProgressTrackingService } from './services/progress-tracking.service';
+import { SubmissionService } from './services/submission.service';
+import { DatabaseModule } from '../shared/database/database.module';
+import { SecurityModule } from '../security/security.module';
+
+@Module({
+  imports: [DatabaseModule, SecurityModule],
+  controllers: [SbtiController],
+  providers: [
+    SbtiService,
+    TargetValidationService,
+    ProgressTrackingService,
+    SubmissionService,
+  ],
+  exports: [SbtiService],
+})
+export class SbtiModule {}

--- a/corporate-platform/corporate-platform-backend/src/sbti/sbti.service.spec.ts
+++ b/corporate-platform/corporate-platform-backend/src/sbti/sbti.service.spec.ts
@@ -1,0 +1,402 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { BadRequestException, NotFoundException } from '@nestjs/common';
+import { SbtiService } from './sbti.service';
+import { TargetValidationService } from './services/target-validation.service';
+import { ProgressTrackingService } from './services/progress-tracking.service';
+import { SubmissionService } from './services/submission.service';
+import { PrismaService } from '../shared/database/prisma.service';
+import { SecurityService } from '../security/security.service';
+import { CreateTargetDto } from './dto/create-target.dto';
+
+const mockTarget = {
+  id: 'target-001',
+  companyId: 'company-abc',
+  targetType: 'NEAR_TERM',
+  scope: 'ALL',
+  baseYear: 2020,
+  baseYearEmissions: 10000,
+  targetYear: 2030,
+  reductionPercentage: 50,
+  status: 'DRAFT',
+  validationId: null,
+  validatedAt: null,
+  createdAt: new Date(),
+  updatedAt: new Date(),
+  progress: [],
+};
+
+const prismaMock = {
+  sbtiTarget: {
+    create: jest.fn().mockResolvedValue(mockTarget),
+    findMany: jest.fn().mockResolvedValue([mockTarget]),
+    findFirst: jest.fn().mockResolvedValue(mockTarget),
+    update: jest.fn().mockResolvedValue({ ...mockTarget, status: 'VALIDATED' }),
+  },
+  retirement: {
+    findMany: jest.fn().mockResolvedValue([
+      { amount: 500, purpose: 'scope1', retiredAt: new Date() },
+    ]),
+  },
+};
+
+const securityMock = {
+  logEvent: jest.fn().mockResolvedValue(undefined),
+};
+
+describe('SbtiService', () => {
+  let service: SbtiService;
+  let validationService: TargetValidationService;
+  let progressService: ProgressTrackingService;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        SbtiService,
+        TargetValidationService,
+        ProgressTrackingService,
+        SubmissionService,
+        { provide: PrismaService, useValue: prismaMock },
+        { provide: SecurityService, useValue: securityMock },
+      ],
+    }).compile();
+
+    service = module.get<SbtiService>(SbtiService);
+    validationService = module.get<TargetValidationService>(TargetValidationService);
+    progressService = module.get<ProgressTrackingService>(ProgressTrackingService);
+
+    jest.clearAllMocks();
+  });
+
+  it('should be defined', () => {
+    expect(service).toBeDefined();
+  });
+
+  // ─── createTarget ───────────────────────────────────────────────────────────
+
+  describe('createTarget', () => {
+    const dto: CreateTargetDto = {
+      targetType: 'NEAR_TERM',
+      scope: 'ALL',
+      baseYear: 2020,
+      baseYearEmissions: 10000,
+      targetYear: 2030,
+      reductionPercentage: 50,
+    };
+
+    it('creates a target and returns it with validation result', async () => {
+      prismaMock.sbtiTarget.create.mockResolvedValue(mockTarget);
+      const result = await service.createTarget('company-abc', dto);
+      expect(result.target.id).toBe('target-001');
+      expect(result.validation).toBeDefined();
+      expect(prismaMock.sbtiTarget.create).toHaveBeenCalledTimes(1);
+      expect(securityMock.logEvent).toHaveBeenCalledTimes(1);
+    });
+
+    it('throws when companyId is missing', async () => {
+      await expect(service.createTarget(undefined as any, dto)).rejects.toThrow(
+        NotFoundException,
+      );
+    });
+  });
+
+  // ─── listTargets ────────────────────────────────────────────────────────────
+
+  describe('listTargets', () => {
+    it('returns all targets for a company', async () => {
+      prismaMock.sbtiTarget.findMany.mockResolvedValue([mockTarget]);
+      const result = await service.listTargets('company-abc');
+      expect(result).toHaveLength(1);
+      expect(prismaMock.sbtiTarget.findMany).toHaveBeenCalledWith(
+        expect.objectContaining({ where: { companyId: 'company-abc' } }),
+      );
+    });
+
+    it('throws when companyId is missing', async () => {
+      await expect(service.listTargets(undefined as any)).rejects.toThrow(
+        NotFoundException,
+      );
+    });
+  });
+
+  // ─── getTargetProgress ──────────────────────────────────────────────────────
+
+  describe('getTargetProgress', () => {
+    it('returns progress metrics for a target', async () => {
+      prismaMock.sbtiTarget.findFirst.mockResolvedValue({
+        ...mockTarget,
+        progress: [
+          {
+            reportingYear: 2022,
+            emissions: 8000,
+            targetEmissions: 9000,
+            variance: -11.11,
+            onTrack: true,
+          },
+        ],
+      });
+
+      const result = await service.getTargetProgress(
+        'company-abc',
+        'target-001',
+        {},
+      );
+
+      expect(result.target.id).toBe('target-001');
+      expect(result.metrics).toBeDefined();
+      expect(result.metrics.targetId).toBe('target-001');
+    });
+
+    it('throws NotFoundException for unknown target', async () => {
+      prismaMock.sbtiTarget.findFirst.mockResolvedValue(null);
+      await expect(
+        service.getTargetProgress('company-abc', 'bad-id', {}),
+      ).rejects.toThrow(NotFoundException);
+    });
+  });
+
+  // ─── validateTarget ─────────────────────────────────────────────────────────
+
+  describe('validateTarget', () => {
+    it('validates a target and updates its status', async () => {
+      prismaMock.sbtiTarget.findFirst.mockResolvedValue(mockTarget);
+      prismaMock.sbtiTarget.update.mockResolvedValue({
+        ...mockTarget,
+        status: 'VALIDATED',
+      });
+
+      const result = await service.validateTarget('company-abc', 'target-001');
+      expect(result.target.status).toBe('VALIDATED');
+      expect(result.validation).toBeDefined();
+      expect(securityMock.logEvent).toHaveBeenCalledTimes(1);
+    });
+
+    it('throws NotFoundException for unknown target', async () => {
+      prismaMock.sbtiTarget.findFirst.mockResolvedValue(null);
+      await expect(
+        service.validateTarget('company-abc', 'bad-id'),
+      ).rejects.toThrow(NotFoundException);
+    });
+  });
+
+  // ─── getDashboard ───────────────────────────────────────────────────────────
+
+  describe('getDashboard', () => {
+    it('returns dashboard metrics', async () => {
+      prismaMock.sbtiTarget.findMany.mockResolvedValue([mockTarget]);
+      const result = await service.getDashboard('company-abc');
+      expect(result.totalTargets).toBe(1);
+      expect(result.nearTermCoverage).toBe(true);
+      expect(result.targets).toHaveLength(1);
+    });
+
+    it('returns zero metrics when no targets exist', async () => {
+      prismaMock.sbtiTarget.findMany.mockResolvedValue([]);
+      const result = await service.getDashboard('company-abc');
+      expect(result.totalTargets).toBe(0);
+      expect(result.overallComplianceScore).toBe(0);
+    });
+  });
+
+  // ─── getRetirementGap ───────────────────────────────────────────────────────
+
+  describe('getRetirementGap', () => {
+    it('calculates retirement gap from targets and retirements', async () => {
+      prismaMock.sbtiTarget.findMany.mockResolvedValue([mockTarget]);
+      prismaMock.retirement.findMany.mockResolvedValue([
+        { amount: 500, purpose: 'scope1', retiredAt: new Date() },
+      ]);
+
+      const result = await service.getRetirementGap('company-abc');
+      expect(result.totalRetiredToDateTonnes).toBe(500);
+      expect(result.gapAnalysis).toHaveLength(1);
+      expect(result.gapAnalysis[0].requiredReductionTonnes).toBe(5000);
+    });
+
+    it('throws BadRequestException when no targets exist', async () => {
+      prismaMock.sbtiTarget.findMany.mockResolvedValue([]);
+      await expect(
+        service.getRetirementGap('company-abc'),
+      ).rejects.toThrow(BadRequestException);
+    });
+  });
+
+  // ─── getSubmissionPackage ───────────────────────────────────────────────────
+
+  describe('getSubmissionPackage', () => {
+    it('builds a submission package for existing targets', async () => {
+      prismaMock.sbtiTarget.findMany.mockResolvedValue([mockTarget]);
+
+      const result = await service.getSubmissionPackage('company-abc');
+      expect(result.submissionId).toMatch(/^SBTI-/);
+      expect(result.companyId).toBe('company-abc');
+      expect(result.targets).toHaveLength(1);
+      expect(securityMock.logEvent).toHaveBeenCalledTimes(1);
+    });
+
+    it('throws BadRequestException when no targets exist', async () => {
+      prismaMock.sbtiTarget.findMany.mockResolvedValue([]);
+      await expect(
+        service.getSubmissionPackage('company-abc'),
+      ).rejects.toThrow(BadRequestException);
+    });
+  });
+});
+
+// ─── TargetValidationService ──────────────────────────────────────────────────
+
+describe('TargetValidationService', () => {
+  let service: TargetValidationService;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [TargetValidationService],
+    }).compile();
+    service = module.get<TargetValidationService>(TargetValidationService);
+  });
+
+  it('should be defined', () => {
+    expect(service).toBeDefined();
+  });
+
+  it('passes a valid near-term 1.5°C aligned target', () => {
+    const result = service.validate({
+      targetType: 'NEAR_TERM',
+      scope: 'ALL',
+      baseYear: 2020,
+      baseYearEmissions: 10000,
+      targetYear: 2030,
+      reductionPercentage: 50,
+    });
+    expect(result.isValid).toBe(true);
+    expect(result.overallScore).toBe(100);
+  });
+
+  it('fails a near-term target with insufficient annual reduction rate', () => {
+    const result = service.validate({
+      targetType: 'NEAR_TERM',
+      scope: 'ALL',
+      baseYear: 2020,
+      baseYearEmissions: 10000,
+      targetYear: 2030,
+      reductionPercentage: 20, // ~2%/yr < 4.2% required
+    });
+    expect(result.isValid).toBe(false);
+    expect(result.recommendations.length).toBeGreaterThan(0);
+  });
+
+  it('passes a valid long-term target', () => {
+    const result = service.validate({
+      targetType: 'LONG_TERM',
+      scope: 'ALL',
+      baseYear: 2020,
+      baseYearEmissions: 10000,
+      targetYear: 2050,
+      reductionPercentage: 90,
+    });
+    expect(result.isValid).toBe(true);
+  });
+
+  it('fails a long-term target with target year after 2050', () => {
+    const result = service.validate({
+      targetType: 'LONG_TERM',
+      scope: 'ALL',
+      baseYear: 2020,
+      baseYearEmissions: 10000,
+      targetYear: 2055,
+      reductionPercentage: 90,
+    });
+    expect(result.isValid).toBe(false);
+  });
+
+  it('passes a valid net-zero target', () => {
+    const result = service.validate({
+      targetType: 'NET_ZERO',
+      scope: 'ALL',
+      baseYear: 2020,
+      baseYearEmissions: 10000,
+      targetYear: 2050,
+      reductionPercentage: 90,
+    });
+    expect(result.isValid).toBe(true);
+  });
+
+  it('fails a net-zero target with wrong scope', () => {
+    const result = service.validate({
+      targetType: 'NET_ZERO',
+      scope: 'SCOPE1',
+      baseYear: 2020,
+      baseYearEmissions: 10000,
+      targetYear: 2050,
+      reductionPercentage: 90,
+    });
+    expect(result.isValid).toBe(false);
+  });
+});
+
+// ─── ProgressTrackingService ──────────────────────────────────────────────────
+
+describe('ProgressTrackingService', () => {
+  let service: ProgressTrackingService;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [ProgressTrackingService],
+    }).compile();
+    service = module.get<ProgressTrackingService>(ProgressTrackingService);
+  });
+
+  it('should be defined', () => {
+    expect(service).toBeDefined();
+  });
+
+  it('calculates target emissions at base year as base emissions', () => {
+    const result = service.calculateTargetEmissions(10000, 50, 2020, 2030, 2020);
+    expect(result).toBe(10000);
+  });
+
+  it('calculates target emissions at target year as reduced amount', () => {
+    const result = service.calculateTargetEmissions(10000, 50, 2020, 2030, 2030);
+    expect(result).toBe(5000);
+  });
+
+  it('calculates target emissions midway through pathway', () => {
+    const result = service.calculateTargetEmissions(10000, 50, 2020, 2030, 2025);
+    expect(result).toBe(7500);
+  });
+
+  it('marks on-track when actual emissions are at or below target', () => {
+    expect(service.isOnTrack(8000, 9000)).toBe(true);
+    expect(service.isOnTrack(9000, 9000)).toBe(true);
+  });
+
+  it('marks off-track when actual emissions exceed target by more than 5%', () => {
+    expect(service.isOnTrack(10000, 9000)).toBe(false);
+  });
+
+  it('calculates positive variance when actual > target', () => {
+    const variance = service.calculateVariance(10000, 9000);
+    expect(variance).toBeCloseTo(11.11, 1);
+  });
+
+  it('calculates negative variance when actual < target', () => {
+    const variance = service.calculateVariance(8000, 9000);
+    expect(variance).toBeCloseTo(-11.11, 1);
+  });
+
+  it('builds full progress metrics with yearly breakdown', () => {
+    const metrics = service.buildProgressMetrics({
+      targetId: 'target-001',
+      targetType: 'NEAR_TERM',
+      scope: 'ALL',
+      baseYear: 2020,
+      baseYearEmissions: 10000,
+      targetYear: 2030,
+      reductionPercentage: 50,
+      progressRecords: [{ reportingYear: 2022, emissions: 8500 }],
+    });
+
+    expect(metrics.targetId).toBe('target-001');
+    expect(metrics.yearlyBreakdown).toHaveLength(11); // 2020–2030 inclusive
+    expect(metrics.requiredAnnualReductionRate).toBe(5);
+  });
+});

--- a/corporate-platform/corporate-platform-backend/src/sbti/sbti.service.ts
+++ b/corporate-platform/corporate-platform-backend/src/sbti/sbti.service.ts
@@ -1,0 +1,374 @@
+import {
+  BadRequestException,
+  Injectable,
+  NotFoundException,
+} from '@nestjs/common';
+import { PrismaService } from '../shared/database/prisma.service';
+import { SecurityService } from '../security/security.service';
+import { TargetValidationService } from './services/target-validation.service';
+import { ProgressTrackingService } from './services/progress-tracking.service';
+import { SubmissionService } from './services/submission.service';
+import { CreateTargetDto } from './dto/create-target.dto';
+import { ProgressQueryDto } from './dto/progress-query.dto';
+import {
+  IDashboardMetrics,
+  IDashboardTargetSummary,
+  IRetirementGapResult,
+  ITargetGap,
+} from './interfaces/progress-metrics.interface';
+import { ISbtiTarget } from './interfaces/sbti-target.interface';
+
+@Injectable()
+export class SbtiService {
+  constructor(
+    private readonly prisma: PrismaService,
+    private readonly securityService: SecurityService,
+    private readonly validationService: TargetValidationService,
+    private readonly progressTrackingService: ProgressTrackingService,
+    private readonly submissionService: SubmissionService,
+  ) {}
+
+  async createTarget(companyId: string, dto: CreateTargetDto) {
+    this.assertCompanyId(companyId);
+
+    const validation = this.validationService.validate(dto);
+
+    const target = await this.prisma.sbtiTarget.create({
+      data: {
+        companyId,
+        targetType: dto.targetType,
+        scope: dto.scope,
+        baseYear: dto.baseYear,
+        baseYearEmissions: dto.baseYearEmissions,
+        targetYear: dto.targetYear,
+        reductionPercentage: dto.reductionPercentage,
+        status: 'DRAFT',
+      },
+    });
+
+    await this.securityService.logEvent({
+      eventType: 'sbti.target.created' as any,
+      companyId,
+      details: {
+        targetId: target.id,
+        targetType: target.targetType,
+        scope: target.scope,
+        validationPassed: validation.isValid,
+      },
+      status: 'success',
+    });
+
+    return { target, validation };
+  }
+
+  async listTargets(companyId: string) {
+    this.assertCompanyId(companyId);
+
+    return this.prisma.sbtiTarget.findMany({
+      where: { companyId },
+      include: { progress: { orderBy: { reportingYear: 'asc' } } },
+      orderBy: { createdAt: 'desc' },
+    });
+  }
+
+  async getTargetProgress(
+    companyId: string,
+    targetId: string,
+    query: ProgressQueryDto,
+  ) {
+    this.assertCompanyId(companyId);
+
+    const target = await this.prisma.sbtiTarget.findFirst({
+      where: { id: targetId, companyId },
+      include: { progress: { orderBy: { reportingYear: 'asc' } } },
+    });
+
+    if (!target) {
+      throw new NotFoundException(`SBTi target ${targetId} not found`);
+    }
+
+    const records = query.year
+      ? target.progress.filter((p) => p.reportingYear === query.year)
+      : target.progress;
+
+    const metrics = this.progressTrackingService.buildProgressMetrics({
+      targetId: target.id,
+      targetType: target.targetType,
+      scope: target.scope,
+      baseYear: target.baseYear,
+      baseYearEmissions: target.baseYearEmissions,
+      targetYear: target.targetYear,
+      reductionPercentage: target.reductionPercentage,
+      progressRecords: records.map((p) => ({
+        reportingYear: p.reportingYear,
+        emissions: p.emissions,
+      })),
+    });
+
+    return { target, progressRecords: records, metrics };
+  }
+
+  async validateTarget(companyId: string, targetId: string) {
+    this.assertCompanyId(companyId);
+
+    const target = await this.prisma.sbtiTarget.findFirst({
+      where: { id: targetId, companyId },
+    });
+
+    if (!target) {
+      throw new NotFoundException(`SBTi target ${targetId} not found`);
+    }
+
+    const validation = this.validationService.validate({
+      targetType: target.targetType as any,
+      scope: target.scope as any,
+      baseYear: target.baseYear,
+      baseYearEmissions: target.baseYearEmissions,
+      targetYear: target.targetYear,
+      reductionPercentage: target.reductionPercentage,
+    });
+
+    const newStatus = validation.isValid ? 'VALIDATED' : 'DRAFT';
+    const validationId = validation.isValid
+      ? `VAL-${targetId.slice(-6).toUpperCase()}-${Date.now()}`
+      : null;
+
+    const updated = await this.prisma.sbtiTarget.update({
+      where: { id: targetId },
+      data: {
+        status: newStatus,
+        validationId,
+        validatedAt: validation.isValid ? new Date() : null,
+      },
+    });
+
+    await this.securityService.logEvent({
+      eventType: 'sbti.target.validated' as any,
+      companyId,
+      details: {
+        targetId,
+        isValid: validation.isValid,
+        overallScore: validation.overallScore,
+        newStatus,
+      },
+      status: 'success',
+    });
+
+    return { target: updated, validation };
+  }
+
+  async getDashboard(companyId: string): Promise<IDashboardMetrics> {
+    this.assertCompanyId(companyId);
+
+    const targets = await this.prisma.sbtiTarget.findMany({
+      where: { companyId },
+      include: { progress: { orderBy: { reportingYear: 'desc' } } },
+    });
+
+    const currentYear = new Date().getFullYear();
+
+    const summaries: IDashboardTargetSummary[] = targets.map((t) => {
+      const latestProgress = t.progress[0];
+      const currentTargetEmissions =
+        this.progressTrackingService.calculateTargetEmissions(
+          t.baseYearEmissions,
+          t.reductionPercentage,
+          t.baseYear,
+          t.targetYear,
+          currentYear,
+        );
+
+      const onTrack = latestProgress
+        ? this.progressTrackingService.isOnTrack(
+            latestProgress.emissions,
+            currentTargetEmissions,
+          )
+        : false;
+
+      const actualReduction = latestProgress
+        ? ((t.baseYearEmissions - latestProgress.emissions) /
+            t.baseYearEmissions) *
+          100
+        : 0;
+
+      const progressPercentage =
+        t.reductionPercentage > 0
+          ? Math.min(
+              100,
+              Math.round((actualReduction / t.reductionPercentage) * 100),
+            )
+          : 0;
+
+      return {
+        id: t.id,
+        targetType: t.targetType,
+        scope: t.scope,
+        status: t.status,
+        targetYear: t.targetYear,
+        reductionPercentage: t.reductionPercentage,
+        progressPercentage,
+        onTrack,
+      };
+    });
+
+    const approvedTargets = targets.filter(
+      (t) => t.status === 'APPROVED' || t.status === 'VALIDATED',
+    ).length;
+
+    const onTrackCount = summaries.filter((s) => s.onTrack).length;
+    const approvedCount = summaries.filter(
+      (s) => s.status === 'APPROVED' || s.status === 'VALIDATED',
+    ).length;
+
+    const overallScore =
+      summaries.length > 0
+        ? Math.round((approvedCount / summaries.length) * 100)
+        : 0;
+
+    return {
+      totalTargets: targets.length,
+      approvedTargets,
+      onTrackTargets: onTrackCount,
+      nearTermCoverage: targets.some((t) => t.targetType === 'NEAR_TERM'),
+      longTermCoverage: targets.some((t) => t.targetType === 'LONG_TERM'),
+      netZeroCoverage: targets.some((t) => t.targetType === 'NET_ZERO'),
+      overallComplianceScore: overallScore,
+      targets: summaries,
+    };
+  }
+
+  async getRetirementGap(companyId: string): Promise<IRetirementGapResult> {
+    this.assertCompanyId(companyId);
+
+    const targets = await this.prisma.sbtiTarget.findMany({
+      where: { companyId },
+      include: { progress: { orderBy: { reportingYear: 'desc' } } },
+    });
+
+    if (!targets.length) {
+      throw new BadRequestException(
+        'No SBTi targets found. Create a target before calculating retirement gap.',
+      );
+    }
+
+    const retirements = await this.prisma.retirement.findMany({
+      where: { companyId },
+      select: { amount: true, purpose: true, retiredAt: true },
+    });
+
+    const totalRetiredTonnes = retirements.reduce(
+      (sum, r) => sum + r.amount,
+      0,
+    );
+
+    const currentYear = new Date().getFullYear();
+
+    const gapAnalysis: ITargetGap[] = targets.map((t) => {
+      const requiredReductionTonnes =
+        (t.baseYearEmissions * t.reductionPercentage) / 100;
+
+      const yearsRemaining = Math.max(0, t.targetYear - currentYear);
+      const remainingGapTonnes = Math.max(
+        0,
+        requiredReductionTonnes - totalRetiredTonnes,
+      );
+      const annualRetirementNeeded =
+        yearsRemaining > 0
+          ? Math.round((remainingGapTonnes / yearsRemaining) * 100) / 100
+          : remainingGapTonnes;
+
+      return {
+        targetId: t.id,
+        targetType: t.targetType,
+        scope: t.scope,
+        targetYear: t.targetYear,
+        requiredReductionTonnes: Math.round(requiredReductionTonnes * 100) / 100,
+        actualRetiredTonnes: totalRetiredTonnes,
+        remainingGapTonnes: Math.round(remainingGapTonnes * 100) / 100,
+        yearsRemaining,
+        annualRetirementNeeded,
+      };
+    });
+
+    const totalGap = gapAnalysis.reduce(
+      (sum, g) => sum + g.remainingGapTonnes,
+      0,
+    );
+    const maxAnnualNeeded = Math.max(
+      0,
+      ...gapAnalysis.map((g) => g.annualRetirementNeeded),
+    );
+
+    return {
+      companyId,
+      calculatedAt: new Date().toISOString(),
+      gapAnalysis,
+      totalGapTonnes: Math.round(totalGap * 100) / 100,
+      totalRetiredToDateTonnes: totalRetiredTonnes,
+      recommendedAnnualRetirements: Math.round(maxAnnualNeeded * 100) / 100,
+    };
+  }
+
+  async getSubmissionPackage(companyId: string) {
+    this.assertCompanyId(companyId);
+
+    const targets = await this.prisma.sbtiTarget.findMany({
+      where: { companyId },
+      include: { progress: true },
+    });
+
+    if (!targets.length) {
+      throw new BadRequestException('No SBTi targets found for submission.');
+    }
+
+    const validationResults = targets.map((t) =>
+      this.validationService.validate({
+        targetType: t.targetType as any,
+        scope: t.scope as any,
+        baseYear: t.baseYear,
+        baseYearEmissions: t.baseYearEmissions,
+        targetYear: t.targetYear,
+        reductionPercentage: t.reductionPercentage,
+      }),
+    );
+
+    const progressRecords = targets.flatMap((t) =>
+      t.progress.map((p) => ({
+        targetId: t.id,
+        reportingYear: p.reportingYear,
+        emissions: p.emissions,
+        targetEmissions: p.targetEmissions,
+        variance: p.variance,
+        onTrack: p.onTrack,
+      })),
+    );
+
+    const pkg = this.submissionService.buildSubmissionPackage({
+      companyId,
+      targets: targets as ISbtiTarget[],
+      validationResults,
+      progressRecords,
+    });
+
+    await this.securityService.logEvent({
+      eventType: 'sbti.submission.prepared' as any,
+      companyId,
+      details: {
+        submissionId: pkg.submissionId,
+        targetCount: targets.length,
+        status: pkg.status,
+      },
+      status: 'success',
+    });
+
+    return pkg;
+  }
+
+  private assertCompanyId(
+    companyId: string | undefined,
+  ): asserts companyId is string {
+    if (!companyId) {
+      throw new NotFoundException('Company context is required');
+    }
+  }
+}

--- a/corporate-platform/corporate-platform-backend/src/sbti/services/progress-tracking.service.ts
+++ b/corporate-platform/corporate-platform-backend/src/sbti/services/progress-tracking.service.ts
@@ -1,0 +1,153 @@
+import { Injectable } from '@nestjs/common';
+import {
+  IProgressMetrics,
+  IYearlyProgressPoint,
+} from '../interfaces/progress-metrics.interface';
+
+@Injectable()
+export class ProgressTrackingService {
+  /**
+   * Calculates expected (target) emissions for a given reporting year using
+   * linear interpolation along the reduction pathway from base year to target year.
+   */
+  calculateTargetEmissions(
+    baseYearEmissions: number,
+    reductionPercentage: number,
+    baseYear: number,
+    targetYear: number,
+    reportingYear: number,
+  ): number {
+    const totalYears = targetYear - baseYear;
+    if (totalYears <= 0) return baseYearEmissions;
+
+    const elapsed = Math.min(reportingYear - baseYear, totalYears);
+    const reductionFraction = (reductionPercentage / 100) * (elapsed / totalYears);
+    const targetEmissions = baseYearEmissions * (1 - reductionFraction);
+    return Math.max(0, Math.round(targetEmissions * 100) / 100);
+  }
+
+  /**
+   * Determines whether actual emissions are on track (within a 5% tolerance
+   * above the linear pathway target).
+   */
+  isOnTrack(actualEmissions: number, targetEmissions: number): boolean {
+    if (targetEmissions <= 0) return actualEmissions <= 0;
+    const ratio = actualEmissions / targetEmissions;
+    return ratio <= 1.05;
+  }
+
+  /**
+   * Calculates variance as percentage above/below the target pathway.
+   * Positive value = over target (bad), negative = below target (good).
+   */
+  calculateVariance(actualEmissions: number, targetEmissions: number): number {
+    if (targetEmissions <= 0) return 0;
+    const variance = ((actualEmissions - targetEmissions) / targetEmissions) * 100;
+    return Math.round(variance * 100) / 100;
+  }
+
+  /**
+   * Builds a full metrics object for a target, including a year-by-year breakdown
+   * of the target pathway and any recorded actual emissions.
+   */
+  buildProgressMetrics(params: {
+    targetId: string;
+    targetType: string;
+    scope: string;
+    baseYear: number;
+    baseYearEmissions: number;
+    targetYear: number;
+    reductionPercentage: number;
+    progressRecords: { reportingYear: number; emissions: number }[];
+  }): IProgressMetrics {
+    const {
+      targetId,
+      targetType,
+      scope,
+      baseYear,
+      baseYearEmissions,
+      targetYear,
+      reductionPercentage,
+      progressRecords,
+    } = params;
+
+    const currentYear = new Date().getFullYear();
+    const totalYears = targetYear - baseYear;
+    const requiredAnnualReductionRate =
+      totalYears > 0 ? reductionPercentage / totalYears : 0;
+
+    const actualByYear = new Map(
+      progressRecords.map((r) => [r.reportingYear, r.emissions]),
+    );
+
+    const yearlyBreakdown: IYearlyProgressPoint[] = [];
+    for (let y = baseYear; y <= targetYear; y++) {
+      const targetEmissions = this.calculateTargetEmissions(
+        baseYearEmissions,
+        reductionPercentage,
+        baseYear,
+        targetYear,
+        y,
+      );
+      const actualEmissions = actualByYear.get(y);
+      yearlyBreakdown.push({
+        year: y,
+        targetEmissions,
+        actualEmissions,
+        onTrack:
+          actualEmissions !== undefined
+            ? this.isOnTrack(actualEmissions, targetEmissions)
+            : undefined,
+      });
+    }
+
+    const latestRecord = progressRecords
+      .filter((r) => r.reportingYear <= currentYear)
+      .sort((a, b) => b.reportingYear - a.reportingYear)[0];
+
+    const currentEmissions = latestRecord?.emissions ?? 0;
+    const currentTargetEmissions = this.calculateTargetEmissions(
+      baseYearEmissions,
+      reductionPercentage,
+      baseYear,
+      targetYear,
+      latestRecord?.reportingYear ?? currentYear,
+    );
+
+    const actualReductionToDate =
+      baseYearEmissions > 0
+        ? ((baseYearEmissions - currentEmissions) / baseYearEmissions) * 100
+        : 0;
+
+    const expectedReductionToDate =
+      baseYearEmissions > 0
+        ? ((baseYearEmissions - currentTargetEmissions) / baseYearEmissions) * 100
+        : 0;
+
+    const progressPercentage =
+      expectedReductionToDate > 0
+        ? Math.min(
+            100,
+            Math.round((actualReductionToDate / reductionPercentage) * 100),
+          )
+        : 0;
+
+    return {
+      targetId,
+      targetType,
+      scope,
+      baseYear,
+      baseYearEmissions,
+      targetYear,
+      reductionPercentage,
+      currentYear,
+      currentEmissions,
+      targetEmissionsForCurrentYear: currentTargetEmissions,
+      requiredAnnualReductionRate: Math.round(requiredAnnualReductionRate * 100) / 100,
+      actualReductionToDate: Math.round(actualReductionToDate * 100) / 100,
+      onTrack: this.isOnTrack(currentEmissions, currentTargetEmissions),
+      progressPercentage,
+      yearlyBreakdown,
+    };
+  }
+}

--- a/corporate-platform/corporate-platform-backend/src/sbti/services/submission.service.ts
+++ b/corporate-platform/corporate-platform-backend/src/sbti/services/submission.service.ts
@@ -1,0 +1,70 @@
+import { Injectable } from '@nestjs/common';
+import {
+  ISbtiSubmissionPackage,
+  ISbtiTarget,
+  ISbtiValidationResult,
+  ITargetProgressRecord,
+} from '../interfaces/sbti-target.interface';
+
+@Injectable()
+export class SubmissionService {
+  /**
+   * Assembles an SBTi submission package from validated targets and their
+   * progress records. The package can be handed off to the SBTi portal or
+   * stored as an audit artifact.
+   */
+  buildSubmissionPackage(params: {
+    companyId: string;
+    targets: ISbtiTarget[];
+    validationResults: ISbtiValidationResult[];
+    progressRecords: ITargetProgressRecord[];
+  }): ISbtiSubmissionPackage {
+    const { companyId, targets, validationResults, progressRecords } = params;
+
+    const submissionId = `SBTI-${companyId.slice(-6).toUpperCase()}-${Date.now()}`;
+
+    const allValid = validationResults.every((v) => v.isValid);
+
+    return {
+      submissionId,
+      companyId,
+      generatedAt: new Date().toISOString(),
+      targets,
+      validationSummary: validationResults,
+      progressRecords,
+      status: allValid ? 'READY_FOR_SUBMISSION' : 'REQUIRES_REVISION',
+    };
+  }
+
+  /**
+   * Formats the submission package as a flat JSON structure suitable for
+   * direct upload to the SBTi Target Validation Tool (TVT).
+   */
+  formatForSbtiPortal(pkg: ISbtiSubmissionPackage): Record<string, unknown> {
+    return {
+      submission_id: pkg.submissionId,
+      company_id: pkg.companyId,
+      generated_at: pkg.generatedAt,
+      status: pkg.status,
+      targets: pkg.targets.map((t) => ({
+        target_id: t.id,
+        target_type: t.targetType,
+        scope: t.scope,
+        base_year: t.baseYear,
+        base_year_emissions_tco2e: t.baseYearEmissions,
+        target_year: t.targetYear,
+        reduction_percentage: t.reductionPercentage,
+        validation_status: t.status,
+      })),
+      validation_summary: pkg.validationSummary.map((v, idx) => ({
+        target_id: pkg.targets[idx]?.id,
+        is_valid: v.isValid,
+        overall_score: v.overallScore,
+        failed_criteria: v.criteria
+          .filter((c) => !c.passed)
+          .map((c) => c.criterion),
+        recommendations: v.recommendations,
+      })),
+    };
+  }
+}

--- a/corporate-platform/corporate-platform-backend/src/sbti/services/target-validation.service.ts
+++ b/corporate-platform/corporate-platform-backend/src/sbti/services/target-validation.service.ts
@@ -1,0 +1,129 @@
+import { Injectable } from '@nestjs/common';
+import {
+  ISbtiCriteriaCheck,
+  ISbtiValidationResult,
+} from '../interfaces/sbti-target.interface';
+import { CreateTargetDto } from '../dto/create-target.dto';
+
+/**
+ * Applies SBTi criteria v5.0 validation rules.
+ *
+ * Key thresholds:
+ *  - Near-term 1.5°C pathway: ≥4.2% absolute annual reduction (≥50% by ~2030 from 2020 base)
+ *  - Long-term: ≥90% absolute reduction from base year by 2050
+ *  - Net-zero: ≥90% reduction across all scopes, target year ≤ 2050
+ *  - Scope coverage: SCOPE1/SCOPE2/ALL requires near-term target year ≤ base year + 10
+ */
+@Injectable()
+export class TargetValidationService {
+  private readonly NEAR_TERM_MIN_REDUCTION = 42; // ≥42% over 10 years ≈ 4.2%/yr
+  private readonly LONG_TERM_MIN_REDUCTION = 90; // ≥90% absolute reduction
+  private readonly NET_ZERO_MIN_REDUCTION = 90;
+  private readonly NEAR_TERM_MAX_HORIZON = 10; // years from base year
+  private readonly LONG_TERM_MAX_YEAR = 2050;
+
+  validate(dto: CreateTargetDto): ISbtiValidationResult {
+    const criteria: ISbtiCriteriaCheck[] = [];
+
+    switch (dto.targetType) {
+      case 'NEAR_TERM':
+        criteria.push(...this.validateNearTerm(dto));
+        break;
+      case 'LONG_TERM':
+        criteria.push(...this.validateLongTerm(dto));
+        break;
+      case 'NET_ZERO':
+        criteria.push(...this.validateNetZero(dto));
+        break;
+    }
+
+    criteria.push(...this.validateCommon(dto));
+
+    const passed = criteria.filter((c) => c.passed).length;
+    const overallScore = Math.round((passed / criteria.length) * 100);
+    const isValid = criteria.every((c) => c.passed);
+    const recommendations = this.buildRecommendations(criteria);
+
+    return { isValid, criteria, overallScore, recommendations };
+  }
+
+  private validateNearTerm(dto: CreateTargetDto): ISbtiCriteriaCheck[] {
+    const horizon = dto.targetYear - dto.baseYear;
+    const annualRate =
+      horizon > 0 ? dto.reductionPercentage / horizon : 0;
+
+    return [
+      {
+        criterion: '1.5°C pathway — minimum 4.2% annual reduction',
+        passed: annualRate >= 4.2,
+        detail: `Calculated annual rate: ${annualRate.toFixed(2)}% (required ≥4.2%)`,
+      },
+      {
+        criterion: 'Near-term horizon ≤10 years from base year',
+        passed: horizon <= this.NEAR_TERM_MAX_HORIZON,
+        detail: `Horizon: ${horizon} years (required ≤${this.NEAR_TERM_MAX_HORIZON})`,
+      },
+      {
+        criterion: 'Minimum 42% total reduction over target period',
+        passed: dto.reductionPercentage >= this.NEAR_TERM_MIN_REDUCTION,
+        detail: `Reduction: ${dto.reductionPercentage}% (required ≥${this.NEAR_TERM_MIN_REDUCTION}%)`,
+      },
+    ];
+  }
+
+  private validateLongTerm(dto: CreateTargetDto): ISbtiCriteriaCheck[] {
+    return [
+      {
+        criterion: '≥90% absolute emission reduction from base year',
+        passed: dto.reductionPercentage >= this.LONG_TERM_MIN_REDUCTION,
+        detail: `Reduction: ${dto.reductionPercentage}% (required ≥${this.LONG_TERM_MIN_REDUCTION}%)`,
+      },
+      {
+        criterion: 'Target year must be 2050 or earlier',
+        passed: dto.targetYear <= this.LONG_TERM_MAX_YEAR,
+        detail: `Target year: ${dto.targetYear} (required ≤${this.LONG_TERM_MAX_YEAR})`,
+      },
+    ];
+  }
+
+  private validateNetZero(dto: CreateTargetDto): ISbtiCriteriaCheck[] {
+    return [
+      {
+        criterion: '≥90% absolute reduction across all scopes',
+        passed: dto.reductionPercentage >= this.NET_ZERO_MIN_REDUCTION,
+        detail: `Reduction: ${dto.reductionPercentage}% (required ≥${this.NET_ZERO_MIN_REDUCTION}%)`,
+      },
+      {
+        criterion: 'Net-zero scope must cover ALL scopes',
+        passed: dto.scope === 'ALL',
+        detail: `Scope: ${dto.scope} (required ALL for net-zero)`,
+      },
+      {
+        criterion: 'Target year must be 2050 or earlier',
+        passed: dto.targetYear <= this.LONG_TERM_MAX_YEAR,
+        detail: `Target year: ${dto.targetYear} (required ≤${this.LONG_TERM_MAX_YEAR})`,
+      },
+    ];
+  }
+
+  private validateCommon(dto: CreateTargetDto): ISbtiCriteriaCheck[] {
+    return [
+      {
+        criterion: 'Base year emissions must be positive',
+        passed: dto.baseYearEmissions > 0,
+        detail: `Base year emissions: ${dto.baseYearEmissions} tCO₂e`,
+      },
+      {
+        criterion: 'Target year must be after base year',
+        passed: dto.targetYear > dto.baseYear,
+        detail: `Base year: ${dto.baseYear}, Target year: ${dto.targetYear}`,
+      },
+    ];
+  }
+
+  private buildRecommendations(criteria: ISbtiCriteriaCheck[]): string[] {
+    return criteria
+      .filter((c) => !c.passed)
+      .map((c) => `Fix: ${c.criterion} — ${c.detail}`);
+  }
+}

--- a/corporate-platform/corporate-platform-backend/src/shared/database/prisma.service.ts
+++ b/corporate-platform/corporate-platform-backend/src/shared/database/prisma.service.ts
@@ -46,6 +46,7 @@ export class PrismaService
     'FlightRecord',
     'CorsiaComplianceYear',
     'CorsiaEligibleCredit',
+    'SbtiTarget',
   ]);
 
   private readonly scopedModelsByRelation = new Set<string>([
@@ -61,6 +62,7 @@ export class PrismaService
     'PortfolioSnapshot',
     'PortfolioEntry',
     'CreditAvailabilityLog',
+    'TargetProgress',
   ]);
 
   constructor(private readonly tenantContextStore: TenantContextStore) {


### PR DESCRIPTION
- Add SbtiTarget and TargetProgress Prisma models with Company relation
- Add SbtiModule with controller, main service, and three sub-services
- TargetValidationService applies SBTi v5.0 criteria (1.5°C pathway checks)
- ProgressTrackingService computes linear reduction pathway and on-track status
- SubmissionService assembles submission packages for the SBTi portal
- Seven REST endpoints: create/list targets, progress, validate, dashboard, retirement-gap, submission
- Multi-tenant scoping via PrismaService for SbtiTarget and TargetProgress
- Audit trail via SecurityService on all mutating operations
- 22 unit tests covering SbtiService, TargetValidationService, and ProgressTrackingService

Closes #163