### PR TITLE
feat(team): replace hardcoded team members with real collaboration AP…

### DIFF
--- a/project-portal/project-portal-web/src/app/(portal)/team/page.tsx
+++ b/project-portal/project-portal-web/src/app/(portal)/team/page.tsx
@@ -2,184 +2,99 @@
 'use client';
 
 import { useState } from 'react';
-import { 
-  Users, 
-  UserPlus, 
-  Mail, 
-  Phone, 
-  MapPin, 
-  Calendar, 
+import {
+  Users,
+  UserPlus,
+  Mail,
+  Calendar,
   Award,
   Shield,
-  CheckCircle,
   Clock,
   MessageSquare,
   Video,
   FileText,
   TrendingUp,
-  MoreVertical,
   Filter,
   Search,
   Download,
   Share2,
-  Eye,
-  Edit,
-  X,
-  Plus
+  Plus,
+  AlertCircle,
+  Loader2,
+  ChevronDown,
 } from 'lucide-react';
+import { useTeamMembers } from '@/lib/hooks/useTeamMembers';
+import TeamMembersList from '@/components/collaboration/TeamMembersList';
+import PendingInvitationsList from '@/components/collaboration/PendingInvitationsList';
+import InviteUserModal from '@/components/collaboration/InviteUserModal';
+import type { Project } from '@/lib/store/projects/projects.types';
+
+// ── Static sections (will be wired to backend in later issues) ────────────────
+
+const communityStats = [
+  { label: 'Training Sessions Completed', value: '42', change: '+8%', icon: Award },
+  { label: 'Local Jobs Created', value: '89', change: '+24%', icon: TrendingUp },
+  { label: 'Women Participation', value: '64%', change: '+15%', icon: Shield },
+];
+
+const upcomingEvents = [
+  { id: 1, title: 'Soil Health Workshop', date: 'Apr 15, 2024', time: '10:00 AM', location: 'Nairobi Center', attendees: 24 },
+  { id: 2, title: 'Carbon Credit Training', date: 'Apr 20, 2024', time: '2:00 PM', location: 'Virtual', attendees: 56 },
+  { id: 3, title: 'Tree Planting Day', date: 'Apr 25, 2024', time: '8:00 AM', location: 'Amazon Site', attendees: 45 },
+  { id: 4, title: 'Quarterly Review Meeting', date: 'May 5, 2024', time: '11:00 AM', location: 'Virtual', attendees: 18 },
+];
+
+// ── Skeleton loader ────────────────────────────────────────────────────────────
+
+function TeamSkeleton() {
+  return (
+    <div className="space-y-4 animate-pulse">
+      {[...Array(4)].map((_, i) => (
+        <div key={i} className="flex items-center gap-3 py-3 border-b border-gray-100">
+          <div className="w-9 h-9 rounded-full bg-gray-200" />
+          <div className="flex-1 space-y-2">
+            <div className="h-4 bg-gray-200 rounded w-1/3" />
+            <div className="h-3 bg-gray-100 rounded w-1/4" />
+          </div>
+          <div className="h-6 w-20 bg-gray-100 rounded-full" />
+        </div>
+      ))}
+    </div>
+  );
+}
+
+// ── Main component ─────────────────────────────────────────────────────────────
 
 const TeamPage = () => {
   const [activeTab, setActiveTab] = useState('members');
-  const [selectedProject, setSelectedProject] = useState('all');
   const [searchQuery, setSearchQuery] = useState('');
+  const [showInviteModal, setShowInviteModal] = useState(false);
 
-  // Mock team data
-  const teamMembers = [
-    {
-      id: 1,
-      name: 'Samuel Kariuki',
-      role: 'Lead Farmer',
-      project: 'Kenyan Agroforestry Initiative',
-      location: 'Nairobi, Kenya',
-      phone: '+254 712 345 678',
-      email: 'samuel@carbonscribe.farm',
-      joined: 'Mar 2023',
-      status: 'active',
-      skills: ['Agroforestry', 'Soil Management', 'Training'],
-      tasksCompleted: 42,
-      creditsGenerated: 320,
-      avatarColor: 'bg-emerald-500'
-    },
-    {
-      id: 2,
-      name: 'Maria Santos',
-      role: 'Field Coordinator',
-      project: 'Amazon Rainforest Restoration',
-      location: 'Manaus, Brazil',
-      phone: '+55 92 98765 4321',
-      email: 'maria@carbonscribe.farm',
-      joined: 'Jan 2023',
-      status: 'active',
-      skills: ['Reforestation', 'Community Engagement', 'GIS'],
-      tasksCompleted: 56,
-      creditsGenerated: 450,
-      avatarColor: 'bg-blue-500'
-    },
-    {
-      id: 3,
-      name: 'Raj Patel',
-      role: 'Soil Scientist',
-      project: 'Midwest Soil Carbon Project',
-      location: 'Iowa, USA',
-      phone: '+1 515 123 4567',
-      email: 'raj@carbonscribe.farm',
-      joined: 'Feb 2024',
-      status: 'active',
-      skills: ['Soil Analysis', 'Carbon Measurement', 'Research'],
-      tasksCompleted: 18,
-      creditsGenerated: 210,
-      avatarColor: 'bg-amber-500'
-    },
-    {
-      id: 4,
-      name: 'Fatima Al-Mansoori',
-      role: 'Mangrove Specialist',
-      project: 'Sundarbans Mangrove Conservation',
-      location: 'Khulna, Bangladesh',
-      phone: '+880 1712 345678',
-      email: 'fatima@carbonscribe.farm',
-      joined: 'Nov 2022',
-      status: 'active',
-      skills: ['Blue Carbon', 'Marine Ecology', 'Conservation'],
-      tasksCompleted: 67,
-      creditsGenerated: 580,
-      avatarColor: 'bg-teal-500'
-    },
-    {
-      id: 5,
-      name: 'James Omondi',
-      role: 'Training Officer',
-      project: 'Kenyan Agroforestry Initiative',
-      location: 'Nakuru, Kenya',
-      phone: '+254 723 456 789',
-      email: 'james@carbonscribe.farm',
-      joined: 'Apr 2023',
-      status: 'pending',
-      skills: ['Training', 'Monitoring', 'Reporting'],
-      tasksCompleted: 12,
-      creditsGenerated: 85,
-      avatarColor: 'bg-purple-500'
-    },
-    {
-      id: 6,
-      name: 'Chen Wei',
-      role: 'Bamboo Expert',
-      project: 'Vietnam Bamboo Plantation',
-      location: 'Mekong Delta, Vietnam',
-      phone: '+84 90 123 4567',
-      email: 'chen@carbonscribe.farm',
-      joined: 'Sep 2023',
-      status: 'active',
-      skills: ['Bamboo Cultivation', 'Sustainable Harvesting', 'Processing'],
-      tasksCompleted: 34,
-      creditsGenerated: 180,
-      avatarColor: 'bg-green-500'
-    },
-    {
-      id: 7,
-      name: 'Amina Diallo',
-      role: 'Community Liaison',
-      project: 'Ethiopian Forest Protection',
-      location: 'Addis Ababa, Ethiopia',
-      phone: '+251 91 123 4567',
-      email: 'amina@carbonscribe.farm',
-      joined: 'Jul 2022',
-      status: 'inactive',
-      skills: ['Community Outreach', 'Conflict Resolution', 'Local Knowledge'],
-      tasksCompleted: 89,
-      creditsGenerated: 890,
-      avatarColor: 'bg-rose-500'
-    },
-    {
-      id: 8,
-      name: 'Carlos Mendez',
-      role: 'Drone Operator',
-      project: 'All Projects',
-      location: 'Remote',
-      phone: '+1 305 987 6543',
-      email: 'carlos@carbonscribe.farm',
-      joined: 'May 2023',
-      status: 'active',
-      skills: ['Aerial Mapping', 'Photogrammetry', 'Data Analysis'],
-      tasksCompleted: 45,
-      creditsGenerated: 1250,
-      avatarColor: 'bg-indigo-500'
-    },
-  ];
+  const {
+    projects,
+    projectsLoading,
+    selectedProject,
+    setSelectedProject,
+    clearSelectedProject,
+    members,
+    invitations,
+    isLoadingMembers,
+    errorMembers,
+    canManage,
+  } = useTeamMembers();
 
-  const communityStats = [
-    { label: 'Total Community Members', value: '156', change: '+12%', icon: Users },
-    { label: 'Training Sessions Completed', value: '42', change: '+8%', icon: Award },
-    { label: 'Local Jobs Created', value: '89', change: '+24%', icon: TrendingUp },
-    { label: 'Women Participation', value: '64%', change: '+15%', icon: Shield },
-  ];
+  const pendingInvitations = invitations.filter((i) => i.status === 'pending');
 
-  const upcomingEvents = [
-    { id: 1, title: 'Soil Health Workshop', date: 'Apr 15, 2024', time: '10:00 AM', location: 'Nairobi Center', attendees: 24 },
-    { id: 2, title: 'Carbon Credit Training', date: 'Apr 20, 2024', time: '2:00 PM', location: 'Virtual', attendees: 56 },
-    { id: 3, title: 'Tree Planting Day', date: 'Apr 25, 2024', time: '8:00 AM', location: 'Amazon Site', attendees: 45 },
-    { id: 4, title: 'Quarterly Review Meeting', date: 'May 5, 2024', time: '11:00 AM', location: 'Virtual', attendees: 18 },
-  ];
-
-  const getStatusConfig = (status: string) => {
-    const configs = {
-      active: { color: 'bg-emerald-100 text-emerald-700', icon: CheckCircle },
-      pending: { color: 'bg-amber-100 text-amber-700', icon: Clock },
-      inactive: { color: 'bg-gray-100 text-gray-700', icon: X },
-    };
-    return configs[status as keyof typeof configs] || configs.active;
+  const handleProjectChange = (projectId: string) => {
+    if (!projectId) {
+      clearSelectedProject();
+      return;
+    }
+    const project = projects.find((p: Project) => p.id === projectId);
+    if (project) setSelectedProject(project);
   };
 
+  // ── Render ──────────────────────────────────────────────────────────────────
   return (
     <div className="space-y-6 animate-fadeIn">
       {/* Header */}
@@ -190,7 +105,12 @@ const TeamPage = () => {
             <p className="text-emerald-100 opacity-90">Manage your project team and community engagement</p>
           </div>
           <div className="mt-4 md:mt-0 flex items-center space-x-4">
-            <button className="flex items-center px-4 py-2 bg-white/20 backdrop-blur-sm rounded-lg hover:bg-white/30 transition-colors">
+            <button
+              onClick={() => setShowInviteModal(true)}
+              disabled={!selectedProject}
+              className="flex items-center px-4 py-2 bg-white/20 backdrop-blur-sm rounded-lg hover:bg-white/30 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+              title={!selectedProject ? 'Select a project first' : 'Invite a member'}
+            >
               <UserPlus className="w-5 h-5 mr-2" />
               Invite Member
             </button>
@@ -204,6 +124,28 @@ const TeamPage = () => {
 
       {/* Community Stats */}
       <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-4">
+        {/* Dynamic: real member count */}
+        <div className="bg-white rounded-xl p-6 shadow-sm border border-gray-100">
+          <div className="flex items-center justify-between">
+            <div>
+              <div className="text-2xl font-bold text-gray-900">
+                {isLoadingMembers ? (
+                  <Loader2 className="w-6 h-6 animate-spin text-emerald-600" />
+                ) : (
+                  members.length
+                )}
+              </div>
+              <div className="text-sm text-gray-600">
+                {selectedProject ? `Members in ${selectedProject.name}` : 'Team Members'}
+              </div>
+            </div>
+            <div className="p-3 rounded-lg bg-emerald-100 text-emerald-600">
+              <Users className="w-6 h-6" />
+            </div>
+          </div>
+        </div>
+
+        {/* Static stats (wired in future issues) */}
         {communityStats.map((stat, index) => {
           const Icon = stat.icon;
           return (
@@ -236,7 +178,7 @@ const TeamPage = () => {
                 <h2 className="text-xl font-bold text-gray-900">Team Members</h2>
                 <p className="text-gray-600">Manage your project team and collaborators</p>
               </div>
-              
+
               <div className="flex items-center space-x-4">
                 <div className="relative">
                   <Search className="absolute left-3 top-1/2 transform -translate-y-1/2 w-5 h-5 text-gray-400" />
@@ -248,140 +190,127 @@ const TeamPage = () => {
                     className="pl-10 pr-4 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-emerald-500 focus:border-emerald-500 outline-none transition-colors"
                   />
                 </div>
-                
-                <div className="flex items-center space-x-2">
-                  <Filter className="w-5 h-5 text-gray-600" />
-                  <select
-                    value={selectedProject}
-                    onChange={(e) => setSelectedProject(e.target.value)}
-                    className="px-4 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-emerald-500 focus:border-emerald-500 outline-none transition-colors"
-                  >
-                    <option value="all">All Projects</option>
-                    <option value="amazon">Amazon Restoration</option>
-                    <option value="kenya">Kenyan Agroforestry</option>
-                    <option value="sundarbans">Mangrove Conservation</option>
-                  </select>
+
+                {/* Project selector – populated from real project store */}
+                <div className="relative flex items-center space-x-2">
+                  <Filter className="w-5 h-5 text-gray-600 shrink-0" />
+                  <div className="relative">
+                    <select
+                      value={selectedProject?.id ?? ''}
+                      onChange={(e) => handleProjectChange(e.target.value)}
+                      disabled={projectsLoading}
+                      className="appearance-none pl-3 pr-8 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-emerald-500 focus:border-emerald-500 outline-none transition-colors disabled:opacity-50 disabled:cursor-wait"
+                    >
+                      <option value="">
+                        {projectsLoading ? 'Loading projects…' : 'Select a project'}
+                      </option>
+                      {projects.map((p: Project) => (
+                        <option key={p.id} value={p.id}>
+                          {p.name}
+                        </option>
+                      ))}
+                    </select>
+                    <ChevronDown className="pointer-events-none absolute right-2 top-1/2 -translate-y-1/2 w-4 h-4 text-gray-400" />
+                  </div>
                 </div>
               </div>
             </div>
 
             {/* Tabs */}
             <div className="flex border-b border-gray-200 mb-6">
-              {['members', 'roles', 'permissions'].map((tab) => (
+              {['members', 'invitations', 'permissions'].map((tab) => (
                 <button
                   key={tab}
                   onClick={() => setActiveTab(tab)}
                   className={`px-6 py-3 font-medium capitalize ${
-                    activeTab === tab 
-                      ? 'text-emerald-600 border-b-2 border-emerald-600' 
+                    activeTab === tab
+                      ? 'text-emerald-600 border-b-2 border-emerald-600'
                       : 'text-gray-600 hover:text-gray-900'
                   }`}
                 >
                   {tab}
+                  {tab === 'invitations' && pendingInvitations.length > 0 && (
+                    <span className="ml-2 inline-flex items-center justify-center w-5 h-5 text-xs font-bold bg-amber-100 text-amber-700 rounded-full">
+                      {pendingInvitations.length}
+                    </span>
+                  )}
                 </button>
               ))}
             </div>
 
-            {/* Team Members Grid */}
+            {/* Tab: Members */}
             {activeTab === 'members' && (
-              <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
-                {teamMembers.map((member) => {
-                  const statusConfig = getStatusConfig(member.status);
-                  const StatusIcon = statusConfig.icon;
-                  
-                  return (
-                    <div key={member.id} className="border border-gray-200 rounded-xl p-6 hover:border-emerald-300 hover:shadow-lg transition-all">
-                      {/* Member Header */}
-                      <div className="flex items-start justify-between mb-4">
-                        <div className="flex items-center">
-                          <div className={`${member.avatarColor} w-12 h-12 rounded-full flex items-center justify-center text-white font-bold text-lg mr-4`}>
-                            {member.name.split(' ').map(n => n[0]).join('')}
-                          </div>
-                          <div>
-                            <h3 className="font-bold text-gray-900">{member.name}</h3>
-                            <div className="flex items-center text-sm text-gray-600">
-                              <MapPin className="w-4 h-4 mr-1" />
-                              {member.location}
-                            </div>
-                          </div>
-                        </div>
-                        <div className={`inline-flex items-center px-3 py-1 rounded-full text-sm font-medium ${statusConfig.color}`}>
-                          <StatusIcon className="w-4 h-4 mr-2" />
-                          {member.status.charAt(0).toUpperCase() + member.status.slice(1)}
-                        </div>
-                      </div>
+              <>
+                {/* No project selected */}
+                {!selectedProject && (
+                  <div className="flex flex-col items-center justify-center py-12 text-center text-gray-500">
+                    <Users className="w-12 h-12 mb-3 text-gray-300" />
+                    <p className="font-medium text-gray-700 mb-1">No project selected</p>
+                    <p className="text-sm">Use the dropdown above to choose a project and load its team members.</p>
+                  </div>
+                )}
 
-                      {/* Member Details */}
-                      <div className="space-y-3 mb-4">
-                        <div className="flex items-center justify-between">
-                          <div className="text-sm text-gray-600">Role</div>
-                          <div className="font-medium text-gray-900">{member.role}</div>
-                        </div>
-                        <div className="flex items-center justify-between">
-                          <div className="text-sm text-gray-600">Project</div>
-                          <div className="font-medium text-gray-900">{member.project}</div>
-                        </div>
-                        <div className="flex items-center justify-between">
-                          <div className="text-sm text-gray-600">Joined</div>
-                          <div className="font-medium text-gray-900">{member.joined}</div>
-                        </div>
-                      </div>
+                {/* Loading */}
+                {selectedProject && isLoadingMembers && <TeamSkeleton />}
 
-                      {/* Skills */}
-                      <div className="mb-4">
-                        <div className="text-sm text-gray-600 mb-2">Skills</div>
-                        <div className="flex flex-wrap gap-2">
-                          {member.skills.map((skill, index) => (
-                            <span key={index} className="px-2 py-1 bg-gray-100 text-gray-700 rounded text-xs">
-                              {skill}
-                            </span>
-                          ))}
-                        </div>
-                      </div>
+                {/* Error */}
+                {selectedProject && !isLoadingMembers && errorMembers && (
+                  <div className="flex items-center gap-3 p-4 bg-red-50 border border-red-200 rounded-xl text-red-700">
+                    <AlertCircle className="w-5 h-5 shrink-0" />
+                    <span>{errorMembers}</span>
+                  </div>
+                )}
 
-                      {/* Performance */}
-                      <div className="grid grid-cols-2 gap-4 mb-6">
-                        <div className="text-center p-3 bg-gray-50 rounded-lg">
-                          <div className="text-lg font-bold text-gray-900">{member.tasksCompleted}</div>
-                          <div className="text-xs text-gray-600">Tasks Completed</div>
-                        </div>
-                        <div className="text-center p-3 bg-emerald-50 rounded-lg">
-                          <div className="text-lg font-bold text-emerald-700">{member.creditsGenerated}</div>
-                          <div className="text-xs text-emerald-600">Credits Generated</div>
-                        </div>
-                      </div>
+                {/* Members list */}
+                {selectedProject && !isLoadingMembers && !errorMembers && (
+                  <TeamMembersList
+                    projectId={selectedProject.id}
+                    canManage={canManage}
+                  />
+                )}
+              </>
+            )}
 
-                      {/* Actions */}
-                      <div className="flex items-center justify-between pt-4 border-t border-gray-200">
-                        <div className="flex items-center space-x-2">
-                          <button className="p-2 hover:bg-gray-100 rounded-lg transition-colors" title="Email">
-                            <Mail className="w-5 h-5 text-gray-600" />
-                          </button>
-                          <button className="p-2 hover:bg-gray-100 rounded-lg transition-colors" title="Call">
-                            <Phone className="w-5 h-5 text-gray-600" />
-                          </button>
-                          <button className="p-2 hover:bg-gray-100 rounded-lg transition-colors" title="Message">
-                            <MessageSquare className="w-5 h-5 text-gray-600" />
-                          </button>
-                        </div>
-                        <div className="flex items-center space-x-2">
-                          <button className="p-2 hover:bg-gray-100 rounded-lg transition-colors">
-                            <Eye className="w-5 h-5 text-gray-600" />
-                          </button>
-                          <button className="p-2 hover:bg-gray-100 rounded-lg transition-colors">
-                            <Edit className="w-5 h-5 text-gray-600" />
-                          </button>
-                        </div>
-                      </div>
+            {/* Tab: Invitations */}
+            {activeTab === 'invitations' && (
+              <>
+                {!selectedProject ? (
+                  <div className="flex flex-col items-center justify-center py-12 text-center text-gray-500">
+                    <Mail className="w-12 h-12 mb-3 text-gray-300" />
+                    <p className="font-medium text-gray-700 mb-1">No project selected</p>
+                    <p className="text-sm">Select a project to view pending invitations.</p>
+                  </div>
+                ) : (
+                  <div className="space-y-4">
+                    <div className="flex items-center justify-between">
+                      <h3 className="font-semibold text-gray-900">Pending Invitations</h3>
+                      {canManage && (
+                        <button
+                          onClick={() => setShowInviteModal(true)}
+                          className="flex items-center gap-1 px-3 py-1.5 text-sm bg-emerald-600 text-white rounded-lg hover:bg-emerald-700 transition-colors"
+                        >
+                          <UserPlus className="w-4 h-4" />
+                          Invite
+                        </button>
+                      )}
                     </div>
-                  );
-                })}
+                    <PendingInvitationsList projectId={selectedProject.id} />
+                  </div>
+                )}
+              </>
+            )}
+
+            {/* Tab: Permissions */}
+            {activeTab === 'permissions' && (
+              <div className="flex flex-col items-center justify-center py-12 text-center text-gray-400">
+                <Shield className="w-12 h-12 mb-3 text-gray-200" />
+                <p className="font-medium">Role &amp; permissions management coming soon</p>
               </div>
             )}
           </div>
         </div>
 
-        {/* Right Column - Community & Events */}
+        {/* Right Column – Community & Events */}
         <div className="space-y-6">
           {/* Upcoming Events */}
           <div className="bg-white rounded-2xl p-6 shadow-lg border border-gray-100">
@@ -389,7 +318,7 @@ const TeamPage = () => {
               <h3 className="font-bold text-gray-900">Upcoming Events</h3>
               <Calendar className="w-5 h-5 text-emerald-600" />
             </div>
-            
+
             <div className="space-y-4">
               {upcomingEvents.map((event) => (
                 <div key={event.id} className="p-4 border border-gray-200 rounded-xl hover:border-emerald-300 transition-colors">
@@ -425,7 +354,7 @@ const TeamPage = () => {
                 </div>
               ))}
             </div>
-            
+
             <button className="w-full mt-6 py-3 bg-emerald-50 text-emerald-700 rounded-lg font-medium hover:bg-emerald-100 transition-colors">
               View All Events
             </button>
@@ -437,7 +366,7 @@ const TeamPage = () => {
               <h3 className="font-bold text-gray-900">Community Resources</h3>
               <FileText className="w-5 h-5 text-emerald-600" />
             </div>
-            
+
             <div className="space-y-4">
               {[
                 { title: 'Training Manuals', count: 12, icon: '📚', color: 'bg-blue-100 text-blue-700' },
@@ -500,78 +429,14 @@ const TeamPage = () => {
         </div>
       </div>
 
-      {/* Training Progress */}
-      <div className="bg-white rounded-2xl p-6 shadow-lg border border-gray-100">
-        <div className="flex items-center justify-between mb-6">
-          <div>
-            <h3 className="text-xl font-bold text-gray-900">Training Progress</h3>
-            <p className="text-gray-600">Track team training and certification status</p>
-          </div>
-          <button className="px-4 py-2 bg-emerald-600 text-white rounded-lg font-medium hover:bg-emerald-700 transition-colors">
-            Assign Training
-          </button>
-        </div>
-        
-        <div className="overflow-x-auto">
-          <table className="w-full">
-            <thead>
-              <tr className="border-b border-gray-200">
-                <th className="text-left py-3 px-4 text-sm font-medium text-gray-600">Team Member</th>
-                <th className="text-left py-3 px-4 text-sm font-medium text-gray-600">Role</th>
-                <th className="text-left py-3 px-4 text-sm font-medium text-gray-600">Required Training</th>
-                <th className="text-left py-3 px-4 text-sm font-medium text-gray-600">Progress</th>
-                <th className="text-left py-3 px-4 text-sm font-medium text-gray-600">Certification</th>
-                <th className="text-left py-3 px-4 text-sm font-medium text-gray-600">Actions</th>
-              </tr>
-            </thead>
-            <tbody>
-              {[
-                { name: 'Samuel Kariuki', role: 'Lead Farmer', training: 'Carbon Farming Basics', progress: 100, certified: true },
-                { name: 'Maria Santos', role: 'Field Coordinator', training: 'Project Management', progress: 85, certified: false },
-                { name: 'Raj Patel', role: 'Soil Scientist', training: 'Advanced Soil Analysis', progress: 60, certified: false },
-                { name: 'Fatima Al-Mansoori', role: 'Mangrove Specialist', training: 'Blue Carbon Methodologies', progress: 100, certified: true },
-                { name: 'James Omondi', role: 'Training Officer', training: 'Training of Trainers', progress: 30, certified: false },
-              ].map((member, index) => (
-                <tr key={index} className="border-b border-gray-100 hover:bg-gray-50 transition-colors">
-                  <td className="py-4 px-4">
-                    <div className="font-medium text-gray-900">{member.name}</div>
-                    <div className="text-sm text-gray-600">{member.role}</div>
-                  </td>
-                  <td className="py-4 px-4">
-                    <div className="font-medium text-gray-900">{member.role}</div>
-                  </td>
-                  <td className="py-4 px-4">
-                    <div className="font-medium text-gray-900">{member.training}</div>
-                  </td>
-                  <td className="py-4 px-4">
-                    <div className="flex items-center">
-                      <div className="w-32 h-2 bg-gray-200 rounded-full overflow-hidden mr-3">
-                        <div 
-                          className={`h-full ${member.progress === 100 ? 'bg-emerald-500' : 'bg-blue-500'} rounded-full`}
-                          style={{ width: `${member.progress}%` }}
-                        ></div>
-                      </div>
-                      <div className="font-medium text-gray-900">{member.progress}%</div>
-                    </div>
-                  </td>
-                  <td className="py-4 px-4">
-                    <div className={`inline-flex items-center px-3 py-1 rounded-full text-sm font-medium ${
-                      member.certified ? 'bg-emerald-100 text-emerald-700' : 'bg-amber-100 text-amber-700'
-                    }`}>
-                      {member.certified ? 'Certified' : 'In Progress'}
-                    </div>
-                  </td>
-                  <td className="py-4 px-4">
-                    <button className="px-3 py-1 text-sm font-medium text-emerald-600 hover:text-emerald-700">
-                      {member.certified ? 'View Certificate' : 'Continue Training'}
-                    </button>
-                  </td>
-                </tr>
-              ))}
-            </tbody>
-          </table>
-        </div>
-      </div>
+      {/* Invite user modal */}
+      {selectedProject && (
+        <InviteUserModal
+          projectId={selectedProject.id}
+          isOpen={showInviteModal}
+          onClose={() => setShowInviteModal(false)}
+        />
+      )}
     </div>
   );
 };

--- a/project-portal/project-portal-web/src/lib/hooks/useTeamMembers.test.ts
+++ b/project-portal/project-portal-web/src/lib/hooks/useTeamMembers.test.ts
@@ -1,0 +1,111 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+import { useTeamMembers } from './useTeamMembers';
+import { useStore } from '@/lib/store/store';
+import type { Project } from '@/lib/store/projects/projects.types';
+
+vi.mock('@/lib/store/store');
+
+const mockUseStore = vi.mocked(useStore);
+
+const mockProject: Project = {
+  id: 'proj-1',
+  name: 'Carbon Initiative',
+  description: 'A carbon reduction project',
+  status: 'active',
+  created_at: '2024-01-01T00:00:00Z',
+  updated_at: '2024-01-01T00:00:00Z',
+};
+
+const mockMembers = [
+  { id: 'm1', project_id: 'proj-1', user_id: 'user1', role: 'Owner', permissions: ['all'], joined_at: '2024-01-01T00:00:00Z', updated_at: '2024-01-01T00:00:00Z' },
+  { id: 'm2', project_id: 'proj-1', user_id: 'user2', role: 'Contributor', permissions: ['read', 'write'], joined_at: '2024-01-02T00:00:00Z', updated_at: '2024-01-02T00:00:00Z' },
+];
+
+const mockInvitations = [
+  { id: 'i1', project_id: 'proj-1', email: 'pending@example.com', role: 'Viewer', status: 'pending', expires_at: '2024-12-01T00:00:00Z', created_at: '2024-01-01T00:00:00Z', updated_at: '2024-01-01T00:00:00Z' },
+];
+
+describe('useTeamMembers', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  const setupStore = (overrides = {}) => {
+    const state = {
+      ...{
+        projects: [] as Project[],
+        loading: { isFetching: false },
+        selectedProject: null,
+        setSelectedProject: vi.fn(),
+        clearSelectedProject: vi.fn(),
+        fetchProjects: vi.fn(),
+        members: [] as any[],
+        invitations: [] as any[],
+        collaborationLoading: { members: false, invitations: false },
+        collaborationErrors: { members: null, invitations: null },
+        fetchMembers: vi.fn(),
+        fetchInvitations: vi.fn(),
+        removeMember: vi.fn(),
+        inviteUser: vi.fn(),
+        resetCollaborationState: vi.fn(),
+        user: null,
+      },
+      ...overrides,
+    };
+    mockUseStore.mockImplementation((selector) => selector(state as any));
+  };
+
+  it('should return projects and selectedProject from store', () => {
+    setupStore({ projects: [mockProject], selectedProject: mockProject });
+    const { result } = renderHook(() => useTeamMembers());
+    expect(result.current.projects).toEqual([mockProject]);
+    expect(result.current.selectedProject).toEqual(mockProject);
+  });
+
+  it('should return members and invitations from store', () => {
+    setupStore({ members: mockMembers, invitations: mockInvitations });
+    const { result } = renderHook(() => useTeamMembers());
+    expect(result.current.members).toEqual(mockMembers);
+    expect(result.current.invitations).toEqual(mockInvitations);
+  });
+
+  it('should return loading states from store', () => {
+    setupStore({ collaborationLoading: { members: true, invitations: false } });
+    const { result } = renderHook(() => useTeamMembers());
+    expect(result.current.isLoadingMembers).toBe(true);
+    expect(result.current.isLoadingInvitations).toBe(false);
+  });
+
+  it('should return error states from store', () => {
+    setupStore({ collaborationErrors: { members: 'Fetch error', invitations: null } });
+    const { result } = renderHook(() => useTeamMembers());
+    expect(result.current.errorMembers).toBe('Fetch error');
+    expect(result.current.errorInvitations).toBeNull();
+  });
+
+  it('should return canManage=false when user is not an Owner or Manager', () => {
+    setupStore({ user: { id: 'user2', name: 'User 2' }, members: mockMembers });
+    const { result } = renderHook(() => useTeamMembers());
+    expect(result.current.canManage).toBe(false);
+  });
+
+  it('should return canManage=true when user is an Owner', () => {
+    setupStore({ user: { id: 'user1', name: 'User 1' }, members: mockMembers });
+    const { result } = renderHook(() => useTeamMembers());
+    expect(result.current.canManage).toBe(true);
+  });
+
+  it('should return canManage=true when user is a Manager', () => {
+    const managerMember = { id: 'm3', project_id: 'proj-1', user_id: 'user3', role: 'Manager', permissions: ['manage'], joined_at: '2024-01-03T00:00:00Z', updated_at: '2024-01-03T00:00:00Z' };
+    setupStore({ user: { id: 'user3', name: 'User 3' }, members: [...mockMembers, managerMember] });
+    const { result } = renderHook(() => useTeamMembers());
+    expect(result.current.canManage).toBe(true);
+  });
+
+  it('should return canManage=false when no user is logged in', () => {
+    setupStore({ user: null, members: mockMembers });
+    const { result } = renderHook(() => useTeamMembers());
+    expect(result.current.canManage).toBe(false);
+  });
+});

--- a/project-portal/project-portal-web/src/lib/hooks/useTeamMembers.test.ts
+++ b/project-portal/project-portal-web/src/lib/hooks/useTeamMembers.test.ts
@@ -11,8 +11,15 @@ const mockUseStore = vi.mocked(useStore);
 const mockProject: Project = {
   id: 'proj-1',
   name: 'Carbon Initiative',
-  description: 'A carbon reduction project',
+  type: 'reforestation',
+  location: 'Nairobi, Kenya',
+  area: 500,
+  farmers: 25,
+  carbon_credits: 1200,
+  progress: 65,
+  icon: '🌱',
   status: 'active',
+  start_date: '2024-01-01',
   created_at: '2024-01-01T00:00:00Z',
   updated_at: '2024-01-01T00:00:00Z',
 };

--- a/project-portal/project-portal-web/src/lib/hooks/useTeamMembers.ts
+++ b/project-portal/project-portal-web/src/lib/hooks/useTeamMembers.ts
@@ -1,0 +1,95 @@
+'use client';
+
+import { useEffect } from 'react';
+import { useStore } from '@/lib/store/store';
+import { ROLES_CAN_MANAGE } from '@/lib/store/collaboration/collaboration.types';
+
+/**
+ * Hook that manages team member data for a selected project.
+ *
+ * - Bootstraps the projects list from the store on first mount.
+ * - Fetches members and invitations whenever the selected project changes.
+ * - Derives `canManage` based on the current user's role in the project.
+ */
+export function useTeamMembers() {
+  // ── Projects ────────────────────────────────────────────────────────────────
+  const projects = useStore((s) => s.projects);
+  const projectsLoading = useStore((s) => s.loading.isFetching);
+  const selectedProject = useStore((s) => s.selectedProject);
+  const setSelectedProject = useStore((s) => s.setSelectedProject);
+  const clearSelectedProject = useStore((s) => s.clearSelectedProject);
+  const fetchProjects = useStore((s) => s.fetchProjects);
+
+  // ── Collaboration state ──────────────────────────────────────────────────────
+  const members = useStore((s) => s.members);
+  const invitations = useStore((s) => s.invitations);
+  const isLoadingMembers = useStore((s) => s.collaborationLoading.members);
+  const isLoadingInvitations = useStore((s) => s.collaborationLoading.invitations);
+  const errorMembers = useStore((s) => s.collaborationErrors.members);
+  const errorInvitations = useStore((s) => s.collaborationErrors.invitations);
+
+  // ── Actions ──────────────────────────────────────────────────────────────────
+  const fetchMembers = useStore((s) => s.fetchMembers);
+  const fetchInvitations = useStore((s) => s.fetchInvitations);
+  const removeMember = useStore((s) => s.removeMember);
+  const inviteUser = useStore((s) => s.inviteUser);
+  const resetCollaborationState = useStore((s) => s.resetCollaborationState);
+
+  // ── Auth ─────────────────────────────────────────────────────────────────────
+  const currentUser = useStore((s) => s.user);
+
+  // Bootstrap project list if not yet loaded
+  useEffect(() => {
+    if (projects.length === 0 && !projectsLoading) {
+      fetchProjects();
+    }
+  }, [projects.length, projectsLoading, fetchProjects]);
+
+  // Fetch members + invitations whenever the selected project changes
+  useEffect(() => {
+    if (selectedProject?.id) {
+      fetchMembers(selectedProject.id);
+      fetchInvitations(selectedProject.id);
+    } else {
+      resetCollaborationState();
+    }
+  }, [selectedProject?.id, fetchMembers, fetchInvitations, resetCollaborationState]);
+
+  // Derive manage permission from the current user's membership role
+  const currentUserMember = currentUser
+    ? members.find((m) => m.user_id === currentUser.id)
+    : null;
+  const canManage = currentUserMember
+    ? (ROLES_CAN_MANAGE as readonly string[]).includes(currentUserMember.role)
+    : false;
+
+  return {
+    // Project context
+    projects,
+    projectsLoading,
+    selectedProject,
+    setSelectedProject,
+    clearSelectedProject,
+
+    // Team data
+    members,
+    invitations,
+
+    // Loading states
+    isLoadingMembers,
+    isLoadingInvitations,
+
+    // Error states
+    errorMembers,
+    errorInvitations,
+
+    // Actions
+    fetchMembers,
+    fetchInvitations,
+    removeMember,
+    inviteUser,
+
+    // Permissions
+    canManage,
+  };
+}


### PR DESCRIPTION
…I data

Connect Team page to backend collaboration store:
- Remove 8 hardcoded mock users from page.tsx (207 insertions, 342 deletions)
- Add useTeamMembers hook to centralize project context, members, invitations, and permissions
- Project selector now loads real projects from store and fetches members on selection
- Tab Members: wired to TeamMembersList component with loading/error/empty states
- Tab Invitations: wired to PendingInvitationsList with pending count badge
- InviteUserModal wired to inviteUser action, auto-refreshes list on success
- RemoveMember wired to store action with confirmation dialog
- Static sections (community stats, upcoming events, quick actions) kept as-is for future issues
- Add useTeamMembers.test.ts with 8 tests covering canManage, loading states, errors

Closes #190