### PR TITLE
docs: synchronize and detail all platform README.md folder structures

### DIFF
--- a/corporate-platform/README.md
+++ b/corporate-platform/README.md
@@ -1,0 +1,66 @@
+# Corporate Platform: Enterprise Carbon Management Suite
+
+![NestJS](https://img.shields.io/badge/NestJS-10.0-red)
+![Next.js 15](https://img.shields.io/badge/Next.js-15-black)
+![Stellar Mainnet](https://img.shields.io/badge/Stellar-Mainnet-red)
+![License: AGPL-3.0](https://img.shields.io/badge/license-AGPL--3.0-green)
+
+The **Corporate Platform** is CarbonScribe’s enterprise-grade solution for transparent, real-time carbon credit retirement, compliance, and ESG reporting. It empowers corporations to manage their carbon portfolios, retire credits instantly, and generate regulatory-grade reports with on-chain proof.
+
+---
+
+## 📚 Table of Contents
+- [Overview](#-overview)
+- [Architecture](#-architecture)
+- [Key Features](#key-features)
+- [Folder Structure](#folder-structure)
+- [Quick Start](#quick-start)
+- [Security](#security)
+- [Contributing](#contributing)
+
+---
+
+## 🌟 Overview
+The Corporate Platform enables:
+- **One-click retirement** of carbon credits with blockchain verification
+- **Automated ESG reporting** (CSRD, GHG Protocol, SBTi)
+- **Dutch auction marketplace** for dynamic credit pricing
+- **Impact visualization** and SDG alignment
+
+## 🏗️ Architecture
+```
+corporate-platform/
+├── corporate-platform-backend/   # NestJS API & compliance engine
+├── corporate-platform-web/       # Next.js 15 frontend dashboard
+```
+- **Backend:** Handles retirement, compliance, marketplace, and analytics
+- **Frontend:** Corporate dashboard for portfolio, marketplace, and reporting
+
+## 🚀 Key Features
+- Instant on-chain retirement & certificate generation
+- ESG & sustainability reporting
+- Real-time analytics and dashboards
+- Marketplace for credit discovery and auctions
+- Secure, role-based access
+
+## 📁 Folder Structure
+```
+corporate-platform/
+├── corporate-platform-backend/   # Backend API (NestJS)
+├── corporate-platform-web/       # Frontend (Next.js)
+```
+
+## ⚡ Quick Start
+See individual backend and frontend READMEs for setup instructions.
+
+## 🔒 Security
+- Role-based authentication
+- On-chain verification
+- Immutable audit trails
+
+## 🤝 Contributing
+Pull requests welcome! See root CONTRIBUTING.md for guidelines.
+
+---
+
+*Part of the CarbonScribe 7-Layer Architecture. See root README for full platform overview.*

--- a/corporate-platform/corporate-platform-backend/README.md
+++ b/corporate-platform/corporate-platform-backend/README.md
@@ -199,63 +199,64 @@ JWT_EXPIRY=15m
 ```
 corporate-platform-backend/
 ├── src/
-│   ├── retirement/                 # Retirement module
-│   │   ├── dto/                    # Data transfer objects
-│   │   │   ├── retire-credits.dto.ts
-│   │   │   └── retirement-query.dto.ts
-│   │   ├── services/               
-│   │   │   ├── instant-retirement.service.ts
-│   │   │   ├── validation.service.ts
-│   │   │   ├── certificate.service.ts
-│   │   │   └── history.service.ts
-│   │   ├── retirement.controller.ts
-│   │   ├── retirement.service.ts
-│   │   └── retirement.module.ts
-│   ├── compliance/                  # Compliance module
-│   │   ├── compliance.controller.ts
-│   │   ├── reporting-engine.service.ts
-│   │   └── compliance.module.ts
-│   ├── marketplace/                 # Marketplace module
-│   │   ├── marketplace.controller.ts
-│   │   ├── discovery-engine.service.ts
-│   │   └── marketplace.module.ts
-│   ├── stellar/                     # Blockchain integration
-│   │   ├── stellar.service.ts
-│   │   ├── soroban.service.ts
-│   │   └── stellar.module.ts
-│   ├── webhooks/                     # Webhook handlers
-│   │   ├── webhooks.controller.ts
-│   │   ├── stellar-webhook.service.ts
-│   │   └── webhooks.module.ts
-│   ├── analytics/                     # Analytics module
-│   │   ├── analytics.controller.ts
-│   │   ├── impact-dashboard.service.ts
-│   │   └── analytics.module.ts
-│   ├── shared/                        # Shared resources
-│   │   ├── database/
-│   │   │   ├── database.module.ts
-│   │   │   └── prisma.service.ts      # Prisma client service
-│   │   ├── cache/
-│   │   │   └── redis.service.ts       # Redis cache
-│   │   ├── ipfs/
-│   │   │   └── ipfs.service.ts        # IPFS storage
-│   │   ├── guards/                     # Auth guards
-│   │   └── interceptors/               # HTTP interceptors
-│   ├── app.module.ts
+│   ├── analytics/
+│   ├── api-key/
+│   ├── app.controller.spec.ts
 │   ├── app.controller.ts
-│   └── main.ts
+│   ├── app.module.ts
+│   ├── app.service.ts
+│   ├── auction/
+│   ├── audit/
+│   ├── audit-trail/
+│   ├── auth/
+│   ├── cache/
+│   ├── cart/
+│   ├── cbam/
+│   ├── compliance/
+│   ├── config/
+│   ├── corsia/
+│   ├── credit/
+│   ├── csrd/
+│   ├── event-bus/
+│   ├── framework-registry/
+│   ├── ghg-protocol/
+│   ├── ipfs/
+│   ├── logger/
+│   ├── main.ts
+│   ├── marketplace/
+│   ├── multi-tenant/
+│   ├── order/
+│   ├── portfolio/
+│   ├── rbac/
+│   ├── retirement/
+│   ├── retirement-analytics/
+│   ├── retirement-scheduling/
+│   ├── security/
+│   ├── shared/
+│   ├── shims.d.ts
+│   ├── stellar/
+│   ├── team-collaboration/
+│   ├── team-management/
+│   ├── types/
+│   └── webhooks/
 ├── prisma/
-│   ├── schema.prisma                   # Database schema
-│   └── migrations/                      # Migration files
+│   ├── schema.prisma
+│   └── migrations/
 ├── test/
+│   ├── api-key-integration.e2e-spec.ts
+│   ├── app.e2e-spec.ts
+│   ├── compliance.e2e-spec.ts
+│   ├── jest-e2e.json
+│   ├── marketplace.e2e-spec.ts
+│   ├── portfolio.e2e-spec.ts
 │   ├── retirement.e2e-spec.ts
-│   └── compliance.e2e-spec.ts
+│   └── team-collaboration.e2e-spec.ts
 ├── .env.example
 ├── .eslintrc.js
 ├── .prettierrc
 ├── nest-cli.json
 ├── package.json
-├── prisma.config.js                     # Prisma 7+ config
+├── prisma.config.js
 ├── tsconfig.json
 └── README.md
 ```

--- a/corporate-platform/corporate-platform-web/README.md
+++ b/corporate-platform/corporate-platform-web/README.md
@@ -27,20 +27,46 @@ A modern Next.js web application for corporate buyers to purchase, manage, and r
 
 ## Project Structure
 
+
 ```
-    src/
-    ├── app/                    # App router pages
-    ├── components/            # Reusable components
-    │   ├── layout/           # Layout components (Navbar, Sidebar)
-    │   ├── dashboard/        # Dashboard components
-    │   ├── marketplace/      # Credit marketplace components
-    │   ├── retirement/       # Retirement components
-    │   ├── analytics/        # Analytics components
-    │   └── theme/           # Theme provider
-    ├── contexts/             # React contexts
-    ├── lib/                  # Utilities and mock data
-    ├── types/               # TypeScript definitions
-    └── utils/               # Helper functions
+src/
+├── app/
+│   ├── analytics/
+│   ├── api/
+│   ├── compliance/
+│   ├── corporate/
+│   ├── favicon.ico
+│   ├── globals.css
+│   ├── layout.tsx
+│   ├── marketplace/
+│   ├── page.tsx
+│   ├── portfolio/
+│   ├── projects/
+│   ├── reporting/
+│   ├── retirement/
+│   ├── settings/
+│   └── team/
+├── components/
+│   ├── actions/
+│   ├── analytics/
+│   ├── dashboard/
+│   ├── feed/
+│   ├── goals/
+│   ├── layout/
+│   ├── marketplace/
+│   ├── reporting/
+│   ├── retirement/
+│   └── theme/
+├── contexts/
+│   └── CorporateContext.tsx
+├── hooks/
+│   └── useTheme.ts
+├── lib/
+│   ├── analytics/
+│   ├── compliance/
+│   └── mockData.ts
+├── types/
+│   └── index.ts
 ```
 
 ---

--- a/project-portal/README.md
+++ b/project-portal/README.md
@@ -1,0 +1,66 @@
+# Project Portal: Developer Onboarding & Monitoring Suite
+
+![Go Backend](https://img.shields.io/badge/Go-1.21-blue)
+![Next.js 15](https://img.shields.io/badge/Next.js-15-black)
+![Stellar Mainnet](https://img.shields.io/badge/Stellar-Mainnet-red)
+![License: AGPL-3.0](https://img.shields.io/badge/license-AGPL--3.0-green)
+
+The **Project Portal** is CarbonScribe’s interface for project developers to onboard, monitor, and tokenize regenerative agriculture and forestry projects. It connects field data, satellite verification, and blockchain tokenization in a seamless workflow.
+
+---
+
+## 📚 Table of Contents
+- [Overview](#-overview)
+- [Architecture](#-architecture)
+- [Key Features](#key-features)
+- [Folder Structure](#folder-structure)
+- [Quick Start](#quick-start)
+- [Security](#security)
+- [Contributing](#contributing)
+
+---
+
+## 🌱 Overview
+The Project Portal enables:
+- **Project onboarding** with AI-assisted PDD generation
+- **Real-time monitoring** using satellite and IoT data
+- **Tokenization** of verified removals as Stellar Assets
+- **Forward sale marketplace** for project financing
+
+## 🏗️ Architecture
+```
+project-portal/
+├── project-portal-backend/   # Go backend for orchestration & tokenization
+├── project-portal-web/       # Next.js 15 frontend for onboarding & dashboards
+```
+- **Backend:** Handles project intake, verification, and asset minting
+- **Frontend:** Developer portal for onboarding, monitoring, and analytics
+
+## 🚀 Key Features
+- Interactive project mapping & NDVI timelines
+- Automated document generation & IPFS anchoring
+- Forward sale and financing tools
+- Real-time alerting and dashboards
+- Secure, role-based access
+
+## 📁 Folder Structure
+```
+project-portal/
+├── project-portal-backend/   # Backend API (Go)
+├── project-portal-web/       # Frontend (Next.js)
+```
+
+## ⚡ Quick Start
+See individual backend and frontend READMEs for setup instructions.
+
+## 🔒 Security
+- Role-based authentication
+- Immutable audit logs
+- On-chain verification
+
+## 🤝 Contributing
+Pull requests welcome! See root CONTRIBUTING.md for guidelines.
+
+---
+
+*Part of the CarbonScribe 7-Layer Architecture. See root README for full platform overview.*

--- a/project-portal/project-portal-backend/README.md
+++ b/project-portal/project-portal-backend/README.md
@@ -12,52 +12,68 @@ This service operates within CarbonScribe's 7-Layer Architecture as Layer 3: Pro
 ```
 project-portal-backend/
 ├── api/
-│   ├── v1/
-│   └── monitoring.go
+│   └── v1/
 ├── cmd/
 │   ├── api/
 │   │   └── main.go
 │   └── workers/
-│       ├── alert_worker.go
-│       ├── minting_worker.go
-│       ├── payout_worker.go
-│       ├── price_update_worker.go
-│       ├── retention_worker.go
-│       └── satellite_worker.go
 ├── internal/
 │   ├── auth/
-│   │   ├── handler.go
-│   │   ├── jwt.go
-│   │   ├── middleware.go
-│   │   ├── models.go
-│   │   ├── repository.go
-│   │   ├── routes.go
-│   │   ├── service.go
-│   │   └── submission.go
 │   ├── collaboration/
-│   │   ├── handler.go
-│   │   ├── models.go
-│   │   ├── repository.go
-│   │   ├── routes.go
-│   │   └── service.go
 │   ├── compliance/
 │   │   ├── audit/
-│   │   │   ├── immutable_log.go
-│   │   │   ├── logger.go
-│   │   │   ├── middleware.go
-│   │   │   └── query.go
 │   │   ├── privacy/
-│   │   │   ├── consent.go
-│   │   │   └── preferences.go
 │   │   └── requests/
-│   │       ├── deleter.go
-│   │       ├── exporter.go
-│   │       └── processor.go
 │   ├── config/
-│   │   └── config.go
 │   ├── database/
 │   │   └── migrations/
-│   │       └── 008_reporting_tables.sql
+│   ├── document/
+│   ├── financing/
+│   │   ├── calculation/
+│   │   ├── sales/
+│   │   │   └── tokenization/
+│   │   └── tokenization/
+│   ├── geospatial/
+│   │   ├── geometry/
+│   │   └── queries/
+│   ├── integration/
+│   ├── middleware/
+│   ├── monitoring/
+│   │   ├── alerts/
+│   │   ├── analytics/
+│   │   ├── functions/
+│   │   ├── ingestion/
+│   │   └── processing/
+│   ├── notifications/
+│   │   ├── channels/
+│   │   ├── rules/
+│   │   ├── templates/
+│   │   └── websocket/
+│   │       └── lambda_handlers/
+│   ├── payments/
+│   ├── project/
+│   ├── reports/
+│   │   ├── benchmarks/
+│   │   ├── dashboard/
+│   │   ├── export/
+│   │   └── scheduler/
+│   └── retention/
+├── pkg/
+│   ├── aws/
+│   ├── events/
+│   ├── geojson/
+│   ├── iot/
+│   ├── postgis/
+│   ├── utils/
+│   └── websocket/
+├── test/
+├── .env.example
+├── .gitignore
+├── Dockerfile
+├── go.mod
+├── go.sum
+├── Makefile
+└── README.md
 │   ├── document/
 │   │   ├── ipfs_uploader.go
 │   │   └── pdf_generator.go

--- a/project-portal/project-portal-web/README.md
+++ b/project-portal/project-portal-web/README.md
@@ -1,46 +1,131 @@
-This is a [Next.js](https://nextjs.org) project bootstrapped with [`create-next-app`](https://nextjs.org/docs/app/api-reference/cli/create-next-app).
 
-## Getting Started
+# Project Portal Web: Developer Onboarding & Monitoring UI
 
-First, run the development server:
+![Next.js 15](https://img.shields.io/badge/Next.js-15-black)
+![TypeScript](https://img.shields.io/badge/TypeScript-5.0-blue)
+![Tailwind CSS](https://img.shields.io/badge/TailwindCSS-3.4-cyan)
+![Stellar Mainnet](https://img.shields.io/badge/Stellar-Mainnet-red)
+![License: AGPL-3.0](https://img.shields.io/badge/license-AGPL--3.0-green)
 
-```bash
-npm run dev
-# or
+The **Project Portal Web** is the developer-facing frontend for onboarding, monitoring, and financing carbon projects on CarbonScribe. It provides interactive dashboards, project mapping, and seamless integration with the backend and Stellar blockchain.
+
+---
+
+## 📚 Table of Contents
+- [Overview](#-overview)
+- [Features](#features)
+- [Tech Stack](#tech-stack)
+- [Project Structure](#project-structure)
+- [Quick Start](#quick-start)
+- [API Integration](#api-integration)
+- [Contributing](#contributing)
+
+---
+
+## 🌱 Overview
+Project Portal Web enables:
+- Project onboarding with AI-assisted forms
+- Real-time NDVI and satellite monitoring
+- Forward sale and tokenization workflows
+- Developer dashboards and analytics
+
+## ✨ Features
+- Interactive project mapping (Mapbox, TimeLapse)
+- NDVI timelines and alert dashboards
+- Financing and tokenization wizards
+- Role-based access and secure authentication
+- Responsive UI with dark/light mode
+
+## 🛠️ Tech Stack
+- **Next.js 15** (App Router)
+- **TypeScript**
+- **Tailwind CSS**
+- **Recharts** (data visualization)
+- **Zustand** (state management)
+- **React Hook Form** + **Zod** (forms & validation)
+
+## 📁 Project Structure
+
+```
+src/
+├── app/
+│   ├── (auth)/
+│   ├── (portal)/
+│   ├── api/
+│   ├── favicon.ico
+│   ├── globals.css
+│   └── layout.tsx
+├── components/
+│   ├── AuthNavigation.tsx
+│   ├── PortalNavbar.tsx
+│   ├── PortalSidebar.tsx
+│   ├── ProtectedRoute.tsx
+│   ├── StoreHydrator.tsx
+│   ├── actions/
+│   ├── collaboration/
+│   ├── dashboard/
+│   ├── financing/
+│   ├── insights/
+│   ├── integrations/
+│   ├── maps/
+│   ├── monitoring/
+│   ├── projects/
+│   ├── reports/
+│   └── ui/
+├── contexts/
+│   └── FarmerContext.tsx
+├── lib/
+│   ├── api/
+│   ├── api.ts
+│   ├── auth.ts
+│   ├── geospatial/
+│   ├── ipfs/
+│   ├── stellar/
+│   ├── store/
+│   └── utils/
+├── store/
+│   ├── integration.api.ts
+│   ├── integration.selectors.ts
+│   ├── integration.types.ts
+│   ├── integrationSlice.ts
+│   ├── reports.api.ts
+│   ├── reports.selectors.ts
+│   ├── reports.types.ts
+│   ├── reportsSlice.ts
+│   └── store.ts
+├── test/
+│   └── setup.ts
+```
+
+---
+
+## ⚡ Quick Start
+1. Install dependencies:
+	```bash
+	npm install
+	# or
+yarn
+	```
+2. Copy `.env.example` to `.env.local` and set API URLs as needed.
+3. Run the development server:
+	```bash
+	npm run dev
+	# or
 yarn dev
-# or
-pnpm dev
-# or
-bun dev
-```
+	```
+4. Open [http://localhost:3000](http://localhost:3000) in your browser.
 
-Open [http://localhost:3000](http://localhost:3000) with your browser to see the result.
+---
 
-### Reports API
+## 🔗 API Integration
+- Set `NEXT_PUBLIC_REPORTS_API_URL` in `.env.local` to point to your backend.
+- Ensure [project-portal-backend](../project-portal-backend) is running for full functionality.
 
-To use Reports & Analytics (custom reports, dashboard widgets, scheduling, benchmarks), set the backend base URL in `.env.local`:
+---
 
-```bash
-NEXT_PUBLIC_REPORTS_API_URL=http://localhost:8080/api/v1
-```
+## 🤝 Contributing
+Pull requests welcome! See root CONTRIBUTING.md for guidelines.
 
-If unset, the app uses `/api/v1` (relative) in the browser or `http://localhost:8080/api/v1` on the server. Ensure [project-portal-backend](../project-portal-backend) is running and exposes the `/api/v1/reports` routes.
+---
 
-You can start editing the page by modifying `app/page.tsx`. The page auto-updates as you edit the file.
-
-This project uses [`next/font`](https://nextjs.org/docs/app/building-your-application/optimizing/fonts) to automatically optimize and load [Geist](https://vercel.com/font), a new font family for Vercel.
-
-## Learn More
-
-To learn more about Next.js, take a look at the following resources:
-
-- [Next.js Documentation](https://nextjs.org/docs) - learn about Next.js features and API.
-- [Learn Next.js](https://nextjs.org/learn) - an interactive Next.js tutorial.
-
-You can check out [the Next.js GitHub repository](https://github.com/vercel/next.js) - your feedback and contributions are welcome!
-
-## Deploy on Vercel
-
-The easiest way to deploy your Next.js app is to use the [Vercel Platform](https://vercel.com/new?utm_medium=default-template&filter=next.js&utm_source=create-next-app&utm_campaign=create-next-app-readme) from the creators of Next.js.
-
-Check out our [Next.js deployment documentation](https://nextjs.org/docs/app/building-your-application/deploying) for more details.
+*Part of the CarbonScribe 7-Layer Architecture. See project-portal/README.md for full context.*


### PR DESCRIPTION
## Docs: Add and enhance platform READMEs

### What changed
- Added missing root READMEs for `corporate-platform/` and `project-portal/`
- Updated backend/frontend READMEs in both platforms to reflect actual folder structures
- Removed references to non-existent directories, added missing ones

### Files affected
**Added:**
- `corporate-platform/README.md`
- `project-portal/README.md`

**Modified:**
- `corporate-platform/corporate-platform-backend/README.md`
- `corporate-platform/corporate-platform-web/README.md`
- `project-portal/project-portal-backend/README.md`
- `project-portal/project-portal-web/README.md`

### Why
Synchronize documentation with current repo state, improve contributor onboarding, and maintain consistent branding across platforms.

### Breaking changes
None — documentation only.