### PR TITLE
fix: Integrate Team Collaboration API for Project Teamwork into `corporate-platform-web`

### DIFF
--- a/corporate-platform/corporate-platform-web/src/hooks/useTeamCollaboration.ts
+++ b/corporate-platform/corporate-platform-web/src/hooks/useTeamCollaboration.ts
@@ -1,0 +1,170 @@
+'use client';
+
+import { useCallback, useEffect, useRef, useState } from 'react';
+import {
+  TeamActivity,
+  TeamCollaborationApiError,
+  TeamMessage,
+  TeamNotification,
+  teamCollaborationClient,
+} from '@/lib/team-collaboration';
+
+type Status = 'idle' | 'loading' | 'success' | 'error';
+
+interface UseActivityFeedOptions {
+  limit?: number;
+  pollIntervalMs?: number;
+  enabled?: boolean;
+}
+
+export function useActivityFeed(options: UseActivityFeedOptions = {}) {
+  const { limit = 20, pollIntervalMs = 0, enabled = true } = options;
+  const [data, setData] = useState<TeamActivity[]>([]);
+  const [status, setStatus] = useState<Status>('idle');
+  const [error, setError] = useState<TeamCollaborationApiError | Error | null>(
+    null,
+  );
+  const mounted = useRef(true);
+
+  const refresh = useCallback(async () => {
+    setStatus('loading');
+    try {
+      const items = await teamCollaborationClient.getRecentActivities(limit);
+      if (!mounted.current) return;
+      setData(items);
+      setStatus('success');
+      setError(null);
+    } catch (err) {
+      if (!mounted.current) return;
+      setStatus('error');
+      setError(err as Error);
+    }
+  }, [limit]);
+
+  useEffect(() => {
+    mounted.current = true;
+    if (!enabled) return () => {
+      mounted.current = false;
+    };
+
+    refresh();
+    let interval: ReturnType<typeof setInterval> | undefined;
+    if (pollIntervalMs > 0) {
+      interval = setInterval(refresh, pollIntervalMs);
+    }
+    return () => {
+      mounted.current = false;
+      if (interval) clearInterval(interval);
+    };
+  }, [enabled, pollIntervalMs, refresh]);
+
+  return { data, status, error, refresh };
+}
+
+interface UseTeamMessagesOptions {
+  teamId: string;
+  limit?: number;
+  pollIntervalMs?: number;
+  enabled?: boolean;
+}
+
+export function useTeamMessages(options: UseTeamMessagesOptions) {
+  const { teamId, limit = 50, pollIntervalMs = 0, enabled = true } = options;
+  const [messages, setMessages] = useState<TeamMessage[]>([]);
+  const [status, setStatus] = useState<Status>('idle');
+  const [error, setError] = useState<Error | null>(null);
+  const mounted = useRef(true);
+
+  const refresh = useCallback(async () => {
+    if (!teamId) return;
+    setStatus('loading');
+    try {
+      const items = await teamCollaborationClient.getTeamMessages(
+        teamId,
+        limit,
+      );
+      if (!mounted.current) return;
+      setMessages(items);
+      setStatus('success');
+      setError(null);
+    } catch (err) {
+      if (!mounted.current) return;
+      setStatus('error');
+      setError(err as Error);
+    }
+  }, [teamId, limit]);
+
+  const send = useCallback(
+    async (content: string) => {
+      const message = await teamCollaborationClient.postTeamMessage(
+        teamId,
+        content,
+      );
+      if (mounted.current) {
+        setMessages((prev) => [message, ...prev]);
+      }
+      return message;
+    },
+    [teamId],
+  );
+
+  useEffect(() => {
+    mounted.current = true;
+    if (!enabled || !teamId) {
+      return () => {
+        mounted.current = false;
+      };
+    }
+    refresh();
+    let interval: ReturnType<typeof setInterval> | undefined;
+    if (pollIntervalMs > 0) {
+      interval = setInterval(refresh, pollIntervalMs);
+    }
+    return () => {
+      mounted.current = false;
+      if (interval) clearInterval(interval);
+    };
+  }, [enabled, teamId, pollIntervalMs, refresh]);
+
+  return { messages, status, error, refresh, send };
+}
+
+export function useUnreadNotifications(pollIntervalMs = 0) {
+  const [notifications, setNotifications] = useState<TeamNotification[]>([]);
+  const [status, setStatus] = useState<Status>('idle');
+  const mounted = useRef(true);
+
+  const refresh = useCallback(async () => {
+    setStatus('loading');
+    try {
+      const items = await teamCollaborationClient.getUnreadNotifications();
+      if (!mounted.current) return;
+      setNotifications(items);
+      setStatus('success');
+    } catch {
+      if (!mounted.current) return;
+      setStatus('error');
+    }
+  }, []);
+
+  const markRead = useCallback(async (id: string) => {
+    await teamCollaborationClient.markNotificationRead(id);
+    if (!mounted.current) return;
+    setNotifications((prev) => prev.filter((n) => n.id !== id));
+  }, []);
+
+  useEffect(() => {
+    mounted.current = true;
+    refresh();
+    let interval: ReturnType<typeof setInterval> | undefined;
+    if (pollIntervalMs > 0) {
+      interval = setInterval(refresh, pollIntervalMs);
+    }
+    return () => {
+      mounted.current = false;
+      if (interval) clearInterval(interval);
+    };
+  }, [pollIntervalMs, refresh]);
+
+  return { notifications, status, refresh, markRead };
+}

--- a/corporate-platform/corporate-platform-web/src/lib/team-collaboration/README.md
+++ b/corporate-platform/corporate-platform-web/src/lib/team-collaboration/README.md
@@ -1,0 +1,111 @@
+# Team Collaboration API Integration
+
+This module integrates the backend Team Collaboration endpoints
+(`/api/v1/team/*`) into the frontend.
+
+## Configuration
+
+Set the following environment variable so the client can reach the backend:
+
+```
+NEXT_PUBLIC_API_BASE_URL=https://your-backend.example.com/api/v1
+```
+
+If unset, the client defaults to the relative path `/api/v1`, which works when
+the backend is proxied by Next.js.
+
+## Usage
+
+### Direct client
+
+```ts
+import { teamCollaborationClient } from '@/lib/team-collaboration';
+
+const recent = await teamCollaborationClient.getRecentActivities(10);
+const score = await teamCollaborationClient.getCollaborationScore();
+```
+
+To use an authenticated token, create a client explicitly:
+
+```ts
+import { TeamCollaborationClient } from '@/lib/team-collaboration';
+
+const client = new TeamCollaborationClient({
+  baseUrl: process.env.NEXT_PUBLIC_API_BASE_URL,
+  getAuthToken: () => localStorage.getItem('access_token'),
+});
+```
+
+### React hooks
+
+```tsx
+import {
+  useActivityFeed,
+  useTeamMessages,
+  useUnreadNotifications,
+} from '@/hooks/useTeamCollaboration';
+
+function TeamFeed() {
+  const { data, status, error, refresh } = useActivityFeed({
+    limit: 20,
+    pollIntervalMs: 15000, // poll every 15s for near-real-time updates
+  });
+
+  if (status === 'loading' && data.length === 0) return <p>Loading…</p>;
+  if (status === 'error') return <p>Failed to load: {error?.message}</p>;
+
+  return (
+    <ul>
+      {data.map((a) => (
+        <li key={a.id}>{a.description}</li>
+      ))}
+    </ul>
+  );
+}
+```
+
+### Posting messages
+
+```tsx
+const { messages, send } = useTeamMessages({
+  teamId,
+  pollIntervalMs: 5000,
+});
+
+await send('Shipped the new dashboard!');
+```
+
+## Endpoints
+
+| Frontend method                          | Backend path                              |
+| ---------------------------------------- | ----------------------------------------- |
+| `getActivityFeed(query)`                 | `GET /team/activity`                      |
+| `getRecentActivities(limit)`             | `GET /team/activity/recent`               |
+| `getUserActivity(userId, limit)`         | `GET /team/activity/user/:userId`         |
+| `getActivitySummary(range)`              | `GET /team/activity/summary`              |
+| `getTeamPerformance(range)`              | `GET /team/performance`                   |
+| `getMemberPerformance(range)`            | `GET /team/performance/members`           |
+| `getPerformanceTrends(range)`            | `GET /team/performance/trends`            |
+| `getPerformanceBenchmarks(range)`        | `GET /team/performance/benchmarks`        |
+| `getCollaborationScore(range)`           | `GET /team/collaboration/score`           |
+| `getCollaborationScoreHistory(type)`     | `GET /team/collaboration/score/history`   |
+| `getCollaborationRecommendations(range)` | `GET /team/collaboration/recommendations` |
+| `getTopContributors(limit)`              | `GET /team/collaboration/top-contributors`|
+| `getUnreadNotifications()`               | `GET /team/notifications/unread`          |
+| `markNotificationRead(id)`               | `POST /team/notifications/:id/read`       |
+| `getTeamMessages(teamId, limit)`         | `GET /team/activity?type=MESSAGE_POSTED`  |
+| `postTeamMessage(teamId, content)`       | `POST /team/activity`                     |
+
+## Error handling
+
+All API errors are thrown as `TeamCollaborationApiError` with `status` and
+`body` fields for contextual error UIs. Network errors surface as the native
+`TypeError` from `fetch`. React hooks expose the error via their `error`
+state so components can show user-friendly feedback.
+
+## Real-time updates
+
+Hooks support a `pollIntervalMs` option for lightweight polling. When a
+WebSocket channel becomes available on the backend, the polling hooks can be
+swapped for a subscription-based implementation without changes to calling
+components.

--- a/corporate-platform/corporate-platform-web/src/lib/team-collaboration/api.ts
+++ b/corporate-platform/corporate-platform-web/src/lib/team-collaboration/api.ts
@@ -1,0 +1,232 @@
+import {
+  ActivityFeedQuery,
+  ActivitySummary,
+  CollaborationScore,
+  DateRange,
+  TeamActivity,
+  TeamCollaborationApiError,
+  TeamMessage,
+  TeamNotification,
+  TeamPerformance,
+} from './types';
+
+const DEFAULT_BASE_URL =
+  (typeof process !== 'undefined' &&
+    process.env?.NEXT_PUBLIC_API_BASE_URL) ||
+  '/api/v1';
+
+export interface TeamCollaborationClientOptions {
+  baseUrl?: string;
+  getAuthToken?: () => string | null | undefined | Promise<string | null | undefined>;
+  fetchImpl?: typeof fetch;
+}
+
+function buildQuery(params: Record<string, unknown> | undefined): string {
+  if (!params) return '';
+  const search = new URLSearchParams();
+  for (const [key, value] of Object.entries(params)) {
+    if (value === undefined || value === null) continue;
+    search.append(key, String(value));
+  }
+  const qs = search.toString();
+  return qs ? `?${qs}` : '';
+}
+
+export class TeamCollaborationClient {
+  private readonly baseUrl: string;
+  private readonly getAuthToken?: TeamCollaborationClientOptions['getAuthToken'];
+  private readonly fetchImpl: typeof fetch;
+
+  constructor(options: TeamCollaborationClientOptions = {}) {
+    this.baseUrl = (options.baseUrl ?? DEFAULT_BASE_URL).replace(/\/$/, '');
+    this.getAuthToken = options.getAuthToken;
+    this.fetchImpl =
+      options.fetchImpl ??
+      (typeof fetch !== 'undefined' ? fetch.bind(globalThis) : (undefined as never));
+    if (!this.fetchImpl) {
+      throw new Error(
+        'TeamCollaborationClient requires a fetch implementation in this environment',
+      );
+    }
+  }
+
+  private async request<T>(
+    path: string,
+    init: RequestInit = {},
+  ): Promise<T> {
+    const url = `${this.baseUrl}${path}`;
+    const headers: Record<string, string> = {
+      Accept: 'application/json',
+      ...(init.headers as Record<string, string> | undefined),
+    };
+    if (init.body && !headers['Content-Type']) {
+      headers['Content-Type'] = 'application/json';
+    }
+    if (this.getAuthToken) {
+      const token = await this.getAuthToken();
+      if (token) headers.Authorization = `Bearer ${token}`;
+    }
+
+    const response = await this.fetchImpl(url, { ...init, headers });
+    const text = await response.text();
+    const body = text ? safeJsonParse(text) : null;
+
+    if (!response.ok) {
+      throw new TeamCollaborationApiError(
+        `Team collaboration request failed: ${response.status} ${response.statusText}`,
+        response.status,
+        body,
+      );
+    }
+    return body as T;
+  }
+
+  // ==================== Activity Feed ====================
+
+  getActivityFeed(query: ActivityFeedQuery = {}): Promise<TeamActivity[]> {
+    return this.request<TeamActivity[]>(
+      `/team/activity${buildQuery(query as Record<string, unknown>)}`,
+    );
+  }
+
+  getRecentActivities(limit = 10): Promise<TeamActivity[]> {
+    return this.request<TeamActivity[]>(
+      `/team/activity/recent${buildQuery({ limit })}`,
+    );
+  }
+
+  getUserActivity(userId: string, limit = 50): Promise<TeamActivity[]> {
+    if (!userId) {
+      return Promise.reject(new Error('userId is required'));
+    }
+    return this.request<TeamActivity[]>(
+      `/team/activity/user/${encodeURIComponent(userId)}${buildQuery({ limit })}`,
+    );
+  }
+
+  getActivitySummary(range: DateRange = {}): Promise<ActivitySummary> {
+    return this.request<ActivitySummary>(
+      `/team/activity/summary${buildQuery(range as Record<string, unknown>)}`,
+    );
+  }
+
+  // ==================== Performance ====================
+
+  getTeamPerformance(range: DateRange = {}): Promise<TeamPerformance> {
+    return this.request<TeamPerformance>(
+      `/team/performance${buildQuery(range as Record<string, unknown>)}`,
+    );
+  }
+
+  getMemberPerformance(range: DateRange = {}): Promise<TeamPerformance> {
+    return this.request<TeamPerformance>(
+      `/team/performance/members${buildQuery(range as Record<string, unknown>)}`,
+    );
+  }
+
+  getPerformanceTrends(range: DateRange = {}): Promise<TeamPerformance> {
+    return this.request<TeamPerformance>(
+      `/team/performance/trends${buildQuery(range as Record<string, unknown>)}`,
+    );
+  }
+
+  getPerformanceBenchmarks(range: DateRange = {}): Promise<TeamPerformance> {
+    return this.request<TeamPerformance>(
+      `/team/performance/benchmarks${buildQuery(range as Record<string, unknown>)}`,
+    );
+  }
+
+  // ==================== Collaboration Score ====================
+
+  getCollaborationScore(range: DateRange = {}): Promise<CollaborationScore> {
+    return this.request<CollaborationScore>(
+      `/team/collaboration/score${buildQuery(range as Record<string, unknown>)}`,
+    );
+  }
+
+  getCollaborationScoreHistory(
+    metricType: 'WEEKLY_SCORE' | 'MONTHLY_SCORE' = 'WEEKLY_SCORE',
+  ): Promise<CollaborationScore> {
+    return this.request<CollaborationScore>(
+      `/team/collaboration/score/history${buildQuery({ metricType })}`,
+    );
+  }
+
+  getCollaborationRecommendations(range: DateRange = {}): Promise<{
+    companyId: string;
+    recommendations: string[];
+  }> {
+    return this.request(
+      `/team/collaboration/recommendations${buildQuery(range as Record<string, unknown>)}`,
+    );
+  }
+
+  getTopContributors(limit = 10): Promise<TeamActivity[]> {
+    return this.request<TeamActivity[]>(
+      `/team/collaboration/top-contributors${buildQuery({ limit })}`,
+    );
+  }
+
+  // ==================== Notifications ====================
+
+  getUnreadNotifications(): Promise<TeamNotification[]> {
+    return this.request<TeamNotification[]>(`/team/notifications/unread`);
+  }
+
+  markNotificationRead(id: string): Promise<TeamNotification> {
+    if (!id) {
+      return Promise.reject(new Error('notification id is required'));
+    }
+    return this.request<TeamNotification>(
+      `/team/notifications/${encodeURIComponent(id)}/read`,
+      { method: 'POST' },
+    );
+  }
+
+  // ==================== Messages ====================
+  // Convenience helpers used by UI components. Messages are modelled as
+  // `MESSAGE_POSTED` activities on the backend activity feed.
+
+  getTeamMessages(teamId: string, limit = 50): Promise<TeamMessage[]> {
+    if (!teamId) {
+      return Promise.reject(new Error('teamId is required'));
+    }
+    return this.request<TeamMessage[]>(
+      `/team/activity${buildQuery({
+        type: 'MESSAGE_POSTED',
+        teamId,
+        limit,
+      })}`,
+    );
+  }
+
+  postTeamMessage(teamId: string, content: string): Promise<TeamMessage> {
+    if (!teamId) {
+      return Promise.reject(new Error('teamId is required'));
+    }
+    if (!content || !content.trim()) {
+      return Promise.reject(new Error('content is required'));
+    }
+    return this.request<TeamMessage>(
+      `/team/activity`,
+      {
+        method: 'POST',
+        body: JSON.stringify({
+          type: 'MESSAGE_POSTED',
+          teamId,
+          description: content,
+        }),
+      },
+    );
+  }
+}
+
+function safeJsonParse(text: string): unknown {
+  try {
+    return JSON.parse(text);
+  } catch {
+    return text;
+  }
+}
+
+export const teamCollaborationClient = new TeamCollaborationClient();

--- a/corporate-platform/corporate-platform-web/src/lib/team-collaboration/index.ts
+++ b/corporate-platform/corporate-platform-web/src/lib/team-collaboration/index.ts
@@ -1,0 +1,2 @@
+export * from './api';
+export * from './types';

--- a/corporate-platform/corporate-platform-web/src/lib/team-collaboration/types.ts
+++ b/corporate-platform/corporate-platform-web/src/lib/team-collaboration/types.ts
@@ -1,0 +1,111 @@
+// Types used by the Team Collaboration API client.
+// These mirror the backend response contracts under `/api/v1/team/*`.
+
+export type ActivityType =
+  | 'ACTIVITY_CREATED'
+  | 'ACTIVITY_UPDATED'
+  | 'COMMENT_ADDED'
+  | 'MEMBER_JOINED'
+  | 'MEMBER_LEFT'
+  | 'MESSAGE_POSTED'
+  | 'TASK_COMPLETED'
+  | string;
+
+export interface TeamActivity {
+  id: string;
+  companyId: string;
+  userId: string;
+  type: ActivityType;
+  description: string;
+  metadata?: Record<string, unknown>;
+  createdAt: string;
+}
+
+export interface ActivityFeedQuery {
+  limit?: number;
+  offset?: number;
+  type?: ActivityType;
+  userId?: string;
+  startDate?: string;
+  endDate?: string;
+}
+
+export interface ActivitySummary {
+  total: number;
+  byType: Record<string, number>;
+  periodStart: string;
+  periodEnd: string;
+}
+
+export interface TeamMember {
+  id: string;
+  name: string;
+  email: string;
+  role: string;
+  status: 'active' | 'inactive' | 'pending';
+  joinedAt: string;
+}
+
+export interface TeamPerformance {
+  companyId: string;
+  periodStart: string;
+  periodEnd: string;
+  score: number;
+  members?: TeamMember[];
+  trends?: Array<{ date: string; value: number }>;
+  benchmarks?: Record<string, number>;
+}
+
+export interface CollaborationScoreComponents {
+  communication: number;
+  responsiveness: number;
+  participation: number;
+  outcomes: number;
+}
+
+export interface CollaborationScore {
+  companyId: string;
+  periodStart?: string;
+  periodEnd?: string;
+  overallScore: number;
+  components: CollaborationScoreComponents;
+  rating: 'LOW' | 'MEDIUM' | 'HIGH' | 'EXCELLENT';
+  history?: Array<{ date: string; score: number }>;
+  recommendations?: string[];
+}
+
+export interface TeamNotification {
+  id: string;
+  userId: string;
+  title: string;
+  body: string;
+  read: boolean;
+  createdAt: string;
+}
+
+export interface TeamMessage {
+  id: string;
+  teamId: string;
+  userId: string;
+  content: string;
+  createdAt: string;
+}
+
+export interface DateRange {
+  startDate?: string;
+  endDate?: string;
+  periodStart?: string;
+  periodEnd?: string;
+}
+
+export class TeamCollaborationApiError extends Error {
+  readonly status: number;
+  readonly body: unknown;
+
+  constructor(message: string, status: number, body: unknown) {
+    super(message);
+    this.name = 'TeamCollaborationApiError';
+    this.status = status;
+    this.body = body;
+  }
+}


### PR DESCRIPTION
## Summary

Added a Team Collaboration API integration to `corporate-platform-web`:

- `src/lib/team-collaboration/types.ts` — Typed contracts for activities, performance, collaboration scores, notifications, messages, and a `TeamCollaborationApiError` class for rich error UIs.
- `src/lib/team-collaboration/api.ts` — `TeamCollaborationClient` with pluggable `baseUrl`, auth-token provider, and `fetch` implementation. Covers the backend's `/api/v1/team/*` surface: activity feed (list, recent, per-user, summary), team/member performance, collaboration score (current, history, recommendations, top contributors), notifications (unread, mark-read), plus message helpers (`getTeamMessages`, `postTeamMessage`). JSON bodies, auth headers, and non-2xx responses are handled centrally.
- `src/lib/team-collaboration/index.ts` — Barrel export and a default `teamCollaborationClient` instance.
- `src/hooks/useTeamCollaboration.ts` — `useActivityFeed`, `useTeamMessages` (with `send`), and `useUnreadNotifications` hooks supporting optional polling for near-real-time updates and exposing `status`/`error` for UI feedback.
- `src/lib/team-collaboration/README.md` — Usage, endpoint mapping, configuration (`NEXT_PUBLIC_API_BASE_URL`), error-handling and real-time notes.

---

closes #259