### PR TITLE
feat(#260): integrate Team Management API into corporate-platform-web

### DIFF
--- a/corporate-platform/corporate-platform-web/src/app/team/page.tsx
+++ b/corporate-platform/corporate-platform-web/src/app/team/page.tsx
@@ -1,250 +1,151 @@
 'use client'
 
 import { useState } from 'react'
-import { 
-  Users, 
-  UserPlus, 
-  Settings, 
-  Mail, 
-  Phone, 
-  Globe, 
-  Shield,
-  Award,
-  Calendar,
-  TrendingUp,
-  MessageSquare,
-  Clock,
-  Filter,
-  Search,
-  Edit,
-  Trash2,
-  Eye,
-  ChevronRight,
-  Bell,
-  CheckCircle,
-  AlertCircle,
-  PieChart,
-  BarChart3,
-  FileText,
-  Target
+import {
+  Users, UserPlus, Shield, Clock, BarChart3, Search, Filter,
+  Mail, Calendar, Edit, Trash2, RefreshCw, CheckCircle, AlertCircle,
+  Target, ChevronRight, X, Send,
 } from 'lucide-react'
-import { 
-  BarChart, 
-  Bar, 
-  XAxis, 
-  YAxis, 
-  CartesianGrid, 
-  Tooltip, 
-  ResponsiveContainer,
-  PieChart as RechartsPieChart,
-  Pie,
-  Cell
+import {
+  BarChart, Bar, XAxis, YAxis, CartesianGrid, Tooltip, ResponsiveContainer,
+  PieChart as RechartsPieChart, Pie, Cell,
 } from 'recharts'
+import { useTeam } from '@/hooks/useTeam'
+import AddMemberModal from '@/components/team/AddMemberModal'
+import EditMemberModal from '@/components/team/EditMemberModal'
+import InviteMemberModal from '@/components/team/InviteMemberModal'
+import ManageRoleModal from '@/components/team/ManageRoleModal'
+import type { TeamMember, TeamRole } from '@/types/team'
+
+const ROLE_COLORS: Record<string, string> = {
+  ADMIN: '#0073e6', MANAGER: '#8b5cf6', ANALYST: '#00d4aa',
+  VIEWER: '#f59e0b', AUDITOR: '#ef4444',
+}
+const roleColor = (name: string) => ROLE_COLORS[name.toUpperCase()] ?? '#6b7280'
+
+const statusBadge = (status: string) => {
+  switch (status) {
+    case 'ACTIVE': return 'bg-green-100 text-green-800 dark:bg-green-900/30 dark:text-green-300'
+    case 'PENDING': return 'bg-yellow-100 text-yellow-800 dark:bg-yellow-900/30 dark:text-yellow-300'
+    default: return 'bg-gray-100 text-gray-800 dark:bg-gray-900/30 dark:text-gray-300'
+  }
+}
+
+const memberInitials = (m: TeamMember) => {
+  const f = m.firstName?.[0] ?? ''
+  const l = m.lastName?.[0] ?? ''
+  return (f + l).toUpperCase() || m.email[0].toUpperCase()
+}
+
+const memberDisplayName = (m: TeamMember) =>
+  [m.firstName, m.lastName].filter(Boolean).join(' ') || m.email
 
 export default function TeamPage() {
-  const [activeTab, setActiveTab] = useState<'members' | 'roles' | 'activity' | 'analytics'>('members')
-  const [selectedMember, setSelectedMember] = useState<string | null>(null)
+  const {
+    members, roles, invitations, permissions, loading, error,
+    fetchAll, createMember, updateMember, deactivateMember, reactivateMember,
+    assignRole, createRole, updateRole, deleteRole, inviteMember,
+    resendInvitation, cancelInvitation,
+  } = useTeam()
+
+  const [activeTab, setActiveTab] = useState<'members' | 'roles' | 'invitations'>('members')
   const [searchTerm, setSearchTerm] = useState('')
+  const [selectedMember, setSelectedMember] = useState<TeamMember | null>(null)
+  const [modal, setModal] = useState<
+    | { type: 'addMember' }
+    | { type: 'editMember'; member: TeamMember }
+    | { type: 'invite' }
+    | { type: 'createRole' }
+    | { type: 'editRole'; role: TeamRole }
+    | null
+  >(null)
+  const [actionError, setActionError] = useState<string | null>(null)
+  const [actionSuccess, setActionSuccess] = useState<string | null>(null)
 
-  // Team members data
-  const teamMembers = [
-    {
-      id: '1',
-      name: 'Sarah Johnson',
-      role: 'Sustainability Director',
-      email: 'sarah.johnson@techglobal.com',
-      phone: '+1 (555) 123-4567',
-      avatar: 'SJ',
-      status: 'active',
-      joined: '2022-03-15',
-      permissions: ['admin', 'reporting', 'purchase'],
-      projects: 12,
-      credits: 45000,
-      color: 'bg-blue-500',
-      bio: 'Leads ESG strategy and carbon offset initiatives. Former climate policy advisor.'
-    },
-    {
-      id: '2',
-      name: 'Michael Chen',
-      role: 'Carbon Analyst',
-      email: 'michael.chen@techglobal.com',
-      phone: '+1 (555) 234-5678',
-      avatar: 'MC',
-      status: 'active',
-      joined: '2023-01-20',
-      permissions: ['analytics', 'reporting'],
-      projects: 8,
-      credits: 28000,
-      color: 'bg-green-500',
-      bio: 'Specializes in carbon credit analysis and portfolio optimization.'
-    },
-    {
-      id: '3',
-      name: 'Emma Wilson',
-      role: 'Compliance Manager',
-      email: 'emma.wilson@techglobal.com',
-      phone: '+1 (555) 345-6789',
-      avatar: 'EW',
-      status: 'active',
-      joined: '2022-08-10',
-      permissions: ['compliance', 'reporting'],
-      projects: 15,
-      credits: 62000,
-      color: 'bg-purple-500',
-      bio: 'Ensures regulatory compliance across all sustainability frameworks.'
-    },
-    {
-      id: '4',
-      name: 'David Lee',
-      role: 'Project Manager',
-      email: 'david.lee@techglobal.com',
-      phone: '+1 (555) 456-7890',
-      avatar: 'DL',
-      status: 'away',
-      joined: '2023-05-30',
-      permissions: ['projects', 'monitoring'],
-      projects: 6,
-      credits: 18000,
-      color: 'bg-orange-500',
-      bio: 'Manages relationships with carbon credit project developers.'
-    },
-    {
-      id: '5',
-      name: 'Jessica Martinez',
-      role: 'Financial Analyst',
-      email: 'jessica.martinez@techglobal.com',
-      phone: '+1 (555) 567-8901',
-      avatar: 'JM',
-      status: 'active',
-      joined: '2024-01-05',
-      permissions: ['finance', 'purchase'],
-      projects: 4,
-      credits: 12000,
-      color: 'bg-pink-500',
-      bio: 'Analyzes financial aspects of carbon credit investments.'
-    },
-    {
-      id: '6',
-      name: 'Robert Kim',
-      role: 'Data Scientist',
-      email: 'robert.kim@techglobal.com',
-      phone: '+1 (555) 678-9012',
-      avatar: 'RK',
-      status: 'inactive',
-      joined: '2023-03-22',
-      permissions: ['analytics', 'data'],
-      projects: 10,
-      credits: 35000,
-      color: 'bg-teal-500',
-      bio: 'Develops algorithms for carbon credit quality assessment.'
-    },
-  ]
-
-  // Team roles data
-  const teamRoles = [
-    { name: 'Admin', members: 2, permissions: ['Full Access'], color: '#0073e6' },
-    { name: 'Analyst', members: 3, permissions: ['View', 'Analyze', 'Report'], color: '#00d4aa' },
-    { name: 'Manager', members: 2, permissions: ['View', 'Purchase', 'Approve'], color: '#8b5cf6' },
-    { name: 'Viewer', members: 1, permissions: ['View Only'], color: '#f59e0b' },
-    { name: 'Auditor', members: 1, permissions: ['View', 'Audit'], color: '#ef4444' },
-  ]
-
-  // Team activity data
-  const teamActivity = [
-    { user: 'Sarah Johnson', action: 'Retired 10,000 tCO₂', time: '2 hours ago', project: 'Amazon Rainforest', icon: Award },
-    { user: 'Michael Chen', action: 'Generated Portfolio Report', time: '4 hours ago', project: 'Monthly Analysis', icon: FileText },
-    { user: 'Emma Wilson', action: 'Submitted CSRD Report', time: '1 day ago', project: 'Q1 2024 Compliance', icon: Shield },
-    { user: 'David Lee', action: 'Added Project to Monitor', time: '2 days ago', project: 'Indonesia Mangroves', icon: Eye },
-    { user: 'Jessica Martinez', action: 'Approved Credit Purchase', time: '3 days ago', project: 'Kenya Solar Farms', icon: CheckCircle },
-    { user: 'Robert Kim', action: 'Updated Quality Algorithm', time: '5 days ago', project: 'Dynamic Scoring', icon: TrendingUp },
-  ]
-
-  // Team performance data
-  const performanceData = [
-    { month: 'Jan', retirements: 8000, purchases: 10000, reports: 3 },
-    { month: 'Feb', retirements: 12000, purchases: 15000, reports: 5 },
-    { month: 'Mar', retirements: 15000, purchases: 20000, reports: 7 },
-    { month: 'Apr', retirements: 10000, purchases: 12000, reports: 4 },
-    { month: 'May', retirements: 14000, purchases: 18000, reports: 6 },
-    { month: 'Jun', retirements: 18000, purchases: 22000, reports: 8 },
-  ]
-
-  // Role distribution data for pie chart
-  const roleDistributionData = teamRoles.map(role => ({
-    name: role.name,
-    value: role.members,
-    color: role.color
-  }))
-
-  // Calculate team statistics
-  const totalMembers = teamMembers.length
-  const activeMembers = teamMembers.filter(m => m.status === 'active').length
-  const totalProjects = teamMembers.reduce((sum, m) => sum + m.projects, 0)
-  const totalCredits = teamMembers.reduce((sum, m) => sum + m.credits, 0)
-
-  // Get status color
-  const getStatusColor = (status: string) => {
-    switch (status) {
-      case 'active':
-        return 'bg-green-100 text-green-800 dark:bg-green-900/30 dark:text-green-300'
-      case 'away':
-        return 'bg-yellow-100 text-yellow-800 dark:bg-yellow-900/30 dark:text-yellow-300'
-      case 'inactive':
-        return 'bg-gray-100 text-gray-800 dark:bg-gray-900/30 dark:text-gray-300'
-      default:
-        return 'bg-gray-100 text-gray-800 dark:bg-gray-900/30 dark:text-gray-300'
-    }
+  const notify = (msg: string, isError = false) => {
+    if (isError) { setActionError(msg); setTimeout(() => setActionError(null), 4000) }
+    else { setActionSuccess(msg); setTimeout(() => setActionSuccess(null), 3000) }
   }
 
-  // Filter team members based on search
-  const filteredMembers = teamMembers.filter(member =>
-    member.name.toLowerCase().includes(searchTerm.toLowerCase()) ||
-    member.role.toLowerCase().includes(searchTerm.toLowerCase()) ||
-    member.email.toLowerCase().includes(searchTerm.toLowerCase())
-  )
+  const filteredMembers = members.filter((m) => {
+    const q = searchTerm.toLowerCase()
+    return (
+      memberDisplayName(m).toLowerCase().includes(q) ||
+      m.email.toLowerCase().includes(q) ||
+      (m.role?.name ?? '').toLowerCase().includes(q)
+    )
+  })
+
+  const activeCount = members.filter((m) => m.status === 'ACTIVE').length
+  const pendingInvitations = invitations.filter((i) => i.status === 'PENDING')
+
+  const roleDistribution = roles.map((r) => ({
+    name: r.name, value: r.memberCount, color: roleColor(r.name),
+  }))
 
   return (
     <div className="space-y-6 animate-in">
-      {/* Team Header */}
+      {/* Toast notifications */}
+      {actionError && (
+        <div className="fixed top-4 right-4 z-50 flex items-center gap-2 bg-red-50 dark:bg-red-900/30 border border-red-200 dark:border-red-800 text-red-700 dark:text-red-300 px-4 py-3 rounded-xl shadow-lg">
+          <AlertCircle size={16} /> {actionError}
+        </div>
+      )}
+      {actionSuccess && (
+        <div className="fixed top-4 right-4 z-50 flex items-center gap-2 bg-green-50 dark:bg-green-900/30 border border-green-200 dark:border-green-800 text-green-700 dark:text-green-300 px-4 py-3 rounded-xl shadow-lg">
+          <CheckCircle size={16} /> {actionSuccess}
+        </div>
+      )}
+
+      {/* Header */}
       <div className="bg-linear-to-r from-corporate-navy via-corporate-blue to-corporate-teal rounded-2xl p-6 md:p-8 text-white shadow-2xl">
         <div className="flex flex-col lg:flex-row lg:items-center justify-between">
           <div className="mb-6 lg:mb-0">
-            <h1 className="text-2xl md:text-3xl lg:text-4xl font-bold mb-2 tracking-tight">
-              Team Management
-            </h1>
+            <h1 className="text-2xl md:text-3xl lg:text-4xl font-bold mb-2 tracking-tight">Team Management</h1>
             <p className="text-blue-100 opacity-90 max-w-2xl">
-              Manage your sustainability team, assign roles, track activities, and optimize collaboration.
+              Manage your sustainability team, assign roles, and control permissions.
             </p>
           </div>
           <div className="flex flex-col sm:flex-row gap-4">
-            <div className="bg-white/10 backdrop-blur-sm rounded-xl p-4 min-w-50">
-              <div className="text-sm text-blue-200 mb-1">Team Members</div>
-              <div className="text-2xl font-bold">{totalMembers}</div>
-              <div className="text-xs text-green-300">{activeMembers} active</div>
+            <div className="bg-white/10 backdrop-blur-sm rounded-xl p-4 min-w-[120px]">
+              <div className="text-sm text-blue-200 mb-1">Members</div>
+              <div className="text-2xl font-bold">{members.length}</div>
+              <div className="text-xs text-green-300">{activeCount} active</div>
             </div>
-            <div className="bg-white/10 backdrop-blur-sm rounded-xl p-4 min-w-50">
-              <div className="text-sm text-blue-200 mb-1">Total Projects</div>
-              <div className="text-2xl font-bold">{totalProjects}</div>
-              <div className="text-xs text-blue-300">Managed by team</div>
+            <div className="bg-white/10 backdrop-blur-sm rounded-xl p-4 min-w-[120px]">
+              <div className="text-sm text-blue-200 mb-1">Pending Invites</div>
+              <div className="text-2xl font-bold">{pendingInvitations.length}</div>
+              <div className="text-xs text-blue-300">awaiting response</div>
             </div>
           </div>
         </div>
       </div>
 
-      {/* Tabs Navigation */}
+      {/* Global error */}
+      {error && (
+        <div className="corporate-card p-4 border border-red-200 dark:border-red-800 bg-red-50 dark:bg-red-900/20 flex items-center justify-between">
+          <div className="flex items-center gap-2 text-red-700 dark:text-red-400">
+            <AlertCircle size={16} /> {error}
+          </div>
+          <button onClick={fetchAll} className="flex items-center gap-1 text-sm text-corporate-blue hover:underline">
+            <RefreshCw size={14} /> Retry
+          </button>
+        </div>
+      )}
+
+      {/* Tabs */}
       <div className="corporate-card p-2">
         <div className="flex flex-wrap gap-2">
           {[
             { id: 'members', label: 'Team Members', icon: Users },
             { id: 'roles', label: 'Roles & Permissions', icon: Shield },
-            { id: 'activity', label: 'Team Activity', icon: Clock },
-            { id: 'analytics', label: 'Team Analytics', icon: BarChart3 },
+            { id: 'invitations', label: 'Invitations', icon: Mail, badge: pendingInvitations.length },
           ].map((tab) => {
             const Icon = tab.icon
             return (
               <button
                 key={tab.id}
-                onClick={() => setActiveTab(tab.id as any)}
+                onClick={() => setActiveTab(tab.id as typeof activeTab)}
                 className={`flex items-center px-4 py-3 rounded-lg font-medium transition-colors ${
                   activeTab === tab.id
                     ? 'bg-corporate-blue text-white'
@@ -253,493 +154,420 @@ export default function TeamPage() {
               >
                 <Icon size={18} className="mr-2" />
                 {tab.label}
+                {tab.badge ? (
+                  <span className="ml-2 bg-amber-500 text-white text-xs rounded-full px-1.5 py-0.5">{tab.badge}</span>
+                ) : null}
               </button>
             )
           })}
         </div>
       </div>
 
-      {/* Team Members Tab */}
+      {/* ── Members Tab ── */}
       {activeTab === 'members' && (
         <div className="space-y-6">
-          {/* Search and Actions */}
           <div className="corporate-card p-4">
             <div className="flex flex-col md:flex-row md:items-center justify-between gap-4">
-              <div className="flex-1">
-                <div className="relative">
-                  <Search className="absolute left-3 top-1/2 transform -translate-y-1/2 text-gray-400" size={20} />
-                  <input
-                    type="search"
-                    placeholder="Search team members by name, role, or email..."
-                    className="w-full pl-10 pr-4 py-3 bg-gray-100 dark:bg-gray-800 rounded-lg border border-gray-200 dark:border-gray-700 focus:outline-none focus:ring-2 focus:ring-corporate-blue"
-                    value={searchTerm}
-                    onChange={(e) => setSearchTerm(e.target.value)}
-                  />
-                </div>
+              <div className="flex-1 relative">
+                <Search className="absolute left-3 top-1/2 -translate-y-1/2 text-gray-400" size={20} />
+                <input
+                  type="search"
+                  placeholder="Search by name, email, or role..."
+                  className="w-full pl-10 pr-4 py-3 bg-gray-100 dark:bg-gray-800 rounded-lg border border-gray-200 dark:border-gray-700 focus:outline-none focus:ring-2 focus:ring-corporate-blue"
+                  value={searchTerm}
+                  onChange={(e) => setSearchTerm(e.target.value)}
+                />
               </div>
-              <div className="flex items-center space-x-2">
-                <button className="corporate-btn-secondary px-4 py-2">
-                  <Filter size={16} className="mr-2" />
-                  Filter
+              <div className="flex items-center gap-2">
+                <button onClick={() => setModal({ type: 'invite' })} className="corporate-btn-secondary px-4 py-2 flex items-center">
+                  <Mail size={16} className="mr-2" /> Invite
                 </button>
-                <button className="corporate-btn-primary px-4 py-2">
-                  <UserPlus size={16} className="mr-2" />
-                  Add Member
+                <button onClick={() => setModal({ type: 'addMember' })} className="corporate-btn-primary px-4 py-2 flex items-center">
+                  <UserPlus size={16} className="mr-2" /> Add Member
                 </button>
               </div>
             </div>
           </div>
 
-          {/* Team Members Grid */}
-          <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
-            {filteredMembers.map((member) => (
-              <div 
-                key={member.id} 
-                className={`corporate-card p-5 hover:shadow-xl transition-all duration-300 hover:scale-[1.02] cursor-pointer ${
-                  selectedMember === member.id ? 'ring-2 ring-corporate-blue' : ''
-                }`}
-                onClick={() => setSelectedMember(member.id === selectedMember ? null : member.id)}
-              >
-                <div className="flex items-start justify-between mb-4">
-                  <div className="flex items-center">
-                    <div className={`${member.color} w-12 h-12 rounded-full flex items-center justify-center text-white font-bold text-lg mr-3`}>
-                      {member.avatar}
+          {loading && !members.length ? (
+            <div className="corporate-card p-12 text-center text-gray-500">Loading team members...</div>
+          ) : (
+            <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
+              {filteredMembers.map((member) => (
+                <div
+                  key={member.id}
+                  className={`corporate-card p-5 hover:shadow-xl transition-all duration-300 hover:scale-[1.02] cursor-pointer ${
+                    selectedMember?.id === member.id ? 'ring-2 ring-corporate-blue' : ''
+                  }`}
+                  onClick={() => setSelectedMember(selectedMember?.id === member.id ? null : member)}
+                >
+                  <div className="flex items-start justify-between mb-4">
+                    <div className="flex items-center">
+                      <div
+                        className="w-12 h-12 rounded-full flex items-center justify-center text-white font-bold text-lg mr-3"
+                        style={{ backgroundColor: roleColor(member.role?.name ?? '') }}
+                      >
+                        {memberInitials(member)}
+                      </div>
+                      <div>
+                        <h3 className="font-bold text-gray-900 dark:text-white">{memberDisplayName(member)}</h3>
+                        <div className="text-sm text-gray-600 dark:text-gray-400">{member.role?.name ?? '—'}</div>
+                      </div>
                     </div>
-                    <div>
-                      <h3 className="font-bold text-gray-900 dark:text-white">{member.name}</h3>
-                      <div className="text-sm text-gray-600 dark:text-gray-400">{member.role}</div>
+                    <span className={`px-2 py-1 rounded-full text-xs font-medium ${statusBadge(member.status)}`}>
+                      {member.status}
+                    </span>
+                  </div>
+
+                  <div className="space-y-2 mb-4">
+                    <div className="flex items-center text-sm text-gray-600 dark:text-gray-400">
+                      <Mail size={14} className="mr-2 shrink-0" /> {member.email}
+                    </div>
+                    {member.title && (
+                      <div className="flex items-center text-sm text-gray-600 dark:text-gray-400">
+                        <Target size={14} className="mr-2 shrink-0" /> {member.title}
+                      </div>
+                    )}
+                    <div className="flex items-center text-sm text-gray-600 dark:text-gray-400">
+                      <Calendar size={14} className="mr-2 shrink-0" />
+                      Joined {new Date(member.joinedAt).toLocaleDateString()}
                     </div>
                   </div>
-                  <div className={`px-2 py-1 rounded-full text-xs font-medium ${getStatusColor(member.status)}`}>
-                    {member.status}
+
+                  {member.role?.permissions && (
+                    <div className="mb-4">
+                      <div className="text-xs text-gray-500 dark:text-gray-400 mb-2">Permissions</div>
+                      <div className="flex flex-wrap gap-1">
+                        {(member.role.permissions as string[]).slice(0, 4).map((p) => (
+                          <span key={p} className="px-2 py-0.5 bg-blue-100 dark:bg-blue-900/30 text-blue-800 dark:text-blue-300 rounded text-xs">
+                            {p.split(':')[1]}
+                          </span>
+                        ))}
+                        {(member.role.permissions as string[]).length > 4 && (
+                          <span className="px-2 py-0.5 bg-gray-100 dark:bg-gray-800 text-gray-600 dark:text-gray-400 rounded text-xs">
+                            +{(member.role.permissions as string[]).length - 4} more
+                          </span>
+                        )}
+                      </div>
+                    </div>
+                  )}
+
+                  <div className="flex gap-2">
+                    <button
+                      className="flex-1 corporate-btn-secondary text-sm px-3 py-2 flex items-center justify-center"
+                      onClick={(e) => { e.stopPropagation(); setModal({ type: 'editMember', member }) }}
+                    >
+                      <Edit size={14} className="mr-1" /> Edit
+                    </button>
+                    {member.status === 'ACTIVE' ? (
+                      <button
+                        className="flex-1 text-sm px-3 py-2 flex items-center justify-center text-red-600 hover:bg-red-50 dark:hover:bg-red-900/20 rounded-lg border border-red-200 dark:border-red-800"
+                        onClick={async (e) => {
+                          e.stopPropagation()
+                          try { await deactivateMember(member.id); notify('Member deactivated') }
+                          catch (err) { notify(err instanceof Error ? err.message : 'Failed', true) }
+                        }}
+                      >
+                        <Trash2 size={14} className="mr-1" /> Deactivate
+                      </button>
+                    ) : (
+                      <button
+                        className="flex-1 text-sm px-3 py-2 flex items-center justify-center text-green-600 hover:bg-green-50 dark:hover:bg-green-900/20 rounded-lg border border-green-200 dark:border-green-800"
+                        onClick={async (e) => {
+                          e.stopPropagation()
+                          try { await reactivateMember(member.id); notify('Member reactivated') }
+                          catch (err) { notify(err instanceof Error ? err.message : 'Failed', true) }
+                        }}
+                      >
+                        <RefreshCw size={14} className="mr-1" /> Reactivate
+                      </button>
+                    )}
                   </div>
                 </div>
+              ))}
 
-                <div className="space-y-3 mb-4">
-                  <div className="flex items-center text-sm text-gray-600 dark:text-gray-400">
-                    <Mail size={14} className="mr-2" />
-                    {member.email}
-                  </div>
-                  <div className="flex items-center text-sm text-gray-600 dark:text-gray-400">
-                    <Phone size={14} className="mr-2" />
-                    {member.phone}
-                  </div>
-                  <div className="flex items-center text-sm text-gray-600 dark:text-gray-400">
-                    <Calendar size={14} className="mr-2" />
-                    Joined {new Date(member.joined).toLocaleDateString()}
-                  </div>
+              {!loading && filteredMembers.length === 0 && (
+                <div className="col-span-3 corporate-card p-12 text-center text-gray-500">
+                  {searchTerm ? 'No members match your search.' : 'No team members yet. Add one to get started.'}
                 </div>
+              )}
+            </div>
+          )}
 
-                <div className="mb-4">
-                  <div className="text-xs text-gray-500 dark:text-gray-400 mb-2">Permissions</div>
-                  <div className="flex flex-wrap gap-1">
-                    {member.permissions.map((permission) => (
-                      <span key={permission} className="px-2 py-1 bg-blue-100 dark:bg-blue-900/30 text-blue-800 dark:text-blue-300 rounded text-xs">
-                        {permission}
-                      </span>
-                    ))}
-                  </div>
-                </div>
-
-                <div className="grid grid-cols-2 gap-3 mb-4">
-                  <div className="text-center p-2 bg-gray-50 dark:bg-gray-800/50 rounded-lg">
-                    <div className="font-bold text-gray-900 dark:text-white">{member.projects}</div>
-                    <div className="text-xs text-gray-600 dark:text-gray-400">Projects</div>
-                  </div>
-                  <div className="text-center p-2 bg-gray-50 dark:bg-gray-800/50 rounded-lg">
-                    <div className="font-bold text-gray-900 dark:text-white">{(member.credits / 1000).toFixed(1)}K</div>
-                    <div className="text-xs text-gray-600 dark:text-gray-400">Credits</div>
-                  </div>
-                </div>
-
-                <div className="flex space-x-2">
-                  <button className="flex-1 corporate-btn-secondary text-sm px-3 py-2">
-                    <MessageSquare size={14} className="mr-1" />
-                    Message
-                  </button>
-                  <button className="flex-1 corporate-btn-primary text-sm px-3 py-2">
-                    <Eye size={14} className="mr-1" />
-                    Profile
-                  </button>
-                </div>
-              </div>
-            ))}
-          </div>
-
-          {/* Selected Member Details */}
+          {/* Selected member detail panel */}
           {selectedMember && (
             <div className="corporate-card p-6 animate-in">
               <div className="flex items-center justify-between mb-6">
                 <h2 className="text-xl font-bold text-gray-900 dark:text-white">Member Details</h2>
-                <div className="flex items-center space-x-2">
-                  <button className="corporate-btn-secondary px-3 py-1">
-                    <Edit size={14} className="mr-1" />
-                    Edit
-                  </button>
-                  <button className="text-red-600 hover:text-red-800 px-3 py-1">
-                    <Trash2 size={14} className="mr-1" />
-                    Remove
-                  </button>
+                <button onClick={() => setSelectedMember(null)} className="p-2 hover:bg-gray-100 dark:hover:bg-gray-800 rounded-lg">
+                  <X size={18} />
+                </button>
+              </div>
+              <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
+                <div className="space-y-3">
+                  {[
+                    { label: 'Email', value: selectedMember.email },
+                    { label: 'Department', value: selectedMember.department },
+                    { label: 'Title', value: selectedMember.title },
+                    { label: 'Status', value: selectedMember.status },
+                    { label: 'Role', value: selectedMember.role?.name },
+                    { label: 'Joined', value: new Date(selectedMember.joinedAt).toLocaleDateString() },
+                    { label: 'Last Active', value: selectedMember.lastActiveAt ? new Date(selectedMember.lastActiveAt).toLocaleDateString() : '—' },
+                  ].map(({ label, value }) => value ? (
+                    <div key={label} className="flex justify-between text-sm">
+                      <span className="text-gray-500 dark:text-gray-400">{label}</span>
+                      <span className="font-medium text-gray-900 dark:text-white">{value}</span>
+                    </div>
+                  ) : null)}
+                </div>
+                <div>
+                  <div className="text-sm font-medium text-gray-700 dark:text-gray-300 mb-3">All Permissions</div>
+                  <div className="flex flex-wrap gap-1">
+                    {(selectedMember.role?.permissions as string[] ?? []).map((p) => (
+                      <span key={p} className="px-2 py-0.5 bg-blue-100 dark:bg-blue-900/30 text-blue-800 dark:text-blue-300 rounded text-xs">
+                        {p}
+                      </span>
+                    ))}
+                  </div>
                 </div>
               </div>
-              
-              {(() => {
-                const member = teamMembers.find(m => m.id === selectedMember)
-                if (!member) return null
-                
-                return (
-                  <div className="grid grid-cols-1 md:grid-cols-3 gap-6">
-                    <div className="md:col-span-2">
-                      <div className="mb-6">
-                        <h3 className="font-bold text-gray-900 dark:text-white mb-2">Biography</h3>
-                        <p className="text-gray-600 dark:text-gray-400">{member.bio}</p>
-                      </div>
-                      
-                      <div className="grid grid-cols-2 gap-4">
-                        <div className="p-4 bg-blue-50 dark:bg-blue-900/20 rounded-lg">
-                          <div className="text-2xl font-bold text-corporate-blue mb-1">{member.projects}</div>
-                          <div className="text-sm text-gray-600 dark:text-gray-400">Projects Managed</div>
-                        </div>
-                        <div className="p-4 bg-green-50 dark:bg-green-900/20 rounded-lg">
-                          <div className="text-2xl font-bold text-green-600 mb-1">{(member.credits / 1000).toFixed(1)}K</div>
-                          <div className="text-sm text-gray-600 dark:text-gray-400">Credits Managed</div>
-                        </div>
-                      </div>
-                    </div>
-                    
-                    <div>
-                      <h3 className="font-bold text-gray-900 dark:text-white mb-4">Recent Activity</h3>
-                      <div className="space-y-3">
-                        {teamActivity
-                          .filter(activity => activity.user === member.name)
-                          .slice(0, 3)
-                          .map((activity, index) => {
-                            const Icon = activity.icon
-                            return (
-                              <div key={index} className="p-3 bg-gray-50 dark:bg-gray-800/50 rounded-lg">
-                                <div className="flex items-start">
-                                  <div className="p-2 bg-blue-100 dark:bg-blue-900/30 rounded-lg mr-3">
-                                    <Icon className="text-corporate-blue" size={16} />
-                                  </div>
-                                  <div>
-                                    <div className="font-medium text-gray-900 dark:text-white text-sm">
-                                      {activity.action}
-                                    </div>
-                                    <div className="text-xs text-gray-600 dark:text-gray-400">
-                                      {activity.time} • {activity.project}
-                                    </div>
-                                  </div>
-                                </div>
-                              </div>
-                            )
-                          })}
-                      </div>
-                    </div>
-                  </div>
-                )
-              })()}
             </div>
           )}
         </div>
       )}
 
-      {/* Roles & Permissions Tab */}
+      {/* ── Roles Tab ── */}
       {activeTab === 'roles' && (
         <div className="space-y-6">
           <div className="corporate-card p-6">
             <div className="flex items-center justify-between mb-6">
               <div>
-                <h2 className="text-xl font-bold text-gray-900 dark:text-white">Team Roles</h2>
-                <p className="text-sm text-gray-600 dark:text-gray-400">Define permissions and access levels</p>
+                <h2 className="text-xl font-bold text-gray-900 dark:text-white">Roles & Permissions</h2>
+                <p className="text-sm text-gray-600 dark:text-gray-400">Define access levels for your team</p>
               </div>
-              <button className="corporate-btn-primary px-4 py-2">
-                <UserPlus size={16} className="mr-2" />
-                Create Role
+              <button onClick={() => setModal({ type: 'createRole' })} className="corporate-btn-primary px-4 py-2 flex items-center">
+                <Shield size={16} className="mr-2" /> Create Role
               </button>
             </div>
-            
+
             <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
-              {/* Role Distribution Chart */}
+              {/* Pie chart */}
               <div>
                 <h3 className="font-bold text-gray-900 dark:text-white mb-4">Role Distribution</h3>
-                <div className="h-64">
-                  <ResponsiveContainer width="100%" height="100%">
-                    <RechartsPieChart>
-                      <Pie
-                        data={roleDistributionData}
-                        cx="50%"
-                        cy="50%"
-                        innerRadius={60}
-                        outerRadius={80}
-                        paddingAngle={2}
-                        dataKey="value"
-                      >
-                        {roleDistributionData.map((entry, index) => (
-                          <Cell key={`cell-${index}`} fill={entry.color} />
-                        ))}
-                      </Pie>
-                      <Tooltip formatter={(value) => [`${value} members`, 'Count']} />
-                    </RechartsPieChart>
-                  </ResponsiveContainer>
-                </div>
+                {roleDistribution.length > 0 ? (
+                  <div className="h-64">
+                    <ResponsiveContainer width="100%" height="100%">
+                      <RechartsPieChart>
+                        <Pie data={roleDistribution} cx="50%" cy="50%" innerRadius={60} outerRadius={80} paddingAngle={2} dataKey="value">
+                          {roleDistribution.map((entry, i) => (
+                            <Cell key={i} fill={entry.color} />
+                          ))}
+                        </Pie>
+                        <Tooltip formatter={(v) => [`${v} members`, 'Count']} />
+                      </RechartsPieChart>
+                    </ResponsiveContainer>
+                  </div>
+                ) : (
+                  <div className="h-64 flex items-center justify-center text-gray-400">No roles yet</div>
+                )}
               </div>
-              
-              {/* Role List */}
+
+              {/* Role list */}
               <div>
                 <h3 className="font-bold text-gray-900 dark:text-white mb-4">All Roles</h3>
-                <div className="space-y-4">
-                  {teamRoles.map((role, index) => (
-                    <div key={index} className="p-4 border border-gray-200 dark:border-gray-800 rounded-lg">
-                      <div className="flex items-center justify-between mb-3">
-                        <div className="flex items-center">
-                          <div className="w-3 h-3 rounded-full mr-2" style={{ backgroundColor: role.color }}></div>
-                          <h4 className="font-bold text-gray-900 dark:text-white">{role.name}</h4>
+                {loading && !roles.length ? (
+                  <div className="text-gray-500 text-sm">Loading roles...</div>
+                ) : (
+                  <div className="space-y-4">
+                    {roles.map((role) => (
+                      <div key={role.id} className="p-4 border border-gray-200 dark:border-gray-800 rounded-lg">
+                        <div className="flex items-center justify-between mb-3">
+                          <div className="flex items-center gap-2">
+                            <div className="w-3 h-3 rounded-full" style={{ backgroundColor: roleColor(role.name) }} />
+                            <h4 className="font-bold text-gray-900 dark:text-white">{role.name}</h4>
+                            {role.isSystem && (
+                              <span className="text-xs bg-gray-100 dark:bg-gray-800 text-gray-500 px-1.5 py-0.5 rounded">system</span>
+                            )}
+                          </div>
+                          <span className="text-sm text-gray-600 dark:text-gray-400">{role.memberCount} member{role.memberCount !== 1 ? 's' : ''}</span>
                         </div>
-                        <div className="text-sm text-gray-600 dark:text-gray-400">
-                          {role.members} member{role.members !== 1 ? 's' : ''}
+                        {role.description && (
+                          <p className="text-sm text-gray-600 dark:text-gray-400 mb-2">{role.description}</p>
+                        )}
+                        <div className="flex flex-wrap gap-1 mb-3">
+                          {(role.permissions as string[]).slice(0, 5).map((p) => (
+                            <span key={p} className="px-2 py-0.5 bg-gray-100 dark:bg-gray-800 text-gray-700 dark:text-gray-300 rounded text-xs">{p}</span>
+                          ))}
+                          {(role.permissions as string[]).length > 5 && (
+                            <span className="px-2 py-0.5 bg-gray-100 dark:bg-gray-800 text-gray-500 rounded text-xs">+{(role.permissions as string[]).length - 5}</span>
+                          )}
+                        </div>
+                        <div className="flex justify-end gap-3">
+                          <button
+                            onClick={() => setModal({ type: 'editRole', role })}
+                            className="text-sm text-corporate-blue hover:underline flex items-center gap-1"
+                          >
+                            <Edit size={13} /> Edit
+                          </button>
+                          {!role.isSystem && (
+                            <button
+                              onClick={async () => {
+                                try { await deleteRole(role.id); notify('Role deleted') }
+                                catch (err) { notify(err instanceof Error ? err.message : 'Failed', true) }
+                              }}
+                              className="text-sm text-red-600 hover:underline flex items-center gap-1"
+                            >
+                              <Trash2 size={13} /> Delete
+                            </button>
+                          )}
                         </div>
                       </div>
-                      <div className="flex flex-wrap gap-1 mb-3">
-                        {role.permissions.map((permission, idx) => (
-                          <span key={idx} className="px-2 py-1 bg-gray-100 dark:bg-gray-800 text-gray-700 dark:text-gray-300 rounded text-xs">
-                            {permission}
-                          </span>
-                        ))}
-                      </div>
-                      <div className="flex justify-end space-x-2">
-                        <button className="text-sm text-corporate-blue hover:text-corporate-blue/80">
-                          <Edit size={14} className="inline mr-1" />
-                          Edit
-                        </button>
-                        <button className="text-sm text-gray-600 hover:text-gray-900 dark:text-gray-400">
-                          <Users size={14} className="inline mr-1" />
-                          Assign
-                        </button>
-                      </div>
-                    </div>
-                  ))}
-                </div>
+                    ))}
+                  </div>
+                )}
               </div>
             </div>
           </div>
         </div>
       )}
 
-      {/* Team Activity Tab */}
-      {activeTab === 'activity' && (
+      {/* ── Invitations Tab ── */}
+      {activeTab === 'invitations' && (
         <div className="space-y-6">
           <div className="corporate-card p-6">
             <div className="flex items-center justify-between mb-6">
               <div>
-                <h2 className="text-xl font-bold text-gray-900 dark:text-white">Team Activity Feed</h2>
-                <p className="text-sm text-gray-600 dark:text-gray-400">Recent actions and updates</p>
+                <h2 className="text-xl font-bold text-gray-900 dark:text-white">Invitations</h2>
+                <p className="text-sm text-gray-600 dark:text-gray-400">Pending and past team invitations</p>
               </div>
-              <button className="corporate-btn-secondary px-4 py-2">
-                <Filter size={16} className="mr-2" />
-                Filter Activities
+              <button onClick={() => setModal({ type: 'invite' })} className="corporate-btn-primary px-4 py-2 flex items-center">
+                <Send size={16} className="mr-2" /> Invite Member
               </button>
             </div>
-            
-            <div className="space-y-4">
-              {teamActivity.map((activity, index) => {
-                const Icon = activity.icon
-                return (
-                  <div key={index} className="p-4 border border-gray-200 dark:border-gray-800 rounded-lg hover:border-corporate-blue/50 transition-colors">
-                    <div className="flex items-start">
-                      <div className={`p-2 rounded-lg mr-4 ${
-                        index === 0 ? 'bg-green-100 dark:bg-green-900/30' :
-                        index === 1 ? 'bg-blue-100 dark:bg-blue-900/30' :
-                        'bg-gray-100 dark:bg-gray-800/50'
-                      }`}>
-                        <Icon className={
-                          index === 0 ? 'text-green-600 dark:text-green-400' :
-                          index === 1 ? 'text-blue-600 dark:text-blue-400' :
-                          'text-gray-600 dark:text-gray-400'
-                        } size={20} />
-                      </div>
-                      <div className="flex-1">
-                        <div className="flex items-center justify-between mb-2">
-                          <div className="font-bold text-gray-900 dark:text-white">{activity.user}</div>
-                          <div className="text-sm text-gray-600 dark:text-gray-400">{activity.time}</div>
-                        </div>
-                        <div className="text-gray-900 dark:text-white mb-1">{activity.action}</div>
-                        <div className="text-sm text-gray-600 dark:text-gray-400">Project: {activity.project}</div>
-                      </div>
-                      <button className="text-gray-400 hover:text-gray-600 dark:text-gray-600 dark:hover:text-gray-400 ml-2">
-                        <Bell size={16} />
-                      </button>
-                    </div>
-                  </div>
-                )
-              })}
-            </div>
-            
-            <button className="w-full mt-6 corporate-btn-secondary py-3">
-              <ChevronRight size={16} className="mr-2" />
-              Load More Activities
-            </button>
-          </div>
-        </div>
-      )}
 
-      {/* Team Analytics Tab */}
-      {activeTab === 'analytics' && (
-        <div className="space-y-6">
-          <div className="corporate-card p-6">
-            <div className="flex items-center justify-between mb-6">
-              <div>
-                <h2 className="text-xl font-bold text-gray-900 dark:text-white">Team Performance Analytics</h2>
-                <p className="text-sm text-gray-600 dark:text-gray-400">Monthly team contributions and impact</p>
-              </div>
-              <Target className="text-corporate-blue" size={24} />
-            </div>
-            
-            <div className="h-72 mb-8">
-              <ResponsiveContainer width="100%" height="100%">
-                <BarChart data={performanceData}>
-                  <CartesianGrid strokeDasharray="3 3" stroke="#e5e7eb" />
-                  <XAxis dataKey="month" />
-                  <YAxis />
-                  <Tooltip 
-                    formatter={(value: any, name: string | undefined) => {
-                      if (name === 'retirements') return [`${value.toLocaleString()} tCO₂`, 'Retirements']
-                      if (name === 'purchases') return [`${value.toLocaleString()} tCO₂`, 'Purchases']
-                      return [value, 'Reports Generated']
-                    }}
-                  />
-                  <Bar dataKey="retirements" fill="#0073e6" name="Credits Retired" radius={[4, 4, 0, 0]} />
-                  <Bar dataKey="purchases" fill="#00d4aa" name="Credits Purchased" radius={[4, 4, 0, 0]} />
-                  <Bar dataKey="reports" fill="#8b5cf6" name="Reports Generated" radius={[4, 4, 0, 0]} />
-                </BarChart>
-              </ResponsiveContainer>
-            </div>
-            
-            <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
-              <div className="p-4 bg-linear-to-r from-blue-50 to-cyan-50 dark:from-blue-900/20 dark:to-cyan-900/20 rounded-lg">
-                <div className="text-2xl font-bold text-corporate-blue mb-1">
-                  {(performanceData.reduce((sum, m) => sum + m.retirements, 0) / 1000).toFixed(1)}K
-                </div>
-                <div className="text-sm text-gray-600 dark:text-gray-400">Total Credits Retired</div>
-              </div>
-              <div className="p-4 bg-linear-to-r from-green-50 to-emerald-50 dark:from-green-900/20 dark:to-emerald-900/20 rounded-lg">
-                <div className="text-2xl font-bold text-green-600 mb-1">
-                  {(performanceData.reduce((sum, m) => sum + m.purchases, 0) / 1000).toFixed(1)}K
-                </div>
-                <div className="text-sm text-gray-600 dark:text-gray-400">Total Credits Purchased</div>
-              </div>
-              <div className="p-4 bg-linear-to-r from-purple-50 to-pink-50 dark:from-purple-900/20 dark:to-pink-900/20 rounded-lg">
-                <div className="text-2xl font-bold text-purple-600 mb-1">
-                  {performanceData.reduce((sum, m) => sum + m.reports, 0)}
-                </div>
-                <div className="text-sm text-gray-600 dark:text-gray-400">Total Reports Generated</div>
-              </div>
-            </div>
-          </div>
-          
-          {/* Team Collaboration Metrics */}
-          <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
-            <div className="corporate-card p-6">
-              <div className="flex items-center justify-between mb-6">
-                <div>
-                  <h3 className="font-bold text-gray-900 dark:text-white">Collaboration Score</h3>
-                  <p className="text-sm text-gray-600 dark:text-gray-400">Team collaboration effectiveness</p>
-                </div>
-                <div className="text-2xl font-bold text-corporate-blue">87/100</div>
-              </div>
+            {loading && !invitations.length ? (
+              <div className="text-center text-gray-500 py-8">Loading invitations...</div>
+            ) : invitations.length === 0 ? (
+              <div className="text-center text-gray-500 py-8">No invitations yet.</div>
+            ) : (
               <div className="space-y-3">
-                {[
-                  { metric: 'Cross-team Projects', score: 92, trend: 'up' },
-                  { metric: 'Document Sharing', score: 85, trend: 'up' },
-                  { metric: 'Meeting Participation', score: 78, trend: 'stable' },
-                  { metric: 'Feedback Response', score: 91, trend: 'up' },
-                ].map((item, index) => (
-                  <div key={index}>
-                    <div className="flex justify-between text-sm mb-1">
-                      <span className="text-gray-900 dark:text-white">{item.metric}</span>
-                      <span className="font-medium">{item.score}/100</span>
+                {invitations.map((inv) => (
+                  <div key={inv.id} className="p-4 border border-gray-200 dark:border-gray-800 rounded-lg flex items-center justify-between">
+                    <div className="flex items-center gap-4">
+                      <div className="p-2 bg-blue-100 dark:bg-blue-900/30 rounded-lg">
+                        <Mail className="text-corporate-blue" size={18} />
+                      </div>
+                      <div>
+                        <div className="font-medium text-gray-900 dark:text-white">{inv.email}</div>
+                        <div className="text-sm text-gray-500 dark:text-gray-400">
+                          Role: {inv.role?.name ?? inv.roleId} · Sent {new Date(inv.createdAt).toLocaleDateString()}
+                        </div>
+                        <div className="text-xs text-gray-400 dark:text-gray-500">
+                          Expires {new Date(inv.expiresAt).toLocaleDateString()}
+                        </div>
+                      </div>
                     </div>
-                    <div className="w-full bg-gray-200 dark:bg-gray-700 rounded-full h-2">
-                      <div
-                        className={`h-2 rounded-full ${
-                          item.score >= 90 ? 'bg-green-500' :
-                          item.score >= 80 ? 'bg-blue-500' : 'bg-yellow-500'
-                        }`}
-                        style={{ width: `${item.score}%` }}
-                      ></div>
-                    </div>
-                  </div>
-                ))}
-              </div>
-            </div>
-            
-            <div className="corporate-card p-6">
-              <div className="flex items-center justify-between mb-6">
-                <div>
-                  <h3 className="font-bold text-gray-900 dark:text-white">Team Health</h3>
-                  <p className="text-sm text-gray-600 dark:text-gray-400">Well-being and engagement metrics</p>
-                </div>
-                <PieChart className="text-corporate-blue" size={24} />
-              </div>
-              <div className="space-y-4">
-                {[
-                  { aspect: 'Engagement', value: 88, status: 'Excellent', color: 'bg-green-500' },
-                  { aspect: 'Workload Balance', value: 72, status: 'Good', color: 'bg-blue-500' },
-                  { aspect: 'Skill Development', value: 65, status: 'Moderate', color: 'bg-yellow-500' },
-                  { aspect: 'Recognition', value: 81, status: 'Good', color: 'bg-teal-500' },
-                ].map((item, index) => (
-                  <div key={index} className="flex items-center justify-between">
-                    <div className="flex items-center">
-                      <div className={`w-3 h-3 rounded-full mr-2 ${item.color}`}></div>
-                      <span className="text-gray-900 dark:text-white">{item.aspect}</span>
-                    </div>
-                    <div className="text-right">
-                      <div className="font-bold text-gray-900 dark:text-white">{item.value}%</div>
-                      <div className="text-xs text-gray-600 dark:text-gray-400">{item.status}</div>
+                    <div className="flex items-center gap-3">
+                      <span className={`px-2 py-1 rounded-full text-xs font-medium ${statusBadge(inv.status)}`}>
+                        {inv.status}
+                      </span>
+                      {inv.status === 'PENDING' && (
+                        <>
+                          <button
+                            onClick={async () => {
+                              try { await resendInvitation(inv.id); notify('Invitation resent') }
+                              catch (err) { notify(err instanceof Error ? err.message : 'Failed', true) }
+                            }}
+                            className="text-sm text-corporate-blue hover:underline"
+                          >
+                            Resend
+                          </button>
+                          <button
+                            onClick={async () => {
+                              try { await cancelInvitation(inv.id); notify('Invitation cancelled') }
+                              catch (err) { notify(err instanceof Error ? err.message : 'Failed', true) }
+                            }}
+                            className="text-sm text-red-600 hover:underline"
+                          >
+                            Cancel
+                          </button>
+                        </>
+                      )}
                     </div>
                   </div>
                 ))}
               </div>
-            </div>
+            )}
           </div>
         </div>
       )}
 
-      {/* Team Tools & Resources */}
-      <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
-        <button className="corporate-card p-5 hover:shadow-lg transition-all duration-300 group">
-          <div className="flex items-center">
-            <MessageSquare className="text-corporate-blue mr-3" size={24} />
-            <div>
-              <div className="font-bold text-gray-900 dark:text-white group-hover:text-corporate-blue">
-                Team Chat
-              </div>
-              <div className="text-sm text-gray-600 dark:text-gray-400">Internal communication</div>
-            </div>
-          </div>
-        </button>
-        <button className="corporate-card p-5 hover:shadow-lg transition-all duration-300 group">
-          <div className="flex items-center">
-            <Calendar className="text-corporate-blue mr-3" size={24} />
-            <div>
-              <div className="font-bold text-gray-900 dark:text-white group-hover:text-corporate-blue">
-                Team Calendar
-              </div>
-              <div className="text-sm text-gray-600 dark:text-gray-400">Schedule meetings & deadlines</div>
-            </div>
-          </div>
-        </button>
-        <button className="corporate-card p-5 hover:shadow-lg transition-all duration-300 group">
-          <div className="flex items-center">
-            <FileText className="text-corporate-blue mr-3" size={24} />
-            <div>
-              <div className="font-bold text-gray-900 dark:text-white group-hover:text-corporate-blue">
-                Team Documents
-              </div>
-              <div className="text-sm text-gray-600 dark:text-gray-400">Shared resources & files</div>
-            </div>
-          </div>
-        </button>
-      </div>
+      {/* ── Modals ── */}
+      {modal?.type === 'addMember' && (
+        <AddMemberModal
+          roles={roles}
+          onClose={() => setModal(null)}
+          onSubmit={async (payload) => {
+            const result = await createMember(payload)
+            if (result) notify('Member added successfully')
+            else throw new Error('Failed to add member')
+          }}
+        />
+      )}
+
+      {modal?.type === 'editMember' && (
+        <EditMemberModal
+          member={modal.member}
+          roles={roles}
+          onClose={() => setModal(null)}
+          onUpdate={async (id, payload) => {
+            const result = await updateMember(id, payload)
+            if (!result) throw new Error('Failed to update member')
+          }}
+          onAssignRole={async (memberId, roleId) => {
+            const result = await assignRole(memberId, roleId)
+            if (!result) throw new Error('Failed to assign role')
+            notify('Member updated successfully')
+          }}
+        />
+      )}
+
+      {modal?.type === 'invite' && (
+        <InviteMemberModal
+          roles={roles}
+          onClose={() => setModal(null)}
+          onSubmit={async (payload) => {
+            const result = await inviteMember(payload)
+            if (result) notify('Invitation sent')
+            else throw new Error('Failed to send invitation')
+          }}
+        />
+      )}
+
+      {modal?.type === 'createRole' && (
+        <ManageRoleModal
+          availablePermissions={permissions}
+          onClose={() => setModal(null)}
+          onCreate={async (payload) => {
+            const result = await createRole(payload)
+            if (result) notify('Role created')
+            else throw new Error('Failed to create role')
+          }}
+        />
+      )}
+
+      {modal?.type === 'editRole' && (
+        <ManageRoleModal
+          role={modal.role}
+          availablePermissions={permissions}
+          onClose={() => setModal(null)}
+          onUpdate={async (id, payload) => {
+            const result = await updateRole(id, payload)
+            if (result) notify('Role updated')
+            else throw new Error('Failed to update role')
+          }}
+        />
+      )}
     </div>
   )
 }

--- a/corporate-platform/corporate-platform-web/src/components/team/AddMemberModal.tsx
+++ b/corporate-platform/corporate-platform-web/src/components/team/AddMemberModal.tsx
@@ -1,0 +1,152 @@
+'use client'
+
+import { useState } from 'react'
+import { X, UserPlus } from 'lucide-react'
+import type { TeamRole, CreateMemberPayload } from '@/types/team'
+
+interface Props {
+  roles: TeamRole[]
+  onClose: () => void
+  onSubmit: (payload: CreateMemberPayload) => Promise<unknown>
+}
+
+export default function AddMemberModal({ roles, onClose, onSubmit }: Props) {
+  const [form, setForm] = useState<CreateMemberPayload>({
+    email: '',
+    roleId: roles[0]?.id ?? '',
+    firstName: '',
+    lastName: '',
+    department: '',
+    title: '',
+    status: 'ACTIVE',
+  })
+  const [submitting, setSubmitting] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault()
+    setSubmitting(true)
+    setError(null)
+    try {
+      await onSubmit(form)
+      onClose()
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to add member')
+    } finally {
+      setSubmitting(false)
+    }
+  }
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 backdrop-blur-sm">
+      <div className="bg-white dark:bg-gray-900 rounded-2xl shadow-2xl w-full max-w-lg mx-4 p-6">
+        <div className="flex items-center justify-between mb-6">
+          <div className="flex items-center gap-3">
+            <div className="p-2 bg-blue-100 dark:bg-blue-900/30 rounded-lg">
+              <UserPlus className="text-corporate-blue" size={20} />
+            </div>
+            <h2 className="text-xl font-bold text-gray-900 dark:text-white">Add Team Member</h2>
+          </div>
+          <button onClick={onClose} className="p-2 hover:bg-gray-100 dark:hover:bg-gray-800 rounded-lg">
+            <X size={20} />
+          </button>
+        </div>
+
+        {error && (
+          <div className="mb-4 p-3 bg-red-50 dark:bg-red-900/20 border border-red-200 dark:border-red-800 rounded-lg text-red-700 dark:text-red-400 text-sm">
+            {error}
+          </div>
+        )}
+
+        <form onSubmit={handleSubmit} className="space-y-4">
+          <div className="grid grid-cols-2 gap-4">
+            <div>
+              <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">First Name</label>
+              <input
+                type="text"
+                value={form.firstName}
+                onChange={(e) => setForm({ ...form, firstName: e.target.value })}
+                className="w-full px-3 py-2 bg-gray-100 dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-lg focus:outline-none focus:ring-2 focus:ring-corporate-blue"
+              />
+            </div>
+            <div>
+              <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">Last Name</label>
+              <input
+                type="text"
+                value={form.lastName}
+                onChange={(e) => setForm({ ...form, lastName: e.target.value })}
+                className="w-full px-3 py-2 bg-gray-100 dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-lg focus:outline-none focus:ring-2 focus:ring-corporate-blue"
+              />
+            </div>
+          </div>
+
+          <div>
+            <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">Email <span className="text-red-500">*</span></label>
+            <input
+              type="email"
+              required
+              value={form.email}
+              onChange={(e) => setForm({ ...form, email: e.target.value })}
+              className="w-full px-3 py-2 bg-gray-100 dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-lg focus:outline-none focus:ring-2 focus:ring-corporate-blue"
+            />
+          </div>
+
+          <div>
+            <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">Role <span className="text-red-500">*</span></label>
+            <select
+              required
+              value={form.roleId}
+              onChange={(e) => setForm({ ...form, roleId: e.target.value })}
+              className="w-full px-3 py-2 bg-gray-100 dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-lg focus:outline-none focus:ring-2 focus:ring-corporate-blue"
+            >
+              {roles.map((r) => (
+                <option key={r.id} value={r.id}>{r.name}</option>
+              ))}
+            </select>
+          </div>
+
+          <div className="grid grid-cols-2 gap-4">
+            <div>
+              <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">Department</label>
+              <input
+                type="text"
+                value={form.department}
+                onChange={(e) => setForm({ ...form, department: e.target.value })}
+                className="w-full px-3 py-2 bg-gray-100 dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-lg focus:outline-none focus:ring-2 focus:ring-corporate-blue"
+              />
+            </div>
+            <div>
+              <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">Title</label>
+              <input
+                type="text"
+                value={form.title}
+                onChange={(e) => setForm({ ...form, title: e.target.value })}
+                className="w-full px-3 py-2 bg-gray-100 dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-lg focus:outline-none focus:ring-2 focus:ring-corporate-blue"
+              />
+            </div>
+          </div>
+
+          <div>
+            <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">Status</label>
+            <select
+              value={form.status}
+              onChange={(e) => setForm({ ...form, status: e.target.value as CreateMemberPayload['status'] })}
+              className="w-full px-3 py-2 bg-gray-100 dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-lg focus:outline-none focus:ring-2 focus:ring-corporate-blue"
+            >
+              <option value="ACTIVE">Active</option>
+              <option value="PENDING">Pending</option>
+              <option value="INACTIVE">Inactive</option>
+            </select>
+          </div>
+
+          <div className="flex gap-3 pt-2">
+            <button type="button" onClick={onClose} className="flex-1 corporate-btn-secondary py-2">Cancel</button>
+            <button type="submit" disabled={submitting} className="flex-1 corporate-btn-primary py-2 disabled:opacity-50">
+              {submitting ? 'Adding...' : 'Add Member'}
+            </button>
+          </div>
+        </form>
+      </div>
+    </div>
+  )
+}

--- a/corporate-platform/corporate-platform-web/src/components/team/EditMemberModal.tsx
+++ b/corporate-platform/corporate-platform-web/src/components/team/EditMemberModal.tsx
@@ -1,0 +1,144 @@
+'use client'
+
+import { useState } from 'react'
+import { X, Edit } from 'lucide-react'
+import type { TeamMember, TeamRole, UpdateMemberPayload } from '@/types/team'
+
+interface Props {
+  member: TeamMember
+  roles: TeamRole[]
+  onClose: () => void
+  onUpdate: (id: string, payload: UpdateMemberPayload) => Promise<unknown>
+  onAssignRole: (memberId: string, roleId: string) => Promise<unknown>
+}
+
+export default function EditMemberModal({ member, roles, onClose, onUpdate, onAssignRole }: Props) {
+  const [form, setForm] = useState<UpdateMemberPayload>({
+    firstName: member.firstName ?? '',
+    lastName: member.lastName ?? '',
+    status: member.status,
+    department: member.department ?? '',
+    title: member.title ?? '',
+  })
+  const [selectedRoleId, setSelectedRoleId] = useState(member.roleId)
+  const [submitting, setSubmitting] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault()
+    setSubmitting(true)
+    setError(null)
+    try {
+      await onUpdate(member.id, form)
+      if (selectedRoleId !== member.roleId) {
+        await onAssignRole(member.id, selectedRoleId)
+      }
+      onClose()
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to update member')
+    } finally {
+      setSubmitting(false)
+    }
+  }
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 backdrop-blur-sm">
+      <div className="bg-white dark:bg-gray-900 rounded-2xl shadow-2xl w-full max-w-lg mx-4 p-6">
+        <div className="flex items-center justify-between mb-6">
+          <div className="flex items-center gap-3">
+            <div className="p-2 bg-blue-100 dark:bg-blue-900/30 rounded-lg">
+              <Edit className="text-corporate-blue" size={20} />
+            </div>
+            <h2 className="text-xl font-bold text-gray-900 dark:text-white">Edit Member</h2>
+          </div>
+          <button onClick={onClose} className="p-2 hover:bg-gray-100 dark:hover:bg-gray-800 rounded-lg">
+            <X size={20} />
+          </button>
+        </div>
+
+        {error && (
+          <div className="mb-4 p-3 bg-red-50 dark:bg-red-900/20 border border-red-200 dark:border-red-800 rounded-lg text-red-700 dark:text-red-400 text-sm">
+            {error}
+          </div>
+        )}
+
+        <form onSubmit={handleSubmit} className="space-y-4">
+          <div className="grid grid-cols-2 gap-4">
+            <div>
+              <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">First Name</label>
+              <input
+                type="text"
+                value={form.firstName}
+                onChange={(e) => setForm({ ...form, firstName: e.target.value })}
+                className="w-full px-3 py-2 bg-gray-100 dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-lg focus:outline-none focus:ring-2 focus:ring-corporate-blue"
+              />
+            </div>
+            <div>
+              <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">Last Name</label>
+              <input
+                type="text"
+                value={form.lastName}
+                onChange={(e) => setForm({ ...form, lastName: e.target.value })}
+                className="w-full px-3 py-2 bg-gray-100 dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-lg focus:outline-none focus:ring-2 focus:ring-corporate-blue"
+              />
+            </div>
+          </div>
+
+          <div>
+            <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">Role</label>
+            <select
+              value={selectedRoleId}
+              onChange={(e) => setSelectedRoleId(e.target.value)}
+              className="w-full px-3 py-2 bg-gray-100 dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-lg focus:outline-none focus:ring-2 focus:ring-corporate-blue"
+            >
+              {roles.map((r) => (
+                <option key={r.id} value={r.id}>{r.name}</option>
+              ))}
+            </select>
+          </div>
+
+          <div className="grid grid-cols-2 gap-4">
+            <div>
+              <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">Department</label>
+              <input
+                type="text"
+                value={form.department}
+                onChange={(e) => setForm({ ...form, department: e.target.value })}
+                className="w-full px-3 py-2 bg-gray-100 dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-lg focus:outline-none focus:ring-2 focus:ring-corporate-blue"
+              />
+            </div>
+            <div>
+              <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">Title</label>
+              <input
+                type="text"
+                value={form.title}
+                onChange={(e) => setForm({ ...form, title: e.target.value })}
+                className="w-full px-3 py-2 bg-gray-100 dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-lg focus:outline-none focus:ring-2 focus:ring-corporate-blue"
+              />
+            </div>
+          </div>
+
+          <div>
+            <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">Status</label>
+            <select
+              value={form.status}
+              onChange={(e) => setForm({ ...form, status: e.target.value as UpdateMemberPayload['status'] })}
+              className="w-full px-3 py-2 bg-gray-100 dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-lg focus:outline-none focus:ring-2 focus:ring-corporate-blue"
+            >
+              <option value="ACTIVE">Active</option>
+              <option value="PENDING">Pending</option>
+              <option value="INACTIVE">Inactive</option>
+            </select>
+          </div>
+
+          <div className="flex gap-3 pt-2">
+            <button type="button" onClick={onClose} className="flex-1 corporate-btn-secondary py-2">Cancel</button>
+            <button type="submit" disabled={submitting} className="flex-1 corporate-btn-primary py-2 disabled:opacity-50">
+              {submitting ? 'Saving...' : 'Save Changes'}
+            </button>
+          </div>
+        </form>
+      </div>
+    </div>
+  )
+}

--- a/corporate-platform/corporate-platform-web/src/components/team/InviteMemberModal.tsx
+++ b/corporate-platform/corporate-platform-web/src/components/team/InviteMemberModal.tsx
@@ -1,0 +1,97 @@
+'use client'
+
+import { useState } from 'react'
+import { X, Mail } from 'lucide-react'
+import type { TeamRole, InviteMemberPayload } from '@/types/team'
+
+interface Props {
+  roles: TeamRole[]
+  onClose: () => void
+  onSubmit: (payload: InviteMemberPayload) => Promise<unknown>
+}
+
+export default function InviteMemberModal({ roles, onClose, onSubmit }: Props) {
+  const [form, setForm] = useState<InviteMemberPayload>({
+    email: '',
+    roleId: roles[0]?.id ?? '',
+  })
+  const [submitting, setSubmitting] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault()
+    setSubmitting(true)
+    setError(null)
+    try {
+      await onSubmit(form)
+      onClose()
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to send invitation')
+    } finally {
+      setSubmitting(false)
+    }
+  }
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 backdrop-blur-sm">
+      <div className="bg-white dark:bg-gray-900 rounded-2xl shadow-2xl w-full max-w-md mx-4 p-6">
+        <div className="flex items-center justify-between mb-6">
+          <div className="flex items-center gap-3">
+            <div className="p-2 bg-green-100 dark:bg-green-900/30 rounded-lg">
+              <Mail className="text-green-600" size={20} />
+            </div>
+            <h2 className="text-xl font-bold text-gray-900 dark:text-white">Invite Member</h2>
+          </div>
+          <button onClick={onClose} className="p-2 hover:bg-gray-100 dark:hover:bg-gray-800 rounded-lg">
+            <X size={20} />
+          </button>
+        </div>
+
+        <p className="text-sm text-gray-600 dark:text-gray-400 mb-4">
+          Send an invitation email. The recipient will receive a link to join the team.
+        </p>
+
+        {error && (
+          <div className="mb-4 p-3 bg-red-50 dark:bg-red-900/20 border border-red-200 dark:border-red-800 rounded-lg text-red-700 dark:text-red-400 text-sm">
+            {error}
+          </div>
+        )}
+
+        <form onSubmit={handleSubmit} className="space-y-4">
+          <div>
+            <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">Email <span className="text-red-500">*</span></label>
+            <input
+              type="email"
+              required
+              value={form.email}
+              onChange={(e) => setForm({ ...form, email: e.target.value })}
+              placeholder="colleague@company.com"
+              className="w-full px-3 py-2 bg-gray-100 dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-lg focus:outline-none focus:ring-2 focus:ring-corporate-blue"
+            />
+          </div>
+
+          <div>
+            <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">Role <span className="text-red-500">*</span></label>
+            <select
+              required
+              value={form.roleId}
+              onChange={(e) => setForm({ ...form, roleId: e.target.value })}
+              className="w-full px-3 py-2 bg-gray-100 dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-lg focus:outline-none focus:ring-2 focus:ring-corporate-blue"
+            >
+              {roles.map((r) => (
+                <option key={r.id} value={r.id}>{r.name}</option>
+              ))}
+            </select>
+          </div>
+
+          <div className="flex gap-3 pt-2">
+            <button type="button" onClick={onClose} className="flex-1 corporate-btn-secondary py-2">Cancel</button>
+            <button type="submit" disabled={submitting} className="flex-1 corporate-btn-primary py-2 disabled:opacity-50">
+              {submitting ? 'Sending...' : 'Send Invitation'}
+            </button>
+          </div>
+        </form>
+      </div>
+    </div>
+  )
+}

--- a/corporate-platform/corporate-platform-web/src/components/team/ManageRoleModal.tsx
+++ b/corporate-platform/corporate-platform-web/src/components/team/ManageRoleModal.tsx
@@ -1,0 +1,145 @@
+'use client'
+
+import { useState } from 'react'
+import { X, Shield } from 'lucide-react'
+import type { TeamRole, CreateRolePayload, UpdateRolePayload } from '@/types/team'
+
+interface Props {
+  role?: TeamRole // undefined = create mode
+  availablePermissions: string[]
+  onClose: () => void
+  onCreate?: (payload: CreateRolePayload) => Promise<unknown>
+  onUpdate?: (id: string, payload: UpdateRolePayload) => Promise<unknown>
+}
+
+export default function ManageRoleModal({ role, availablePermissions, onClose, onCreate, onUpdate }: Props) {
+  const isEdit = !!role
+  const [name, setName] = useState(role?.name ?? '')
+  const [description, setDescription] = useState(role?.description ?? '')
+  const [selectedPerms, setSelectedPerms] = useState<string[]>(role?.permissions ?? [])
+  const [submitting, setSubmitting] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  const togglePerm = (perm: string) => {
+    setSelectedPerms((prev) =>
+      prev.includes(perm) ? prev.filter((p) => p !== perm) : [...prev, perm],
+    )
+  }
+
+  // Group permissions by category prefix (e.g. "portfolio", "credit")
+  const grouped = availablePermissions.reduce<Record<string, string[]>>((acc, perm) => {
+    const category = perm.split(':')[0]
+    if (!acc[category]) acc[category] = []
+    acc[category].push(perm)
+    return acc
+  }, {})
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault()
+    setSubmitting(true)
+    setError(null)
+    try {
+      if (isEdit && onUpdate && role) {
+        await onUpdate(role.id, { description, permissions: selectedPerms })
+      } else if (!isEdit && onCreate) {
+        await onCreate({ name, description, permissions: selectedPerms })
+      }
+      onClose()
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to save role')
+    } finally {
+      setSubmitting(false)
+    }
+  }
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 backdrop-blur-sm">
+      <div className="bg-white dark:bg-gray-900 rounded-2xl shadow-2xl w-full max-w-2xl mx-4 p-6 max-h-[90vh] overflow-y-auto">
+        <div className="flex items-center justify-between mb-6">
+          <div className="flex items-center gap-3">
+            <div className="p-2 bg-purple-100 dark:bg-purple-900/30 rounded-lg">
+              <Shield className="text-purple-600" size={20} />
+            </div>
+            <h2 className="text-xl font-bold text-gray-900 dark:text-white">
+              {isEdit ? `Edit Role: ${role.name}` : 'Create Role'}
+            </h2>
+          </div>
+          <button onClick={onClose} className="p-2 hover:bg-gray-100 dark:hover:bg-gray-800 rounded-lg">
+            <X size={20} />
+          </button>
+        </div>
+
+        {error && (
+          <div className="mb-4 p-3 bg-red-50 dark:bg-red-900/20 border border-red-200 dark:border-red-800 rounded-lg text-red-700 dark:text-red-400 text-sm">
+            {error}
+          </div>
+        )}
+
+        <form onSubmit={handleSubmit} className="space-y-5">
+          {!isEdit && (
+            <div>
+              <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">Role Name <span className="text-red-500">*</span></label>
+              <input
+                type="text"
+                required
+                value={name}
+                onChange={(e) => setName(e.target.value)}
+                placeholder="e.g. Senior Analyst"
+                className="w-full px-3 py-2 bg-gray-100 dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-lg focus:outline-none focus:ring-2 focus:ring-corporate-blue"
+              />
+            </div>
+          )}
+
+          <div>
+            <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">Description</label>
+            <textarea
+              value={description}
+              onChange={(e) => setDescription(e.target.value)}
+              rows={2}
+              className="w-full px-3 py-2 bg-gray-100 dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-lg focus:outline-none focus:ring-2 focus:ring-corporate-blue resize-none"
+            />
+          </div>
+
+          <div>
+            <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-3">
+              Permissions
+              <span className="ml-2 text-xs text-gray-500">({selectedPerms.length} selected)</span>
+            </label>
+            <div className="space-y-4 max-h-64 overflow-y-auto pr-1">
+              {Object.entries(grouped).map(([category, perms]) => (
+                <div key={category}>
+                  <div className="text-xs font-semibold text-gray-500 dark:text-gray-400 uppercase tracking-wider mb-2 capitalize">
+                    {category}
+                  </div>
+                  <div className="grid grid-cols-2 gap-2">
+                    {perms.map((perm) => (
+                      <label key={perm} className="flex items-center gap-2 cursor-pointer">
+                        <input
+                          type="checkbox"
+                          checked={selectedPerms.includes(perm)}
+                          onChange={() => togglePerm(perm)}
+                          className="rounded border-gray-300 text-corporate-blue focus:ring-corporate-blue"
+                        />
+                        <span className="text-sm text-gray-700 dark:text-gray-300">{perm.split(':')[1]}</span>
+                      </label>
+                    ))}
+                  </div>
+                </div>
+              ))}
+            </div>
+          </div>
+
+          <div className="flex gap-3 pt-2">
+            <button type="button" onClick={onClose} className="flex-1 corporate-btn-secondary py-2">Cancel</button>
+            <button type="submit" disabled={submitting || (isEdit && !!role?.isSystem)} className="flex-1 corporate-btn-primary py-2 disabled:opacity-50">
+              {submitting ? 'Saving...' : isEdit ? 'Save Changes' : 'Create Role'}
+            </button>
+          </div>
+          {isEdit && role?.isSystem && (
+            <p className="text-xs text-center text-amber-600 dark:text-amber-400">System roles cannot be modified.</p>
+          )}
+        </form>
+      </div>
+    </div>
+  )
+}

--- a/corporate-platform/corporate-platform-web/src/hooks/useTeam.ts
+++ b/corporate-platform/corporate-platform-web/src/hooks/useTeam.ts
@@ -1,0 +1,195 @@
+'use client'
+
+import { useState, useCallback, useEffect } from 'react'
+import { teamApi } from '@/lib/teamApi'
+import type {
+  TeamMember,
+  TeamRole,
+  Invitation,
+  CreateMemberPayload,
+  UpdateMemberPayload,
+  CreateRolePayload,
+  UpdateRolePayload,
+  InviteMemberPayload,
+} from '@/types/team'
+
+export function useTeam() {
+  const [members, setMembers] = useState<TeamMember[]>([])
+  const [roles, setRoles] = useState<TeamRole[]>([])
+  const [invitations, setInvitations] = useState<Invitation[]>([])
+  const [permissions, setPermissions] = useState<string[]>([])
+  const [loading, setLoading] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  const withLoading = useCallback(
+    async <T>(fn: () => Promise<T>): Promise<T | null> => {
+      setLoading(true)
+      setError(null)
+      try {
+        return await fn()
+      } catch (e) {
+        setError(e instanceof Error ? e.message : 'An error occurred')
+        return null
+      } finally {
+        setLoading(false)
+      }
+    },
+    [],
+  )
+
+  const fetchAll = useCallback(async () => {
+    setLoading(true)
+    setError(null)
+    try {
+      const [m, r, inv, perms] = await Promise.all([
+        teamApi.listMembers(),
+        teamApi.listRoles(),
+        teamApi.listInvitations(),
+        teamApi.listPermissions(),
+      ])
+      setMembers(m)
+      setRoles(r)
+      setInvitations(inv)
+      setPermissions(perms)
+    } catch (e) {
+      setError(e instanceof Error ? e.message : 'Failed to load team data')
+    } finally {
+      setLoading(false)
+    }
+  }, [])
+
+  useEffect(() => {
+    fetchAll()
+  }, [fetchAll])
+
+  // Members
+  const createMember = useCallback(
+    async (payload: CreateMemberPayload) => {
+      const member = await withLoading(() => teamApi.createMember(payload))
+      if (member) setMembers((prev) => [member, ...prev])
+      return member
+    },
+    [withLoading],
+  )
+
+  const updateMember = useCallback(
+    async (id: string, payload: UpdateMemberPayload) => {
+      const updated = await withLoading(() => teamApi.updateMember(id, payload))
+      if (updated)
+        setMembers((prev) => prev.map((m) => (m.id === id ? updated : m)))
+      return updated
+    },
+    [withLoading],
+  )
+
+  const deactivateMember = useCallback(
+    async (id: string) => {
+      const updated = await withLoading(() => teamApi.deactivateMember(id))
+      if (updated)
+        setMembers((prev) => prev.map((m) => (m.id === id ? updated : m)))
+      return updated
+    },
+    [withLoading],
+  )
+
+  const reactivateMember = useCallback(
+    async (id: string) => {
+      const updated = await withLoading(() => teamApi.reactivateMember(id))
+      if (updated)
+        setMembers((prev) => prev.map((m) => (m.id === id ? updated : m)))
+      return updated
+    },
+    [withLoading],
+  )
+
+  const assignRole = useCallback(
+    async (memberId: string, roleId: string) => {
+      const updated = await withLoading(() =>
+        teamApi.assignRole(memberId, roleId),
+      )
+      if (updated)
+        setMembers((prev) =>
+          prev.map((m) => (m.id === memberId ? updated : m)),
+        )
+      return updated
+    },
+    [withLoading],
+  )
+
+  // Roles
+  const createRole = useCallback(
+    async (payload: CreateRolePayload) => {
+      const role = await withLoading(() => teamApi.createRole(payload))
+      if (role) setRoles((prev) => [...prev, role])
+      return role
+    },
+    [withLoading],
+  )
+
+  const updateRole = useCallback(
+    async (id: string, payload: UpdateRolePayload) => {
+      const updated = await withLoading(() => teamApi.updateRole(id, payload))
+      if (updated)
+        setRoles((prev) => prev.map((r) => (r.id === id ? updated : r)))
+      return updated
+    },
+    [withLoading],
+  )
+
+  const deleteRole = useCallback(
+    async (id: string) => {
+      const result = await withLoading(() => teamApi.deleteRole(id))
+      if (result !== null) setRoles((prev) => prev.filter((r) => r.id !== id))
+      return result
+    },
+    [withLoading],
+  )
+
+  // Invitations
+  const inviteMember = useCallback(
+    async (payload: InviteMemberPayload) => {
+      const inv = await withLoading(() => teamApi.inviteMember(payload))
+      if (inv) setInvitations((prev) => [inv, ...prev])
+      return inv
+    },
+    [withLoading],
+  )
+
+  const resendInvitation = useCallback(
+    async (id: string) => {
+      return withLoading(() => teamApi.resendInvitation(id))
+    },
+    [withLoading],
+  )
+
+  const cancelInvitation = useCallback(
+    async (id: string) => {
+      const result = await withLoading(() => teamApi.cancelInvitation(id))
+      if (result !== null)
+        setInvitations((prev) => prev.filter((i) => i.id !== id))
+      return result
+    },
+    [withLoading],
+  )
+
+  return {
+    members,
+    roles,
+    invitations,
+    permissions,
+    loading,
+    error,
+    fetchAll,
+    createMember,
+    updateMember,
+    deactivateMember,
+    reactivateMember,
+    assignRole,
+    createRole,
+    updateRole,
+    deleteRole,
+    inviteMember,
+    resendInvitation,
+    cancelInvitation,
+  }
+}

--- a/corporate-platform/corporate-platform-web/src/lib/teamApi.ts
+++ b/corporate-platform/corporate-platform-web/src/lib/teamApi.ts
@@ -1,0 +1,111 @@
+/**
+ * Team Management API client.
+ * All requests include the JWT from localStorage (key: "access_token").
+ */
+
+import type {
+  TeamMember,
+  TeamRole,
+  Invitation,
+  CreateMemberPayload,
+  UpdateMemberPayload,
+  CreateRolePayload,
+  UpdateRolePayload,
+  InviteMemberPayload,
+} from '@/types/team'
+
+const BASE_URL = process.env.NEXT_PUBLIC_API_URL ?? 'http://localhost:4000'
+const TEAM_BASE = `${BASE_URL}/api/v1/team`
+
+function getAuthHeaders(): HeadersInit {
+  const token =
+    typeof window !== 'undefined' ? localStorage.getItem('access_token') : null
+  return {
+    'Content-Type': 'application/json',
+    ...(token ? { Authorization: `Bearer ${token}` } : {}),
+  }
+}
+
+async function request<T>(url: string, init?: RequestInit): Promise<T> {
+  const res = await fetch(url, { ...init, headers: getAuthHeaders() })
+  if (!res.ok) {
+    const body = await res.json().catch(() => ({}))
+    throw new Error(body?.message ?? `Request failed: ${res.status}`)
+  }
+  return res.json() as Promise<T>
+}
+
+// ── Members ──────────────────────────────────────────────────────────────────
+
+export const teamApi = {
+  // Members
+  listMembers: () => request<TeamMember[]>(`${TEAM_BASE}/members`),
+
+  getMember: (id: string) => request<TeamMember>(`${TEAM_BASE}/members/${id}`),
+
+  createMember: (payload: CreateMemberPayload) =>
+    request<TeamMember>(`${TEAM_BASE}/members`, {
+      method: 'POST',
+      body: JSON.stringify(payload),
+    }),
+
+  updateMember: (id: string, payload: UpdateMemberPayload) =>
+    request<TeamMember>(`${TEAM_BASE}/members/${id}`, {
+      method: 'PUT',
+      body: JSON.stringify(payload),
+    }),
+
+  deactivateMember: (id: string) =>
+    request<TeamMember>(`${TEAM_BASE}/members/${id}`, { method: 'DELETE' }),
+
+  reactivateMember: (id: string) =>
+    request<TeamMember>(`${TEAM_BASE}/members/${id}/reactivate`, {
+      method: 'POST',
+    }),
+
+  assignRole: (memberId: string, roleId: string) =>
+    request<TeamMember>(`${TEAM_BASE}/members/${memberId}/role`, {
+      method: 'POST',
+      body: JSON.stringify({ roleId }),
+    }),
+
+  // Roles
+  listRoles: () => request<TeamRole[]>(`${TEAM_BASE}/roles`),
+
+  createRole: (payload: CreateRolePayload) =>
+    request<TeamRole>(`${TEAM_BASE}/roles`, {
+      method: 'POST',
+      body: JSON.stringify(payload),
+    }),
+
+  updateRole: (id: string, payload: UpdateRolePayload) =>
+    request<TeamRole>(`${TEAM_BASE}/roles/${id}`, {
+      method: 'PUT',
+      body: JSON.stringify(payload),
+    }),
+
+  deleteRole: (id: string) =>
+    request<void>(`${TEAM_BASE}/roles/${id}`, { method: 'DELETE' }),
+
+  // Permissions
+  listPermissions: () => request<string[]>(`${TEAM_BASE}/permissions`),
+
+  myPermissions: () => request<string[]>(`${TEAM_BASE}/permissions/my`),
+
+  // Invitations
+  inviteMember: (payload: InviteMemberPayload) =>
+    request<Invitation>(`${TEAM_BASE}/invitations`, {
+      method: 'POST',
+      body: JSON.stringify(payload),
+    }),
+
+  listInvitations: () => request<Invitation[]>(`${TEAM_BASE}/invitations`),
+
+  resendInvitation: (id: string) =>
+    request<Invitation>(`${TEAM_BASE}/invitations/${id}/resend`, {
+      method: 'POST',
+    }),
+
+  cancelInvitation: (id: string) =>
+    request<void>(`${TEAM_BASE}/invitations/${id}`, { method: 'DELETE' }),
+}

--- a/corporate-platform/corporate-platform-web/src/types/team.ts
+++ b/corporate-platform/corporate-platform-web/src/types/team.ts
@@ -1,0 +1,81 @@
+// Team Management Types
+
+export interface TeamRole {
+  id: string
+  companyId: string
+  name: string
+  description?: string
+  isSystem: boolean
+  permissions: string[]
+  memberCount: number
+  createdAt: string
+  updatedAt: string
+}
+
+export interface TeamMember {
+  id: string
+  companyId: string
+  userId: string
+  email: string
+  firstName: string | null
+  lastName: string | null
+  roleId: string
+  status: 'ACTIVE' | 'INACTIVE' | 'PENDING'
+  joinedAt: string
+  invitedBy: string | null
+  invitedAt: string | null
+  lastActiveAt: string | null
+  metadata?: Record<string, unknown>
+  department: string | null
+  title: string | null
+  role?: TeamRole
+}
+
+export interface Invitation {
+  id: string
+  companyId: string
+  email: string
+  roleId: string
+  invitedBy: string
+  token: string
+  expiresAt: string
+  status: 'PENDING' | 'ACCEPTED' | 'EXPIRED'
+  acceptedAt: string | null
+  createdAt: string
+  role?: TeamRole
+}
+
+export interface CreateMemberPayload {
+  userId?: string
+  email: string
+  firstName?: string
+  lastName?: string
+  roleId: string
+  status?: 'ACTIVE' | 'INACTIVE' | 'PENDING'
+  department?: string
+  title?: string
+}
+
+export interface UpdateMemberPayload {
+  firstName?: string
+  lastName?: string
+  status?: 'ACTIVE' | 'INACTIVE' | 'PENDING'
+  department?: string
+  title?: string
+}
+
+export interface CreateRolePayload {
+  name: string
+  description?: string
+  permissions: string[]
+}
+
+export interface UpdateRolePayload {
+  description?: string
+  permissions?: string[]
+}
+
+export interface InviteMemberPayload {
+  email: string
+  roleId: string
+}


### PR DESCRIPTION
- Add TypeScript types for TeamMember, TeamRole, Invitation and payloads (src/types/team.ts)
- Add typed API client covering all team endpoints: members CRUD, role assignment, roles CRUD, permissions, invitations (src/lib/teamApi.ts)
- Add useTeam hook with optimistic state updates for all mutations (src/hooks/useTeam.ts)
- Add AddMemberModal, EditMemberModal, InviteMemberModal, ManageRoleModal components (src/components/team/)
- Rewrite team page to use live API data with Members, Roles & Permissions, and Invitations tabs
- Wire all CRUD actions with loading states, toast feedback, and error handling
- Permission-based UI controls (system roles protected from edit/delete)

closes #260 