### PR TITLE
feat(audit): add audit hash anchoring for retirement records

### DIFF
--- a/corporate-platform/corporate-platform-backend/.env.example
+++ b/corporate-platform/corporate-platform-backend/.env.example
@@ -41,3 +41,28 @@ SOROBAN_START_LEDGER=
 # Multi-tenant configuration
 TENANT_BASE_DOMAIN=platform.com
 TENANT_SYSTEM_BYPASS_TOKEN=
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Audit Hash Anchoring — Retirement Tracker (Soroban)
+# ─────────────────────────────────────────────────────────────────────────────
+
+# Contract ID for the RetirementTracker Soroban contract.
+# Defaults to the value in contract.interface.ts if not set.
+RETIREMENT_TRACKER_CONTRACT_ID=CCDCE6N7Q27TZW6Z6W3DPDCNOGHWFSOQUQPSRRZIY7AEHNOYZMNFDFVU
+
+# Stellar secret key for PRODUCTION on-chain invocations.
+# When set, SorobanService will sign and submit real transactions.
+# Leave blank in development to fall back to simulation mode (no real tx submitted).
+STELLAR_SECRET_KEY=
+
+# Soroban RPC endpoint (already used by SorobanService; repeated here for clarity).
+SOROBAN_RPC_URL=https://soroban-testnet.stellar.org:443
+
+# Generic audit blockchain anchor toggle (existing flag, kept for backwards-compat).
+AUDIT_STELLAR_ANCHOR_ENABLED=false
+
+# Rate limiting for audit hash endpoints (per tenant / IP).
+# Max requests allowed within the rolling window.
+AUDIT_ANCHOR_RATE_LIMIT_MAX=30
+# Window size in milliseconds.
+AUDIT_ANCHOR_RATE_LIMIT_WINDOW_MS=60000

--- a/corporate-platform/corporate-platform-backend/prisma/schema.prisma
+++ b/corporate-platform/corporate-platform-backend/prisma/schema.prisma
@@ -7,39 +7,39 @@ generator client {
 }
 
 model Company {
-  id                     String              @id @default(cuid())
+  id                     String @id @default(cuid())
   name                   String
-  annualRetirementTarget Float               @default(0)
-  netZeroTarget          Float               @default(0)
+  annualRetirementTarget Float  @default(0)
+  netZeroTarget          Float  @default(0)
   netZeroTargetYear      Int?
 
-  retirements             Retirement[]
-  retirementTargets       RetirementTarget[]
-  retirementSchedules     RetirementSchedule[]
-  batchRetirements        BatchRetirement[]
-  users                   User[]
-  ipWhitelists            IpWhitelist[]
-  auditLogs               AuditLog[]
-  carts                   Cart[]
-  orders                  Order[]
-  bids                    Bid[]
-  projects                Project[]
-  portfolios              Portfolio[]
-  transactions            Transaction[]
-  compliances             Compliance[]
-  reports                 Report[]
-  activities              Activity[]
-  apiKeys                 ApiKey[]
-  teamMembers             TeamMember[]
-  teamRoles               Role[]
-  invitations             Invitation[]
-  credits                 Credit[]
-  ipfsDocuments           IpfsDocument[]
+  retirements              Retirement[]
+  retirementTargets        RetirementTarget[]
+  retirementSchedules      RetirementSchedule[]
+  batchRetirements         BatchRetirement[]
+  users                    User[]
+  ipWhitelists             IpWhitelist[]
+  auditLogs                AuditLog[]
+  carts                    Cart[]
+  orders                   Order[]
+  bids                     Bid[]
+  projects                 Project[]
+  portfolios               Portfolio[]
+  transactions             Transaction[]
+  compliances              Compliance[]
+  reports                  Report[]
+  activities               Activity[]
+  apiKeys                  ApiKey[]
+  teamMembers              TeamMember[]
+  teamRoles                Role[]
+  invitations              Invitation[]
+  credits                  Credit[]
+  ipfsDocuments            IpfsDocument[]
   transactionConfirmations TransactionConfirmation[]
-  auditEvents             AuditEvent[]
-  emissionSources         EmissionSource[]
-  emissionRecords         EmissionRecord[]
-  
+  auditEvents              AuditEvent[]
+  emissionSources          EmissionSource[]
+  emissionRecords          EmissionRecord[]
+
   materialityAssessments MaterialityAssessment[]
   esrsDisclosures        EsrsDisclosure[]
   csrdReports            CsrdReport[]
@@ -60,55 +60,55 @@ model Company {
 }
 
 model RetirementTarget {
-  id          String   @id @default(cuid())
-  companyId   String
-  year        Int
-  month       Int
-  target      Float
+  id        String @id @default(cuid())
+  companyId String
+  year      Int
+  month     Int
+  target    Float
 
-  company     Company  @relation(fields: [companyId], references: [id])
+  company Company @relation(fields: [companyId], references: [id])
 
   @@unique([companyId, year, month])
   @@map("retirement_targets")
 }
 
 model Project {
-  id          String   @id @default(cuid())
-  name        String
-  description String?
+  id                   String  @id @default(cuid())
+  name                 String
+  description          String?
   // Classification & Metadata
-  type                  String?   // forestry, renewable, agriculture, bluecarbon, cookstoves, methane
-  methodology           String?
-  verificationStandard  String?
-  country               String?
-  region                String?
+  type                 String? // forestry, renewable, agriculture, bluecarbon, cookstoves, methane
+  methodology          String?
+  verificationStandard String?
+  country              String?
+  region               String?
 
   // Multi-tenant / ownership
-  companyId   String?  // Optional: project can be company-scoped or global
-  company     Company? @relation(fields: [companyId], references: [id])
+  companyId String? // Optional: project can be company-scoped or global
+  company   Company? @relation(fields: [companyId], references: [id])
 
   // Impact
-  totalCredits          Int      @default(0)
-  availableCredits      Int      @default(0)
-  avgScore              Float?   
-  communities           Int?     // People benefited
-  sdgs                  Int[]    @default([])
+  totalCredits     Int    @default(0)
+  availableCredits Int    @default(0)
+  avgScore         Float?
+  communities      Int? // People benefited
+  sdgs             Int[]  @default([])
 
   // Timeline
-  startDate   DateTime
-  endDate     DateTime?
+  startDate        DateTime
+  endDate          DateTime?
   lastVerification DateTime?
 
   // Metadata
-  status      String    @default("active") // active, completed, pending
-  developer   String?
-  website     String?
+  status    String  @default("active") // active, completed, pending
+  developer String?
+  website   String?
 
   // Relations
-  credits     Credit[]
+  credits Credit[]
 
-  createdAt   DateTime @default(now())
-  updatedAt   DateTime @updatedAt
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
 
   @@index([country])
   @@index([type])
@@ -117,49 +117,49 @@ model Project {
 }
 
 model Credit {
-  id           String               @id @default(cuid())
-  companyId    String?
-  company      Company?             @relation(fields: [companyId], references: [id])
-  projectId    String
-  project      Project             @relation(fields: [projectId], references: [id])
-  projectName  String               // Denormalized for display/search
+  id              String   @id @default(cuid())
+  companyId       String?
+  company         Company? @relation(fields: [companyId], references: [id])
+  projectId       String
+  project         Project  @relation(fields: [projectId], references: [id])
+  projectName     String // Denormalized for display/search
   // Credit Details
-  pricePerTon  Float  @default(0)
+  pricePerTon     Float    @default(0)
   availableAmount Int
-  totalAmount  Int
-  status       String   @default("available") // available, reserved, retired, pending
+  totalAmount     Int
+  status          String   @default("available") // available, reserved, retired, pending
 
   // Quality Metrics
-  dynamicScore          Int       @default(0)
-  verificationScore     Int       @default(0)
-  additionalityScore    Int       @default(0)
-  permanenceScore       Int       @default(0)
-  leakageScore          Int       @default(0)
-  cobenefitsScore       Int       @default(0)
-  transparencyScore     Int       @default(0)
+  dynamicScore       Int @default(0)
+  verificationScore  Int @default(0)
+  additionalityScore Int @default(0)
+  permanenceScore    Int @default(0)
+  leakageScore       Int @default(0)
+  cobenefitsScore    Int @default(0)
+  transparencyScore  Int @default(0)
 
   // Metadata
-  methodology  String?
-  vintage      Int?
-  verificationStandard  String?
-  lastVerification DateTime?
-  country      String?
-  sdgs         Int[]    @default([])
-  retirements  Retirement[]
-  cartItems    CartItem[]
-  orderItems   OrderItem[]
-  reservations CreditReservation[]
-  auctions     Auction[]
-  portfolioHoldings  PortfolioHolding[] @relation("PortfolioHolding")
-  portfolioEntries   PortfolioEntry[] @relation("PortfolioEntry")
-  availabilityLogs    CreditAvailabilityLog[]
+  methodology          String?
+  vintage              Int?
+  verificationStandard String?
+  lastVerification     DateTime?
+  country              String?
+  sdgs                 Int[]                   @default([])
+  retirements          Retirement[]
+  cartItems            CartItem[]
+  orderItems           OrderItem[]
+  reservations         CreditReservation[]
+  auctions             Auction[]
+  portfolioHoldings    PortfolioHolding[]      @relation("PortfolioHolding")
+  portfolioEntries     PortfolioEntry[]        @relation("PortfolioEntry")
+  availabilityLogs     CreditAvailabilityLog[]
 
   // Blockchain
-  assetCode     String?
-  issuer        String?
-  contractId    String?
-  createdAt    DateTime             @default(now())
-  updatedAt    DateTime             @updatedAt
+  assetCode  String?
+  issuer     String?
+  contractId String?
+  createdAt  DateTime @default(now())
+  updatedAt  DateTime @updatedAt
 
   // Search & metadata
   searchVector    String?
@@ -179,37 +179,37 @@ model Credit {
 }
 
 model Retirement {
-  id                String    @id @default(cuid())
-  companyId         String
-  company           Company   @relation(fields: [companyId], references: [id])
-  userId            String
-  user              User      @relation(fields: [userId], references: [id])
-  
-  creditId          String
-  credit            Credit    @relation(fields: [creditId], references: [id])
-  
+  id        String  @id @default(cuid())
+  companyId String
+  company   Company @relation(fields: [companyId], references: [id])
+  userId    String
+  user      User    @relation(fields: [userId], references: [id])
+
+  creditId String
+  credit   Credit @relation(fields: [creditId], references: [id])
+
   // Retirement details
-  amount            Int
-  purpose           String    // scope1, scope2, scope3, corporate, events, product
-  purposeDetails    String?   // Additional context
-  
+  amount         Int
+  purpose        String // scope1, scope2, scope3, corporate, events, product
+  purposeDetails String? // Additional context
+
   // Pricing
   priceAtRetirement Float
-  
+
   // Certificate details
-  certificateId     String?    @unique
-  certificateUrl    String?
-  
+  certificateId  String? @unique
+  certificateUrl String?
+
   // Blockchain
-  transactionHash   String?
-  transactionUrl    String?
-  verifiedAt        DateTime?
-  
+  transactionHash String?
+  transactionUrl  String?
+  verifiedAt      DateTime?
+
   // Metadata
-  retiredAt         DateTime  @default(now())
-  
+  retiredAt DateTime @default(now())
+
   // Relations
-  certificate       RetirementCertificate?
+  certificate          RetirementCertificate?
   corsiaEligibleCredit CorsiaEligibleCredit?
 
   @@index([companyId])
@@ -224,23 +224,23 @@ model Retirement {
 // ==========================================
 
 model FlightRecord {
-  id              String   @id @default(cuid())
-  companyId       String
-  company         Company  @relation(fields: [companyId], references: [id])
-  flightNumber    String
-  departureICAO   String   // Airport code
-  arrivalICAO     String
-  departureDate   DateTime
-  aircraftType    String
-  fuelBurn        Float    // In tonnes
-  fuelType        String   // JET_A, SAF, etc.
-  distance        Float    // Great circle distance in km
-  passengerLoad   Float?   // Load factor
-  cargoLoad       Float?   // Cargo in tonnes
-  co2Emissions    Float    // Calculated emissions in tonnes CO2
-  metadata        Json?
-  createdAt       DateTime @default(now())
-  updatedAt       DateTime @updatedAt
+  id            String   @id @default(cuid())
+  companyId     String
+  company       Company  @relation(fields: [companyId], references: [id])
+  flightNumber  String
+  departureICAO String // Airport code
+  arrivalICAO   String
+  departureDate DateTime
+  aircraftType  String
+  fuelBurn      Float // In tonnes
+  fuelType      String // JET_A, SAF, etc.
+  distance      Float // Great circle distance in km
+  passengerLoad Float? // Load factor
+  cargoLoad     Float? // Cargo in tonnes
+  co2Emissions  Float // Calculated emissions in tonnes CO2
+  metadata      Json?
+  createdAt     DateTime @default(now())
+  updatedAt     DateTime @updatedAt
 
   @@index([companyId])
   @@index([companyId, departureDate])
@@ -249,20 +249,20 @@ model FlightRecord {
 }
 
 model CorsiaComplianceYear {
-  id                String   @id @default(cuid())
+  id                String    @id @default(cuid())
   companyId         String
-  company           Company  @relation(fields: [companyId], references: [id])
+  company           Company   @relation(fields: [companyId], references: [id])
   year              Int
-  baselineEmissions Float?   // 2019 baseline for growth calculation
-  totalEmissions    Float    @default(0)
-  offsetRequirement Float    @default(0) // Emissions requiring offsets
-  offsetsRetired    Float    @default(0) // CORSIA-eligible credits retired
-  complianceStatus  String   @default("PENDING") // COMPLIANT, NON_COMPLIANT, PENDING
+  baselineEmissions Float? // 2019 baseline for growth calculation
+  totalEmissions    Float     @default(0)
+  offsetRequirement Float     @default(0) // Emissions requiring offsets
+  offsetsRetired    Float     @default(0) // CORSIA-eligible credits retired
+  complianceStatus  String    @default("PENDING") // COMPLIANT, NON_COMPLIANT, PENDING
   reportSubmitted   DateTime?
   verificationId    String?
   metadata          Json?
-  createdAt         DateTime @default(now())
-  updatedAt         DateTime @updatedAt
+  createdAt         DateTime  @default(now())
+  updatedAt         DateTime  @updatedAt
 
   @@unique([companyId, year])
   @@index([companyId])
@@ -271,19 +271,19 @@ model CorsiaComplianceYear {
 }
 
 model CorsiaEligibleCredit {
-  id              String   @id @default(cuid())
+  id              String     @id @default(cuid())
   companyId       String
-  company         Company  @relation(fields: [companyId], references: [id])
-  retirementId    String   @unique // Link to Retirement Service
+  company         Company    @relation(fields: [companyId], references: [id])
+  retirementId    String     @unique // Link to Retirement Service
   retirement      Retirement @relation(fields: [retirementId], references: [id])
-  program         String   // VERRA, GOLD_STANDARD, etc.
-  creditType      String   // Must meet CORSIA criteria
+  program         String // VERRA, GOLD_STANDARD, etc.
+  creditType      String // Must meet CORSIA criteria
   vintageYear     Int
-  eligible        Boolean  // Verified against CORSIA criteria
-  eligibilityMemo String?  // Explanation if not eligible
+  eligible        Boolean // Verified against CORSIA criteria
+  eligibilityMemo String? // Explanation if not eligible
   metadata        Json?
-  createdAt       DateTime @default(now())
-  updatedAt       DateTime @updatedAt
+  createdAt       DateTime   @default(now())
+  updatedAt       DateTime   @updatedAt
 
   @@index([companyId])
   @@index([companyId, eligible])
@@ -292,23 +292,23 @@ model CorsiaEligibleCredit {
 }
 
 model RetirementCertificate {
-  id                String    @id @default(cuid())
-  retirementId      String    @unique
-  retirement        Retirement @relation(fields: [retirementId], references: [id])
-  
-  certificateNumber String    @unique // e.g., "RET-2024-001234"
+  id           String     @id @default(cuid())
+  retirementId String     @unique
+  retirement   Retirement @relation(fields: [retirementId], references: [id])
+
+  certificateNumber String  @unique // e.g., "RET-2024-001234"
   pdfUrl            String
-  ipfsHash          String?   // IPFS storage for permanence
-  
+  ipfsHash          String? // IPFS storage for permanence
+
   // Certificate data (snapshot)
-  companyName       String
-  retirementDate    DateTime
-  creditProject     String
-  creditAmount      Int
-  creditPurpose     String
-  transactionHash   String?
-  
-  createdAt         DateTime  @default(now())
+  companyName     String
+  retirementDate  DateTime
+  creditProject   String
+  creditAmount    Int
+  creditPurpose   String
+  transactionHash String?
+
+  createdAt DateTime @default(now())
 }
 
 // ==========================================
@@ -385,23 +385,23 @@ model EmissionFactor {
 }
 
 model User {
-  id                   String   @id @default(cuid())
-  email                String   @unique
+  id                   String    @id @default(cuid())
+  email                String    @unique
   password             String
   firstName            String
   lastName             String
-  role                 String   @default("viewer")
+  role                 String    @default("viewer")
   companyId            String
-  company              Company  @relation(fields: [companyId], references: [id])
+  company              Company   @relation(fields: [companyId], references: [id])
   refreshToken         String?
   lastLoginAt          DateTime?
   lastLoginIp          String?
-  isActive             Boolean  @default(true)
-  emailVerified        Boolean  @default(false)
+  isActive             Boolean   @default(true)
+  emailVerified        Boolean   @default(false)
   passwordResetToken   String?
   passwordResetExpires DateTime?
-  createdAt            DateTime @default(now())
-  updatedAt            DateTime @updatedAt
+  createdAt            DateTime  @default(now())
+  updatedAt            DateTime  @updatedAt
 
   sessions            Session[]
   teamMembership      TeamMember?
@@ -418,15 +418,15 @@ model User {
 }
 
 model TeamMember {
-  id           String   @id @default(cuid())
+  id           String    @id @default(cuid())
   companyId    String
-  userId       String   @unique
+  userId       String    @unique
   email        String
   firstName    String?
   lastName     String?
   roleId       String
-  status       String   // ACTIVE, INACTIVE, PENDING
-  joinedAt     DateTime @default(now())
+  status       String // ACTIVE, INACTIVE, PENDING
+  joinedAt     DateTime  @default(now())
   invitedBy    String?
   invitedAt    DateTime?
   lastActiveAt DateTime?
@@ -434,9 +434,9 @@ model TeamMember {
   department   String?
   title        String?
 
-  company      Company  @relation(fields: [companyId], references: [id])
-  user         User     @relation(fields: [userId], references: [id])
-  role         Role     @relation(fields: [roleId], references: [id])
+  company Company @relation(fields: [companyId], references: [id])
+  user    User    @relation(fields: [userId], references: [id])
+  role    Role    @relation(fields: [roleId], references: [id])
 
   @@index([companyId, status])
   @@index([roleId])
@@ -445,7 +445,7 @@ model TeamMember {
 model Role {
   id          String   @id @default(cuid())
   companyId   String
-  name        String   // ADMIN, MANAGER, ANALYST, VIEWER
+  name        String // ADMIN, MANAGER, ANALYST, VIEWER
   description String?
   isSystem    Boolean  @default(false) // Cannot modify system roles
   permissions Json     @default("[]") // Array of permission strings
@@ -462,34 +462,34 @@ model Role {
 }
 
 model Invitation {
-  id         String   @id @default(cuid())
+  id         String    @id @default(cuid())
   companyId  String
   email      String
   roleId     String
   invitedBy  String
-  token      String   @unique
+  token      String    @unique
   expiresAt  DateTime
-  status     String   // PENDING, ACCEPTED, EXPIRED
+  status     String // PENDING, ACCEPTED, EXPIRED
   acceptedAt DateTime?
-  createdAt  DateTime @default(now())
+  createdAt  DateTime  @default(now())
 
-  company    Company  @relation(fields: [companyId], references: [id])
-  role       Role     @relation(fields: [roleId], references: [id])
+  company Company @relation(fields: [companyId], references: [id])
+  role    Role    @relation(fields: [roleId], references: [id])
 
   @@index([companyId, status])
   @@index([email])
 }
 
 model Session {
-  id           String   @id @default(cuid())
+  id           String    @id @default(cuid())
   userId       String
-  user         User     @relation(fields: [userId], references: [id])
-  refreshToken String   @unique
+  user         User      @relation(fields: [userId], references: [id])
+  refreshToken String    @unique
   userAgent    String?
   ipAddress    String?
   expiresAt    DateTime
-  isValid      Boolean  @default(true)
-  createdAt    DateTime @default(now())
+  isValid      Boolean   @default(true)
+  createdAt    DateTime  @default(now())
   lastUsedAt   DateTime?
 
   @@index([refreshToken])
@@ -567,6 +567,38 @@ model AuditEvent {
   @@map("audit_events")
 }
 
+/**
+ * Off-chain store for retirement audit hash anchors.
+ * Design:
+ * - `auditHash` is the SHA-256 hex digest of the full, deterministically
+ * serialized audit record (sorted-key JSON).
+ * - `onChainTxHash` is the Soroban transaction hash that proves the
+ * anchoring action on-chain. The audit hash itself is NOT stored on-chain;
+ * the transaction log is the immutable proof.
+ * - The unique constraint on (tokenId, auditHash) enforces idempotency:
+ * a duplicate anchor request for the same (token, hash) pair returns the
+ * existing record rather than creating a new one.
+ */
+model RetirementAuditHashAnchor {
+  id            String    @id @default(cuid())
+  companyId     String    @map("company_id")
+  tokenId       Int       @map("token_id") // On-chain retirement token ID (u32)
+  auditEventId  String?   @map("audit_event_id") // Optional link to AuditEvent.id
+  auditHash     String    @map("audit_hash") // SHA-256 of the deterministic audit record
+  contractId    String    @map("contract_id") // Retirement Tracker contract ID
+  onChainTxHash String?   @map("on_chain_tx_hash") // Soroban tx hash proving the anchor
+  anchorStatus  String    @default("PENDING") @map("anchor_status") // PENDING | CONFIRMED | FAILED
+  anchoredAt    DateTime  @default(now()) @map("anchored_at")
+  verifiedAt    DateTime? @map("verified_at")
+  metadata      Json?
+
+  @@unique([tokenId, auditHash])
+  @@index([companyId])
+  @@index([tokenId])
+  @@index([anchorStatus])
+  @@map("retirement_audit_hash_anchors")
+}
+
 model Auction {
   id                String   @id @default(cuid())
   creditId          String
@@ -612,11 +644,11 @@ model Bid {
 }
 
 model RetirementSchedule {
-  id               String   @id @default(cuid())
+  id               String              @id @default(cuid())
   companyId        String
-  company          Company  @relation(fields: [companyId], references: [id])
+  company          Company             @relation(fields: [companyId], references: [id])
   userId           String
-  user             User     @relation(fields: [userId], references: [id])
+  user             User                @relation(fields: [userId], references: [id])
   name             String
   description      String?
   purpose          String
@@ -629,14 +661,14 @@ model RetirementSchedule {
   endDate          DateTime?
   nextRunDate      DateTime
   timezone         String?
-  isActive         Boolean  @default(true)
-  createdAt        DateTime @default(now())
-  updatedAt        DateTime @updatedAt
+  isActive         Boolean             @default(true)
+  createdAt        DateTime            @default(now())
+  updatedAt        DateTime            @updatedAt
   lastRunDate      DateTime?
   lastRunStatus    String?
-  runCount         Int      @default(0)
+  runCount         Int                 @default(0)
   notifyBefore     Int?
-  notifyAfter      Boolean  @default(true)
+  notifyAfter      Boolean             @default(true)
   executions       ScheduleExecution[]
   batchRetirements BatchRetirement[]
 
@@ -646,20 +678,20 @@ model RetirementSchedule {
 }
 
 model ScheduleExecution {
-  id            String   @id @default(cuid())
+  id            String             @id @default(cuid())
   scheduleId    String
   schedule      RetirementSchedule @relation(fields: [scheduleId], references: [id])
   runAt         DateTime
   completedAt   DateTime?
   status        String
   error         String?
-  createdAt     DateTime @default(now())
+  createdAt     DateTime           @default(now())
   scheduledDate DateTime?
   executedDate  DateTime?
   amountRetired Int?
   retirementIds String[]
   errorMessage  String?
-  retryCount    Int      @default(0)
+  retryCount    Int                @default(0)
   nextRetryDate DateTime?
   batchItems    BatchRetirement[]
 
@@ -669,9 +701,9 @@ model ScheduleExecution {
 }
 
 model BatchRetirement {
-  id             String   @id @default(cuid())
+  id             String              @id @default(cuid())
   companyId      String
-  company        Company  @relation(fields: [companyId], references: [id])
+  company        Company             @relation(fields: [companyId], references: [id])
   createdBy      String
   name           String
   description    String?
@@ -682,7 +714,7 @@ model BatchRetirement {
   failedItems    Int
   retirementIds  String[]
   errorLog       Json?
-  createdAt      DateTime @default(now())
+  createdAt      DateTime            @default(now())
   completedAt    DateTime?
   scheduleId     String?
   schedule       RetirementSchedule? @relation(fields: [scheduleId], references: [id])
@@ -695,19 +727,19 @@ model BatchRetirement {
 }
 
 model Cart {
-  id        String   @id @default(cuid())
-  companyId String
-  company   Company  @relation(fields: [companyId], references: [id])
-  sessionId String
-  subtotal  Float    @default(0)
-  serviceFee Float   @default(0)
-  total     Float    @default(0)
-  expiresAt DateTime
-  createdAt DateTime @default(now())
-  updatedAt DateTime @updatedAt
+  id         String   @id @default(cuid())
+  companyId  String
+  company    Company  @relation(fields: [companyId], references: [id])
+  sessionId  String
+  subtotal   Float    @default(0)
+  serviceFee Float    @default(0)
+  total      Float    @default(0)
+  expiresAt  DateTime
+  createdAt  DateTime @default(now())
+  updatedAt  DateTime @updatedAt
 
-  items   CartItem[]
-  orders  Order[]
+  items        CartItem[]
+  orders       Order[]
   reservations CreditReservation[]
 
   @@index([companyId])
@@ -730,14 +762,14 @@ model CartItem {
 }
 
 model Order {
-  id              String   @id @default(cuid())
-  orderNumber     String   @unique
+  id              String    @id @default(cuid())
+  orderNumber     String    @unique
   companyId       String
-  company         Company  @relation(fields: [companyId], references: [id])
+  company         Company   @relation(fields: [companyId], references: [id])
   userId          String
-  user            User     @relation(fields: [userId], references: [id])
+  user            User      @relation(fields: [userId], references: [id])
   cartId          String?
-  cart            Cart?    @relation(fields: [cartId], references: [id])
+  cart            Cart?     @relation(fields: [cartId], references: [id])
   subtotal        Float
   serviceFee      Float
   total           Float
@@ -748,11 +780,11 @@ model Order {
   notes           String?
   paidAt          DateTime?
   completedAt     DateTime?
-  createdAt       DateTime @default(now())
-  updatedAt       DateTime @updatedAt
+  createdAt       DateTime  @default(now())
+  updatedAt       DateTime  @updatedAt
 
-  items      OrderItem[]
-  auditLogs  OrderAuditLog[]
+  items     OrderItem[]
+  auditLogs OrderAuditLog[]
 
   @@index([companyId])
   @@index([userId])
@@ -809,54 +841,54 @@ model CreditReservation {
 // ==========================================
 
 model Portfolio {
-  id                    String                    @id @default(cuid())
-  companyId             String                    @unique
-  company               Company                   @relation(fields: [companyId], references: [id])
-  
+  id        String  @id @default(cuid())
+  companyId String  @unique
+  company   Company @relation(fields: [companyId], references: [id])
+
   // Summary metrics
-  totalRetired          Int                       @default(0)
-  currentBalance        Int                       @default(0)
-  totalValue            Float                     @default(0)
-  avgPricePerTon        Float                     @default(0)
-  
+  totalRetired   Int   @default(0)
+  currentBalance Int   @default(0)
+  totalValue     Float @default(0)
+  avgPricePerTon Float @default(0)
+
   // Progress tracking
-  netZeroTarget         Int?                      // Target tCO₂ by target year
-  netZeroProgress       Float                     @default(0)   // Percentage
-  scope3Coverage        Float                     @default(0)   // Percentage
-  
+  netZeroTarget   Int? // Target tCO₂ by target year
+  netZeroProgress Float @default(0) // Percentage
+  scope3Coverage  Float @default(0) // Percentage
+
   // Risk metrics
-  diversificationScore  Int                       @default(0)
-  riskRating            String                    @default("Low")  // Low, Medium, High
-  avgVintage            Float?
-  
+  diversificationScore Int    @default(0)
+  riskRating           String @default("Low") // Low, Medium, High
+  avgVintage           Float?
+
   // Relations
-  holdings              PortfolioHolding[]
-  snapshots             PortfolioSnapshot[]
-  entries               PortfolioEntry[]
-  
+  holdings  PortfolioHolding[]
+  snapshots PortfolioSnapshot[]
+  entries   PortfolioEntry[]
+
   // Timestamps
-  createdAt             DateTime                  @default(now())
-  updatedAt             DateTime                  @updatedAt
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
 
   @@index([companyId])
   @@map("portfolios")
 }
 
 model PortfolioHolding {
-  id              String    @id @default(cuid())
-  portfolioId     String
-  portfolio       Portfolio @relation(fields: [portfolioId], references: [id], onDelete: Cascade)
-  creditId        String
-  credit          Credit    @relation("PortfolioHolding", fields: [creditId], references: [id])
-  
-  quantity        Int
-  purchasePrice   Float
-  purchaseDate    DateTime
-  currentValue    Float
-  
-  createdAt       DateTime  @default(now())
-  updatedAt       DateTime  @updatedAt
-  
+  id          String    @id @default(cuid())
+  portfolioId String
+  portfolio   Portfolio @relation(fields: [portfolioId], references: [id], onDelete: Cascade)
+  creditId    String
+  credit      Credit    @relation("PortfolioHolding", fields: [creditId], references: [id])
+
+  quantity      Int
+  purchasePrice Float
+  purchaseDate  DateTime
+  currentValue  Float
+
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
+
   @@unique([portfolioId, creditId])
   @@index([portfolioId])
   @@index([creditId])
@@ -864,34 +896,34 @@ model PortfolioHolding {
 }
 
 model PortfolioSnapshot {
-  id                      String    @id @default(cuid())
-  portfolioId             String
-  portfolio               Portfolio @relation(fields: [portfolioId], references: [id], onDelete: Cascade)
-  
+  id          String    @id @default(cuid())
+  portfolioId String
+  portfolio   Portfolio @relation(fields: [portfolioId], references: [id], onDelete: Cascade)
+
   // Snapshot data
-  totalValue              Float
-  totalRetired            Int
-  currentBalance          Int
-  
+  totalValue     Float
+  totalRetired   Int
+  currentBalance Int
+
   // Breakdowns (stored as JSON for performance)
   methodologyDistribution Json
   geographicDistribution  Json
   sdgDistribution         Json
-  
-  snapshotDate            DateTime  @default(now())
-  
+
+  snapshotDate DateTime @default(now())
+
   @@index([portfolioId, snapshotDate])
   @@map("portfolio_snapshots")
 }
 
 model PortfolioEntry {
-  id          String   @id @default(cuid())
+  id          String    @id @default(cuid())
   portfolioId String
   portfolio   Portfolio @relation(fields: [portfolioId], references: [id], onDelete: Cascade)
   creditId    String
-  credit      Credit   @relation("PortfolioEntry", fields: [creditId], references: [id])
+  credit      Credit    @relation("PortfolioEntry", fields: [creditId], references: [id])
   quantity    Int
-  createdAt   DateTime @default(now())
+  createdAt   DateTime  @default(now())
 
   @@unique([portfolioId, creditId])
   @@index([portfolioId])
@@ -900,16 +932,16 @@ model PortfolioEntry {
 }
 
 model CreditAvailabilityLog {
-  id            String   @id @default(cuid())
-  creditId      String
-  credit        Credit   @relation(fields: [creditId], references: [id])
-  changedBy     String?  // userId or system
-  changeType    String   // decrement, increment, reserve, release, retire
-  amount        Int
+  id             String   @id @default(cuid())
+  creditId       String
+  credit         Credit   @relation(fields: [creditId], references: [id])
+  changedBy      String? // userId or system
+  changeType     String // decrement, increment, reserve, release, retire
+  amount         Int
   previousAmount Int
-  newAmount     Int
-  reason        String?
-  createdAt     DateTime @default(now())
+  newAmount      Int
+  reason         String?
+  createdAt      DateTime @default(now())
 
   @@index([creditId])
   @@index([createdAt])
@@ -921,17 +953,17 @@ model CreditAvailabilityLog {
 // ==========================================
 
 model Transaction {
-  id          String   @id @default(cuid())
-  companyId   String
-  company     Company  @relation(fields: [companyId], references: [id])
-  userId      String?
-  type        String   // order, refund, adjustment, transfer
-  orderId     String?  // Reference to Order when type = order
-  amount      Float
-  currency    String   @default("USD")
-  status      String   // pending, completed, failed
-  metadata    Json?
-  createdAt   DateTime @default(now())
+  id        String   @id @default(cuid())
+  companyId String
+  company   Company  @relation(fields: [companyId], references: [id])
+  userId    String?
+  type      String // order, refund, adjustment, transfer
+  orderId   String? // Reference to Order when type = order
+  amount    Float
+  currency  String   @default("USD")
+  status    String // pending, completed, failed
+  metadata  Json?
+  createdAt DateTime @default(now())
 
   @@index([companyId])
   @@index([userId])
@@ -945,16 +977,16 @@ model Transaction {
 // ==========================================
 
 model Compliance {
-  id           String   @id @default(cuid())
+  id           String    @id @default(cuid())
   companyId    String
-  company      Company  @relation(fields: [companyId], references: [id])
-  framework    String   // e.g. SBTi, CDP, GRI
-  status       String   // compliant, in_progress, not_started
-  requirements Json?    // Framework-specific requirements
+  company      Company   @relation(fields: [companyId], references: [id])
+  framework    String // e.g. SBTi, CDP, GRI
+  status       String // compliant, in_progress, not_started
+  requirements Json? // Framework-specific requirements
   dueDate      DateTime?
   completedAt  DateTime?
-  createdAt    DateTime @default(now())
-  updatedAt    DateTime @updatedAt
+  createdAt    DateTime  @default(now())
+  updatedAt    DateTime  @updatedAt
 
   @@index([companyId])
   @@index([framework])
@@ -970,10 +1002,10 @@ model Report {
   id          String   @id @default(cuid())
   companyId   String
   company     Company  @relation(fields: [companyId], references: [id])
-  type        String   // sustainability, retirement, compliance, custom
+  type        String // sustainability, retirement, compliance, custom
   name        String
   fileUrl     String?
-  params      Json?    // Generation parameters
+  params      Json? // Generation parameters
   generatedAt DateTime @default(now())
   createdAt   DateTime @default(now())
 
@@ -992,8 +1024,8 @@ model Activity {
   companyId  String
   company    Company  @relation(fields: [companyId], references: [id])
   userId     String?
-  action     String   // e.g. login, retirement_created, order_placed
-  entityType String?  // e.g. Retirement, Order
+  action     String // e.g. login, retirement_created, order_placed
+  entityType String? // e.g. Retirement, Order
   entityId   String?
   metadata   Json?
   ipAddress  String?
@@ -1007,30 +1039,30 @@ model Activity {
 }
 
 model ApiKey {
-  id            String    @id @default(cuid())
-  name          String
-  key           String    @unique
-  prefix        String
+  id     String @id @default(cuid())
+  name   String
+  key    String @unique
+  prefix String
 
-  companyId     String
-  company       Company   @relation(fields: [companyId], references: [id])
-  createdBy     String
+  companyId String
+  company   Company @relation(fields: [companyId], references: [id])
+  createdBy String
 
-  permissions   String[]  @default([])
+  permissions String[] @default([])
 
-  lastUsedAt    DateTime?
-  requestCount  Int       @default(0)
+  lastUsedAt   DateTime?
+  requestCount Int       @default(0)
 
-  expiresAt     DateTime?
-  rateLimit     Int       @default(100)
-  ipWhitelist   String[]  @default([])
+  expiresAt   DateTime?
+  rateLimit   Int       @default(100)
+  ipWhitelist String[]  @default([])
 
   isActive      Boolean   @default(true)
   revokedAt     DateTime?
   revokedReason String?
 
-  createdAt     DateTime  @default(now())
-  updatedAt     DateTime  @updatedAt
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
 
   @@index([key])
   @@index([companyId])
@@ -1038,21 +1070,21 @@ model ApiKey {
 }
 
 model IpfsDocument {
-  id              String   @id @default(cuid())
-  companyId       String
-  company         Company  @relation(fields: [companyId], references: [id])
-  documentType    String   // CERTIFICATE, REPORT, AUDIT_LOG, PROOF
-  referenceId     String   // retirementId, reportId, auditId
-  ipfsCid         String   @unique
-  ipfsGateway     String
-  fileName        String
-  fileSize        Int
-  mimeType        String
-  pinned          Boolean  @default(true)
-  pinnedAt        DateTime
-  metadata        Json?
-  createdAt       DateTime @default(now())
-  expiresAt       DateTime?
+  id           String    @id @default(cuid())
+  companyId    String
+  company      Company   @relation(fields: [companyId], references: [id])
+  documentType String // CERTIFICATE, REPORT, AUDIT_LOG, PROOF
+  referenceId  String // retirementId, reportId, auditId
+  ipfsCid      String    @unique
+  ipfsGateway  String
+  fileName     String
+  fileSize     Int
+  mimeType     String
+  pinned       Boolean   @default(true)
+  pinnedAt     DateTime
+  metadata     Json?
+  createdAt    DateTime  @default(now())
+  expiresAt    DateTime?
 
   @@index([companyId])
   @@index([referenceId])
@@ -1063,69 +1095,69 @@ model IpfsDocument {
 // ==========================================
 
 model Framework {
-  id              String   @id @default(cuid())
-  code            String   @unique // GHG, CSRD, SBTi, CORSIA, CBAM
-  name            String
-  description     String?
-  requirements    Json?    // List of requirement IDs and their metadata
-  mappings        FrameworkMethodologyMapping[]
-  createdAt       DateTime @default(now())
-  updatedAt       DateTime @updatedAt
+  id           String                        @id @default(cuid())
+  code         String                        @unique // GHG, CSRD, SBTi, CORSIA, CBAM
+  name         String
+  description  String?
+  requirements Json? // List of requirement IDs and their metadata
+  mappings     FrameworkMethodologyMapping[]
+  createdAt    DateTime                      @default(now())
+  updatedAt    DateTime                      @updatedAt
 
   @@map("frameworks")
 }
 
 model SyncedMethodology {
-  id              String   @id @default(cuid())
-  tokenId         Int      @unique
-  name            String
-  version         String
-  registry        String
-  registryLink    String
+  id               String                        @id @default(cuid())
+  tokenId          Int                           @unique
+  name             String
+  version          String
+  registry         String
+  registryLink     String
   issuingAuthority String
-  ipfsCid         String?
-  isActive        Boolean  @default(true)
-  lastSyncedAt    DateTime @default(now())
-  syncedFromBlock Int
-  mappings        FrameworkMethodologyMapping[]
-  createdAt       DateTime @default(now())
-  updatedAt       DateTime @updatedAt
+  ipfsCid          String?
+  isActive         Boolean                       @default(true)
+  lastSyncedAt     DateTime                      @default(now())
+  syncedFromBlock  Int
+  mappings         FrameworkMethodologyMapping[]
+  createdAt        DateTime                      @default(now())
+  updatedAt        DateTime                      @updatedAt
 
   @@map("synced_methodologies")
 }
 
 model FrameworkMethodologyMapping {
-  id              String   @id @default(cuid())
-  frameworkId     String
-  methodologyId   String   // References SyncedMethodology
-  methodologyTokenId Int      // Original token ID from contract
-  requirementIds  String[] // Which requirements this methodology fulfills
-  mappingType     String   // AUTO, MANUAL, SYSTEM
-  mappedBy        String?  // User ID or "system"
-  mappedAt        DateTime @default(now())
-  isActive        Boolean  @default(true)
-  metadata        Json?    // Additional mapping context
-  
-  framework       Framework @relation(fields: [frameworkId], references: [id])
-  methodology     SyncedMethodology @relation(fields: [methodologyId], references: [id])
-  
+  id                 String   @id @default(cuid())
+  frameworkId        String
+  methodologyId      String // References SyncedMethodology
+  methodologyTokenId Int // Original token ID from contract
+  requirementIds     String[] // Which requirements this methodology fulfills
+  mappingType        String // AUTO, MANUAL, SYSTEM
+  mappedBy           String? // User ID or "system"
+  mappedAt           DateTime @default(now())
+  isActive           Boolean  @default(true)
+  metadata           Json? // Additional mapping context
+
+  framework   Framework         @relation(fields: [frameworkId], references: [id])
+  methodology SyncedMethodology @relation(fields: [methodologyId], references: [id])
+
   @@unique([frameworkId, methodologyId])
   @@index([methodologyTokenId])
   @@map("framework_methodology_mappings")
 }
 
 model MappingRule {
-  id              String   @id @default(cuid())
-  name            String
-  description     String?
-  conditionType   String   // REGISTRY, METHODOLOGY_TYPE, AUTHORITY, KEYWORD
-  conditionValue  String   // "VERRA", "FORESTRY", etc.
-  targetFramework String   // GHG_PROTOCOL, CSRD, etc.
+  id                 String   @id @default(cuid())
+  name               String
+  description        String?
+  conditionType      String // REGISTRY, METHODOLOGY_TYPE, AUTHORITY, KEYWORD
+  conditionValue     String // "VERRA", "FORESTRY", etc.
+  targetFramework    String // GHG_PROTOCOL, CSRD, etc.
   targetRequirements String[] // Requirement IDs to map to
-  priority        Int      @default(0)
-  isActive        Boolean  @default(true)
-  createdAt       DateTime @default(now())
-  updatedAt       DateTime @updatedAt
+  priority           Int      @default(0)
+  isActive           Boolean  @default(true)
+  createdAt          DateTime @default(now())
+  updatedAt          DateTime @updatedAt
 
   @@map("mapping_rules")
 }
@@ -1135,32 +1167,32 @@ model MappingRule {
 // ==========================================
 
 model WebhookDelivery {
-  id              String   @id @default(cuid())
-  eventType       String
-  payload         Json
-  status          String   // PENDING, DELIVERED, FAILED, RETRYING
-  retryCount      Int      @default(0)
-  lastAttemptAt   DateTime
-  nextAttemptAt   DateTime?
-  deliveredAt     DateTime?
-  errorMessage    String?
-  createdAt       DateTime @default(now())
+  id            String    @id @default(cuid())
+  eventType     String
+  payload       Json
+  status        String // PENDING, DELIVERED, FAILED, RETRYING
+  retryCount    Int       @default(0)
+  lastAttemptAt DateTime
+  nextAttemptAt DateTime?
+  deliveredAt   DateTime?
+  errorMessage  String?
+  createdAt     DateTime  @default(now())
 
   @@map("webhook_deliveries")
 }
 
 model TransactionConfirmation {
-  id              String   @id @default(cuid())
-  transactionHash String   @unique
+  id              String    @id @default(cuid())
+  transactionHash String    @unique
   companyId       String
-  company         Company  @relation(fields: [companyId], references: [id])
-  operationType   String   // TRANSFER, RETIREMENT, MINT
-  status          String   // PENDING, CONFIRMED, FAILED
-  confirmations   Int      @default(0)
+  company         Company   @relation(fields: [companyId], references: [id])
+  operationType   String // TRANSFER, RETIREMENT, MINT
+  status          String // PENDING, CONFIRMED, FAILED
+  confirmations   Int       @default(0)
   ledgerSequence  Int?
   finalizedAt     DateTime?
   metadata        Json?
-  createdAt       DateTime @default(now())
+  createdAt       DateTime  @default(now())
 
   @@index([companyId])
   @@map("transaction_confirmations")
@@ -1171,14 +1203,14 @@ model TransactionConfirmation {
 // ==========================================
 
 model AnalyticsCache {
-  id              String   @id @default(cuid())
-  metricType      String   // DASHBOARD, QUALITY, REGIONAL, PERFORMANCE, etc.
-  period          String   // DAILY, WEEKLY, MONTHLY, QUARTERLY
-  date            DateTime
-  companyId       String?
-  data            Json     // Pre-calculated aggregations
-  expiresAt       DateTime
-  createdAt       DateTime @default(now())
+  id         String   @id @default(cuid())
+  metricType String // DASHBOARD, QUALITY, REGIONAL, PERFORMANCE, etc.
+  period     String // DAILY, WEEKLY, MONTHLY, QUARTERLY
+  date       DateTime
+  companyId  String?
+  data       Json // Pre-calculated aggregations
+  expiresAt  DateTime
+  createdAt  DateTime @default(now())
 
   @@index([metricType, period, date])
   @@index([companyId])
@@ -1190,10 +1222,10 @@ model ProjectScorecard {
   id              String   @id @default(cuid())
   projectId       String
   calculationDate DateTime
-  qualityScore    Float    // 0-100 composite
-  metrics         Json     // Individual metric scores
+  qualityScore    Float // 0-100 composite
+  metrics         Json // Individual metric scores
   riskFactors     Json
-  performanceRank Int?     // Within region/category
+  performanceRank Int? // Within region/category
   createdAt       DateTime @default(now())
   updatedAt       DateTime @updatedAt
 
@@ -1206,16 +1238,16 @@ model ProjectScorecard {
 // ==========================================
 
 model MaterialityAssessment {
-  id              String   @id @default(cuid())
-  companyId       String
-  company         Company  @relation(fields: [companyId], references: [id])
-  assessmentYear  Int
-  status          String   // DRAFT, IN_PROGRESS, COMPLETED
-  completedAt     DateTime?
-  impacts         Json     // Impact materiality results
-  risks           Json     // Financial materiality results
-  doubleMateriality Json   // Combined assessment
-  metadata        Json?
+  id                String    @id @default(cuid())
+  companyId         String
+  company           Company   @relation(fields: [companyId], references: [id])
+  assessmentYear    Int
+  status            String // DRAFT, IN_PROGRESS, COMPLETED
+  completedAt       DateTime?
+  impacts           Json // Impact materiality results
+  risks             Json // Financial materiality results
+  doubleMateriality Json // Combined assessment
+  metadata          Json?
 
   @@index([companyId])
   @@index([assessmentYear])
@@ -1223,17 +1255,17 @@ model MaterialityAssessment {
 }
 
 model EsrsDisclosure {
-  id              String   @id @default(cuid())
-  companyId       String
-  company         Company  @relation(fields: [companyId], references: [id])
-  reportingPeriod String   // e.g., "2024"
-  standard        String   // ESRS E1, ESRS S1, etc.
+  id                    String    @id @default(cuid())
+  companyId             String
+  company               Company   @relation(fields: [companyId], references: [id])
+  reportingPeriod       String // e.g., "2024"
+  standard              String // ESRS E1, ESRS S1, etc.
   disclosureRequirement String
-  dataPoint       String
-  value           Json
-  assuranceLevel  String?  // LIMITED, REASONABLE
-  assuredAt       DateTime?
-  assuredBy       String?
+  dataPoint             String
+  value                 Json
+  assuranceLevel        String? // LIMITED, REASONABLE
+  assuredAt             DateTime?
+  assuredBy             String?
 
   @@index([companyId])
   @@index([reportingPeriod])
@@ -1242,15 +1274,15 @@ model EsrsDisclosure {
 }
 
 model CsrdReport {
-  id              String   @id @default(cuid())
-  companyId       String
-  company         Company  @relation(fields: [companyId], references: [id])
-  reportingYear   Int
-  status          String   // DRAFT, REVIEW, SUBMITTED
-  submittedAt     DateTime?
-  submissionId    String?  // Official submission ID
-  reportUrl       String?  // Generated report location
-  metadata        Json?
+  id            String    @id @default(cuid())
+  companyId     String
+  company       Company   @relation(fields: [companyId], references: [id])
+  reportingYear Int
+  status        String // DRAFT, REVIEW, SUBMITTED
+  submittedAt   DateTime?
+  submissionId  String? // Official submission ID
+  reportUrl     String? // Generated report location
+  metadata      Json?
 
   @@index([companyId])
   @@index([reportingYear])
@@ -1258,15 +1290,15 @@ model CsrdReport {
 }
 
 model CreditTransfer {
-  id              String   @id @default(cuid())
-  purchaseId      String   @unique
+  id              String    @id @default(cuid())
+  purchaseId      String    @unique
   companyId       String
   projectId       String
   amount          Int
   transactionHash String?
-  status          String   // PENDING, CONFIRMED, FAILED
+  status          String // PENDING, CONFIRMED, FAILED
   errorMessage    String?
-  initiatedAt     DateTime @default(now())
+  initiatedAt     DateTime  @default(now())
   confirmedAt     DateTime?
 
   @@index([purchaseId])
@@ -1275,15 +1307,15 @@ model CreditTransfer {
 }
 
 model ContractCall {
-  id              String   @id @default(cuid())
+  id              String    @id @default(cuid())
   companyId       String
   contractId      String
   methodName      String
-  transactionHash String   @unique
+  transactionHash String    @unique
   args            Json
-  status          String   // PENDING, CONFIRMED, FAILED
+  status          String // PENDING, CONFIRMED, FAILED
   result          Json?
-  submittedAt     DateTime @default(now())
+  submittedAt     DateTime  @default(now())
   confirmedAt     DateTime?
 
   @@index([companyId])
@@ -1301,7 +1333,7 @@ model RetirementVerification {
   transactionHash String   @unique
   blockNumber     Int
   verifiedAt      DateTime @default(now())
-  proof           Json?    // Merkle proof for anchoring
+  proof           Json? // Merkle proof for anchoring
 
   @@index([retirementId])
   @@index([verifiedAt])
@@ -1313,19 +1345,19 @@ model RetirementVerification {
 // ==========================================
 
 model TeamActivity {
-  id              String   @id @default(cuid())
-  companyId       String
-  userId          String
-  activityType    String   // LOGIN, RETIREMENT_CREATED, REPORT_GENERATED, etc.
-  entityType      String?  // Retirement, Report, Target
-  entityId        String?
-  metadata        Json     // Additional context
-  ipAddress       String?
-  userAgent       String?
-  timestamp       DateTime @default(now())
-  
-  company         Company  @relation(fields: [companyId], references: [id])
-  
+  id           String   @id @default(cuid())
+  companyId    String
+  userId       String
+  activityType String // LOGIN, RETIREMENT_CREATED, REPORT_GENERATED, etc.
+  entityType   String? // Retirement, Report, Target
+  entityId     String?
+  metadata     Json // Additional context
+  ipAddress    String?
+  userAgent    String?
+  timestamp    DateTime @default(now())
+
+  company Company @relation(fields: [companyId], references: [id])
+
   @@index([companyId, timestamp])
   @@index([userId, timestamp])
   @@map("team_activities")
@@ -1336,36 +1368,36 @@ model CollaborationMetric {
   companyId       String
   periodStart     DateTime
   periodEnd       DateTime
-  metricType      String   // WEEKLY_SCORE, MONTHLY_SCORE
-  overallScore    Float    // 0-100 composite
-  components      Json     // Individual factor scores
-  topContributors Json     // Most engaged members
+  metricType      String // WEEKLY_SCORE, MONTHLY_SCORE
+  overallScore    Float // 0-100 composite
+  components      Json // Individual factor scores
+  topContributors Json // Most engaged members
   insights        String[] // Key observations
   createdAt       DateTime @default(now())
   updatedAt       DateTime @updatedAt
-  
-  company         Company  @relation(fields: [companyId], references: [id])
-  
+
+  company Company @relation(fields: [companyId], references: [id])
+
   @@index([companyId, periodStart])
   @@index([companyId, metricType])
   @@map("collaboration_metrics")
 }
 
 model MemberEngagement {
-  id              String   @id @default(cuid())
-  companyId       String
-  userId          String
-  periodStart     DateTime
-  periodEnd       DateTime
-  actionsCount    Int
-  uniqueDays      Int
-  contributions   Json     // Breakdown by action type
+  id                 String   @id @default(cuid())
+  companyId          String
+  userId             String
+  periodStart        DateTime
+  periodEnd          DateTime
+  actionsCount       Int
+  uniqueDays         Int
+  contributions      Json // Breakdown by action type
   collaborationScore Float // Peer interaction score
-  responseTimeAvg Float?   // Avg response time to mentions
-  lastUpdated     DateTime @updatedAt
-  
-  company         Company  @relation(fields: [companyId], references: [id])
-  
+  responseTimeAvg    Float? // Avg response time to mentions
+  lastUpdated        DateTime @updatedAt
+
+  company Company @relation(fields: [companyId], references: [id])
+
   @@unique([companyId, userId, periodStart, periodEnd])
   @@index([companyId, periodStart])
   @@index([companyId, userId])
@@ -1382,11 +1414,11 @@ model CreditOwnershipHistory {
   companyId       String?
   previousOwner   String
   newOwner        String
-  eventType       String   // MINT, TRANSFER, RETIREMENT
+  eventType       String // MINT, TRANSFER, RETIREMENT
   transactionHash String
   blockNumber     Int
   ledgerSequence  Int
-  metadata        Json?    // Additional event data
+  metadata        Json? // Additional event data
   timestamp       DateTime @default(now())
   createdAt       DateTime @default(now())
 
@@ -1398,11 +1430,11 @@ model CreditOwnershipHistory {
 }
 
 model CreditCurrentOwner {
-  id              String   @id @default(cuid())
-  tokenId         Int      @unique
-  owner           String
-  lastUpdated     DateTime @default(now())
-  createdAt       DateTime @default(now())
+  id          String   @id @default(cuid())
+  tokenId     Int      @unique
+  owner       String
+  lastUpdated DateTime @default(now())
+  createdAt   DateTime @default(now())
 
   @@map("credit_current_owners")
 }
@@ -1412,14 +1444,14 @@ model CreditCurrentOwner {
 // ==========================================
 
 model CbamGoods {
-  id              String   @id @default(cuid())
-  companyId       String
-  cnCode          String   // Combined Nomenclature code
-  goodsName       String
-  sector          String   // Cement, Iron & Steel, Aluminium, Fertilizers, Electricity, Hydrogen
-  defaultValue    Float?   // Default embedded emissions if no actual data
-  unit            String
-  company         Company  @relation(fields: [companyId], references: [id])
+  id                 String              @id @default(cuid())
+  companyId          String
+  cnCode             String // Combined Nomenclature code
+  goodsName          String
+  sector             String // Cement, Iron & Steel, Aluminium, Fertilizers, Electricity, Hydrogen
+  defaultValue       Float? // Default embedded emissions if no actual data
+  unit               String
+  company            Company             @relation(fields: [companyId], references: [id])
   importDeclarations ImportDeclaration[]
 
   @@index([companyId])
@@ -1429,22 +1461,22 @@ model CbamGoods {
 }
 
 model ImportDeclaration {
-  id              String   @id @default(cuid())
-  companyId       String
-  goodsId         String
-  goods           CbamGoods @relation(fields: [goodsId], references: [id])
-  importDate      DateTime
-  quantity        Float
-  quantityUnit    String
-  countryOfOrigin String
-  installationId  String?  // EU CBAM installation ID
-  actualEmissions Float?    // Actual embedded emissions (if reported)
-  defaultEmissions Float    // Default emissions used
-  totalEmissions  Float     // Calculated total
-  certificateCost Float?    // CBAM certificate cost
-  metadata        Json?
-  company         Company  @relation(fields: [companyId], references: [id])
-  cbamReports     CbamQuarterlyReport[] @relation("ReportDeclarations")
+  id               String                @id @default(cuid())
+  companyId        String
+  goodsId          String
+  goods            CbamGoods             @relation(fields: [goodsId], references: [id])
+  importDate       DateTime
+  quantity         Float
+  quantityUnit     String
+  countryOfOrigin  String
+  installationId   String? // EU CBAM installation ID
+  actualEmissions  Float? // Actual embedded emissions (if reported)
+  defaultEmissions Float // Default emissions used
+  totalEmissions   Float // Calculated total
+  certificateCost  Float? // CBAM certificate cost
+  metadata         Json?
+  company          Company               @relation(fields: [companyId], references: [id])
+  cbamReports      CbamQuarterlyReport[] @relation("ReportDeclarations")
 
   @@index([companyId])
   @@index([importDate])
@@ -1453,22 +1485,22 @@ model ImportDeclaration {
 }
 
 model CbamQuarterlyReport {
-  id              String   @id @default(cuid())
-  companyId       String
-  year            Int
-  quarter         Int      // 1, 2, 3, 4
-  status          String   // DRAFT, SUBMITTED, ACCEPTED
-  submittedAt     DateTime?
-  submissionId    String?
-  totalEmissions  Float
-  certificatesRequired Int
+  id                    String              @id @default(cuid())
+  companyId             String
+  year                  Int
+  quarter               Int // 1, 2, 3, 4
+  status                String // DRAFT, SUBMITTED, ACCEPTED
+  submittedAt           DateTime?
+  submissionId          String?
+  totalEmissions        Float
+  certificatesRequired  Int
   certificatesPurchased Int?
-  reportData      Json     // Full report structure
-  company         Company  @relation(fields: [companyId], references: [id])
-  declarations    ImportDeclaration[] @relation("ReportDeclarations")
+  reportData            Json // Full report structure
+  company               Company             @relation(fields: [companyId], references: [id])
+  declarations          ImportDeclaration[] @relation("ReportDeclarations")
 
-  createdAt       DateTime @default(now())
-  updatedAt       DateTime @updatedAt
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
 
   @@unique([companyId, year, quarter])
   @@index([companyId])

--- a/corporate-platform/corporate-platform-backend/src/audit-trail/audit-trail.module.ts
+++ b/corporate-platform/corporate-platform-backend/src/audit-trail/audit-trail.module.ts
@@ -1,13 +1,16 @@
-import { MiddlewareConsumer, Module, NestModule } from '@nestjs/common';
+import { MiddlewareConsumer, Module, NestModule, RequestMethod } from '@nestjs/common';
 import { StellarModule } from '../stellar/stellar.module';
 import { DatabaseModule } from '../shared/database/database.module';
 import { AuditTrailController } from './audit-trail.controller';
+import { AuditController } from './audit.controller';
 import { AuditTrailService } from './audit-trail.service';
 import { BlockchainAnchorService } from './services/blockchain-anchor.service';
 import { EventLoggerService } from './services/event-logger.service';
 import { IntegrityVerifierService } from './services/integrity-verifier.service';
 import { RetentionManagerService } from './services/retention-manager.service';
+import { RetirementAuditHashService } from './services/retirement-audit-hash.service';
 import { ComplianceAuditMiddleware } from './middleware/compliance-audit.middleware';
+import { AuditRateLimitMiddleware } from './middleware/audit-rate-limit.middleware';
 
 @Module({
   imports: [DatabaseModule, StellarModule],
@@ -17,12 +20,23 @@ import { ComplianceAuditMiddleware } from './middleware/compliance-audit.middlew
     IntegrityVerifierService,
     BlockchainAnchorService,
     RetentionManagerService,
+    RetirementAuditHashService,
   ],
-  controllers: [AuditTrailController],
-  exports: [AuditTrailService, EventLoggerService],
+  controllers: [AuditTrailController, AuditController],
+  exports: [AuditTrailService, EventLoggerService, RetirementAuditHashService],
 })
 export class AuditTrailModule implements NestModule {
   configure(consumer: MiddlewareConsumer) {
+    // Existing compliance capture middleware (all non-audit-trail mutation routes)
     consumer.apply(ComplianceAuditMiddleware).forRoutes('*');
+
+    // Rate limiting on audit hash anchoring and verification endpoints
+    consumer
+      .apply(AuditRateLimitMiddleware)
+      .forRoutes(
+        { path: 'api/v1/audit/anchor-hash', method: RequestMethod.POST },
+        { path: 'api/v1/audit/verify-hash/:tokenId', method: RequestMethod.GET },
+      );
   }
 }
+

--- a/corporate-platform/corporate-platform-backend/src/audit-trail/audit.controller.ts
+++ b/corporate-platform/corporate-platform-backend/src/audit-trail/audit.controller.ts
@@ -1,0 +1,94 @@
+import {
+  Body,
+  Controller,
+  Get,
+  Param,
+  ParseIntPipe,
+  Post,
+  UseGuards,
+} from '@nestjs/common';
+import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
+import { RolesGuard } from '../rbac/guards/roles.guard';
+import { Roles } from '../rbac/decorators/roles.decorator';
+import { CurrentUser } from '../auth/decorators/current-user.decorator';
+import { JwtPayload } from '../auth/interfaces/jwt-payload.interface';
+import { AnchorHashDto } from './dto/anchor-hash.dto';
+import { RetirementAuditHashService } from './services/retirement-audit-hash.service';
+
+/**
+ * AuditController — endpoints for retirement audit hash anchoring & verification.
+ *
+ * Base path: /api/v1/audit
+ *
+ * Access control:
+ *   POST /anchor-hash   — roles: admin, manager, auditor
+ *     Anchoring is a mutating, on-chain operation that generates costs and
+ *     immutable records. Restricted to roles with compliance authority.
+ *
+ *   GET  /verify-hash/:tokenId — roles: admin, auditor, analyst
+ *     Verification is read-only. Open to analysts for regulatory reporting.
+ *
+ * Rate limiting is applied by AuditRateLimitMiddleware (registered in
+ * AuditTrailModule.configure) to both endpoints.
+ */
+@Controller('api/v1/audit')
+@UseGuards(JwtAuthGuard, RolesGuard)
+export class AuditController {
+  constructor(
+    private readonly retirementAuditHashService: RetirementAuditHashService,
+  ) {}
+
+  /**
+   * POST /api/v1/audit/anchor-hash
+   *
+   * Generate a SHA-256 audit hash for the provided `auditRecord` and anchor it
+   * to the Retirement Tracker smart contract for token `tokenId`.
+   *
+   * The audit hash is stored off-chain; the on-chain Soroban transaction hash
+   * (`onChainTxHash`) serves as the immutable, tamper-proof cryptographic proof.
+   *
+   * Duplicate requests for the same (tokenId, auditRecord) are idempotent:
+   * a CONFIRMED anchor record is returned immediately without re-invoking
+   * the contract.
+   *
+   * Required roles: admin | manager | auditor
+   */
+  @Post('anchor-hash')
+  @Roles('admin', 'manager', 'auditor')
+  async anchorHash(
+    @CurrentUser() user: JwtPayload,
+    @Body() dto: AnchorHashDto,
+  ) {
+    return this.retirementAuditHashService.anchorHash({
+      tokenId: dto.tokenId,
+      auditEventId: dto.auditEventId,
+      auditRecord: dto.auditRecord,
+      companyId: user.companyId,
+      userId: user.sub,
+    });
+  }
+
+  /**
+   * GET /api/v1/audit/verify-hash/:tokenId
+   *
+   * Retrieve the audit hash anchor for the given on-chain retirement token ID
+   * and verify it against the current on-chain retirement record.
+   *
+   * `txProofConfirmed` in the response is `true` when the stored anchor has
+   * an associated CONFIRMED Soroban transaction — this is the cryptographic
+   * proof of the anchoring action.
+   *
+   * The audit hash itself is NOT stored on-chain; this endpoint confirms the
+   * anchoring transaction was accepted by the Stellar network.
+   *
+   * Required roles: admin | auditor | analyst
+   */
+  @Get('verify-hash/:tokenId')
+  @Roles('admin', 'auditor', 'analyst')
+  async verifyHash(
+    @CurrentUser() user: JwtPayload,
+    @Param('tokenId', ParseIntPipe) tokenId: number,
+  ) {
+    return this.retirementAuditHashService.verifyHash(user.companyId, tokenId);
+  }
+}

--- a/corporate-platform/corporate-platform-backend/src/audit-trail/dto/anchor-hash.dto.ts
+++ b/corporate-platform/corporate-platform-backend/src/audit-trail/dto/anchor-hash.dto.ts
@@ -1,0 +1,37 @@
+import {
+  IsInt,
+  IsObject,
+  IsOptional,
+  IsString,
+  Min,
+} from 'class-validator';
+import { Type } from 'class-transformer';
+
+/**
+ * DTO for POST /api/v1/audit/anchor-hash
+ *
+ * `tokenId` is the numeric on-chain retirement token ID (u32) from the
+ * Soroban RetirementTracker contract.
+ *
+ * `auditRecord` is the full audit record payload that will be hashed.
+ * The server performs deterministic serialization (sorted keys, stable JSON)
+ * before computing the SHA-256 digest — callers must not pre-hash.
+ */
+export class AnchorHashDto {
+  @Type(() => Number)
+  @IsInt()
+  @Min(0)
+  tokenId: number;
+
+  @IsOptional()
+  @IsString()
+  auditEventId?: string;
+
+  /**
+   * Full audit record object. All fields are included in the hash.
+   * Keys are sorted recursively before hashing to guarantee determinism
+   * regardless of insertion order.
+   */
+  @IsObject()
+  auditRecord: Record<string, unknown>;
+}

--- a/corporate-platform/corporate-platform-backend/src/audit-trail/interfaces/retirement-audit-hash.interface.ts
+++ b/corporate-platform/corporate-platform-backend/src/audit-trail/interfaces/retirement-audit-hash.interface.ts
@@ -1,0 +1,72 @@
+/**
+ * Interfaces for the Retirement Audit Hash Anchoring subsystem.
+ *
+ * Architectural note:
+ *   - Audit hashes (SHA-256 of the full audit record) are stored OFF-CHAIN in the
+ *     `RetirementAuditHashAnchor` table.
+ *   - Anchoring is proven ON-CHAIN via a Soroban ContractCall whose transaction hash
+ *     is stored in `onChainTxHash`. The retirement record itself does NOT contain the
+ *     audit hash; the on-chain transaction log serves as the immutable proof of the
+ *     anchoring action.
+ */
+
+export type AnchorStatus = 'PENDING' | 'CONFIRMED' | 'FAILED';
+
+/** Input for anchoring an audit hash to a retirement token. */
+export interface AnchorHashInput {
+  /** On-chain retirement token ID (u32 in Soroban contract). */
+  tokenId: number;
+  /** Optional link to an off-chain AuditEvent.id for traceability. */
+  auditEventId?: string;
+  /**
+   * Full audit record to hash. Must be deterministically serializable
+   * (all fields will be sorted by key before hashing).
+   */
+  auditRecord: Record<string, unknown>;
+  companyId: string;
+  userId: string;
+}
+
+/** Result returned after a successful (or attempted) anchor operation. */
+export interface AnchorHashResult {
+  /** Internal DB anchor record ID. */
+  anchorId: string;
+  /** On-chain retirement token ID. */
+  tokenId: number;
+  /** SHA-256 hex digest of the deterministically serialized audit record. */
+  auditHash: string;
+  /** Soroban transaction hash that proves the anchoring action on-chain. */
+  onChainTxHash: string | null;
+  /** Whether this result was served from an existing idempotent record. */
+  idempotent: boolean;
+  anchorStatus: AnchorStatus;
+  anchoredAt: string;
+}
+
+/** Result returned from a hash verification request. */
+export interface VerifyHashResult {
+  /** On-chain retirement token ID that was queried. */
+  tokenId: number;
+  /**
+   * The audit hash stored in the off-chain anchor record.
+   * Null if no anchor record exists for this tokenId.
+   */
+  auditHash: string | null;
+  /**
+   * The on-chain retirement record fetched from the Soroban contract.
+   * Contains fields returned by `get_retirement_record`.
+   */
+  onChainRecord: Record<string, unknown> | null;
+  /**
+   * True when an off-chain anchor record exists AND the corresponding
+   * on-chain ContractCall transaction is confirmed.
+   * The audit hash itself is NOT stored on-chain; this flag confirms
+   * the anchoring transaction was accepted by the Stellar network.
+   */
+  txProofConfirmed: boolean;
+  /** Soroban transaction hash used as the cryptographic proof. */
+  onChainTxHash: string | null;
+  anchorStatus: string;
+  anchorId: string | null;
+  verifiedAt: string;
+}

--- a/corporate-platform/corporate-platform-backend/src/audit-trail/middleware/audit-rate-limit.middleware.ts
+++ b/corporate-platform/corporate-platform-backend/src/audit-trail/middleware/audit-rate-limit.middleware.ts
@@ -1,0 +1,62 @@
+import {
+  Injectable,
+  NestMiddleware,
+  HttpException,
+  HttpStatus,
+} from '@nestjs/common';
+import { NextFunction, Request, Response } from 'express';
+
+/**
+ * Simple in-process sliding-window rate limiter for audit endpoints.
+ *
+ * Keyed by `companyId` (from the JWT payload if present) or IP address,
+ * preventing any single tenant from flooding the expensive on-chain
+ * anchor or verify operations.
+ *
+ * Limits (configurable via env vars):
+ *   AUDIT_ANCHOR_RATE_LIMIT_MAX   — max requests per window  (default: 30)
+ *   AUDIT_ANCHOR_RATE_LIMIT_WINDOW_MS — window in ms        (default: 60_000)
+ *
+ * For production deployments behind multiple instances, replace this with a
+ * Redis-backed rate limiter (e.g. @nestjs/throttler with redis store).
+ */
+@Injectable()
+export class AuditRateLimitMiddleware implements NestMiddleware {
+  private readonly windowMs: number;
+  private readonly maxRequests: number;
+
+  /** Map<tenantKey, timestamps[]> */
+  private readonly requestLog = new Map<string, number[]>();
+
+  constructor() {
+    this.windowMs = Number(process.env.AUDIT_ANCHOR_RATE_LIMIT_WINDOW_MS ?? 60_000);
+    this.maxRequests = Number(process.env.AUDIT_ANCHOR_RATE_LIMIT_MAX ?? 30);
+  }
+
+  use(req: Request, _res: Response, next: NextFunction) {
+    const user = (req as any).user as
+      | { companyId?: string; sub?: string }
+      | undefined;
+
+    // Key by companyId when available; fall back to IP
+    const key = user?.companyId || req.ip || 'unknown';
+    const now = Date.now();
+    const windowStart = now - this.windowMs;
+
+    const timestamps = (this.requestLog.get(key) ?? []).filter(
+      (t) => t > windowStart,
+    );
+
+    if (timestamps.length >= this.maxRequests) {
+      throw new HttpException(
+        `Audit endpoint rate limit exceeded. Max ${this.maxRequests} requests per ${this.windowMs / 1000}s.`,
+        HttpStatus.TOO_MANY_REQUESTS,
+      );
+    }
+
+    timestamps.push(now);
+    this.requestLog.set(key, timestamps);
+
+    next();
+  }
+}

--- a/corporate-platform/corporate-platform-backend/src/audit-trail/services/retirement-audit-hash.service.spec.ts
+++ b/corporate-platform/corporate-platform-backend/src/audit-trail/services/retirement-audit-hash.service.spec.ts
@@ -1,0 +1,457 @@
+import { NotFoundException } from '@nestjs/common';
+import { RetirementAuditHashService } from './retirement-audit-hash.service';
+import { RETIREMENT_TRACKER_CONTRACT_ID } from '../../stellar/soroban/contracts/contract.interface';
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Test factory
+// ─────────────────────────────────────────────────────────────────────────────
+
+const buildService = (overrides?: {
+  prismaAnchor?: Partial<{
+    findUnique: jest.Mock;
+    findFirst: jest.Mock;
+    create: jest.Mock;
+    update: jest.Mock;
+  }>;
+  trackerInvoke?: jest.Mock;
+  trackerGetRecord?: jest.Mock;
+  loggerRecord?: jest.Mock;
+}) => {
+  const now = new Date('2026-04-25T12:00:00.000Z');
+
+  const defaultAnchor = {
+    id: 'anchor-1',
+    companyId: 'company-1',
+    tokenId: 42,
+    auditEventId: null,
+    auditHash: '', // filled per test
+    contractId: RETIREMENT_TRACKER_CONTRACT_ID,
+    onChainTxHash: null,
+    anchorStatus: 'PENDING',
+    anchoredAt: now,
+    verifiedAt: null,
+    metadata: null,
+  };
+
+  const prisma = {
+    retirementAuditHashAnchor: {
+      findUnique: jest.fn().mockResolvedValue(null),
+      findFirst: jest.fn().mockResolvedValue(null),
+      create: jest.fn().mockImplementation(async ({ data }: any) => ({
+        ...defaultAnchor,
+        ...data,
+        id: 'anchor-1',
+        anchoredAt: now,
+      })),
+      update: jest.fn().mockImplementation(async ({ data, where }: any) => ({
+        ...defaultAnchor,
+        id: where.id ?? 'anchor-1',
+        ...data,
+        anchoredAt: now,
+      })),
+      ...overrides?.prismaAnchor,
+    },
+  };
+
+  const retirementTracker = {
+    invoke: overrides?.trackerInvoke ??
+      jest.fn().mockResolvedValue({
+        transactionHash: 'tx_abc123',
+        status: 'CONFIRMED',
+      }),
+    getRetirementRecord: overrides?.trackerGetRecord ??
+      jest.fn().mockResolvedValue({
+        token_id: 42,
+        retiring_entity: 'GABC...',
+        timestamp: 1714040400,
+      }),
+  };
+
+  const eventLogger = {
+    recordEvent: overrides?.loggerRecord ?? jest.fn().mockResolvedValue({}),
+  };
+
+  const service = new RetirementAuditHashService(
+    prisma as any,
+    retirementTracker as any,
+    eventLogger as any,
+  );
+
+  return { service, prisma, retirementTracker, eventLogger, defaultAnchor, now };
+};
+
+const baseInput = {
+  tokenId: 42,
+  auditRecord: { amount: 10, purpose: 'scope2', companyId: 'company-1' },
+  companyId: 'company-1',
+  userId: 'user-1',
+};
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Hashing — deterministic serialization
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('RetirementAuditHashService — deterministic hashing', () => {
+  it('produces the same SHA-256 hash for identical records regardless of key insertion order', () => {
+    const { service } = buildService();
+
+    const h1 = service.computeAuditHash({ a: 1, b: { y: 2, x: 1 }, c: [1, 2] });
+    const h2 = service.computeAuditHash({ c: [1, 2], b: { x: 1, y: 2 }, a: 1 });
+
+    expect(h1).toBe(h2);
+    expect(h1).toHaveLength(64); // SHA-256 hex
+  });
+
+  it('produces different hashes for different records', () => {
+    const { service } = buildService();
+
+    const h1 = service.computeAuditHash({ tokenId: 1, purpose: 'scope2' });
+    const h2 = service.computeAuditHash({ tokenId: 2, purpose: 'scope2' });
+
+    expect(h1).not.toBe(h2);
+  });
+
+  it('handles nested arrays and null values deterministically', () => {
+    const { service } = buildService();
+    const record = { items: [{ b: null, a: 1 }, { b: 2, a: null }] };
+
+    const h1 = service.computeAuditHash(record);
+    const h2 = service.computeAuditHash(record);
+
+    expect(h1).toBe(h2);
+  });
+
+  it('treats Date objects as ISO strings for stable serialization', () => {
+    const { service } = buildService();
+    const d = new Date('2026-01-01T00:00:00.000Z');
+
+    const h1 = service.computeAuditHash({ ts: d });
+    const h2 = service.computeAuditHash({ ts: '2026-01-01T00:00:00.000Z' });
+
+    expect(h1).toBe(h2);
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// anchorHash — happy path
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('RetirementAuditHashService — anchorHash (happy path)', () => {
+  it('creates a DB anchor record with PENDING status before invoking the contract', async () => {
+    const { service, prisma } = buildService();
+
+    await service.anchorHash(baseInput);
+
+    expect(prisma.retirementAuditHashAnchor.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({
+          tokenId: 42,
+          companyId: 'company-1',
+          anchorStatus: 'PENDING',
+          contractId: RETIREMENT_TRACKER_CONTRACT_ID,
+        }),
+      }),
+    );
+  });
+
+  it('invokes RetirementTrackerService with anchor_audit_hash method and correct args', async () => {
+    const { service, retirementTracker } = buildService();
+
+    const expectedHash = service.computeAuditHash(baseInput.auditRecord);
+    await service.anchorHash(baseInput);
+
+    expect(retirementTracker.invoke).toHaveBeenCalledWith(
+      expect.objectContaining({
+        companyId: 'company-1',
+        methodName: 'anchor_audit_hash',
+        args: [
+          { type: 'u32', value: 42 },
+          { type: 'string', value: expectedHash },
+        ],
+      }),
+    );
+  });
+
+  it('updates the anchor record with the on-chain tx hash and CONFIRMED status', async () => {
+    const { service, prisma } = buildService();
+
+    const result = await service.anchorHash(baseInput);
+
+    expect(prisma.retirementAuditHashAnchor.update).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({
+          onChainTxHash: 'tx_abc123',
+          anchorStatus: 'CONFIRMED',
+        }),
+      }),
+    );
+    expect(result.onChainTxHash).toBe('tx_abc123');
+    expect(result.anchorStatus).toBe('CONFIRMED');
+    expect(result.idempotent).toBe(false);
+  });
+
+  it('records a companion AuditEvent after successful anchoring', async () => {
+    const { service, eventLogger } = buildService();
+
+    await service.anchorHash(baseInput);
+
+    expect(eventLogger.recordEvent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        entityType: 'RetirementAuditHashAnchor',
+        entityId: '42',
+        eventType: 'RETIREMENT',
+        action: 'CREATE',
+      }),
+    );
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// anchorHash — idempotency
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('RetirementAuditHashService — anchorHash (idempotency)', () => {
+  it('returns existing CONFIRMED anchor without re-invoking contract', async () => {
+    const existingHash = new RetirementAuditHashService(
+      {} as any, {} as any, {} as any,
+    ).computeAuditHash(baseInput.auditRecord);
+
+    const confirmedAnchor = {
+      id: 'existing-anchor',
+      tokenId: 42,
+      auditHash: existingHash,
+      onChainTxHash: 'tx_existing',
+      anchorStatus: 'CONFIRMED',
+      anchoredAt: new Date(),
+    };
+
+    const { service, retirementTracker } = buildService({
+      prismaAnchor: {
+        findUnique: jest.fn().mockResolvedValue(confirmedAnchor),
+      },
+    });
+
+    const result = await service.anchorHash(baseInput);
+
+    expect(retirementTracker.invoke).not.toHaveBeenCalled();
+    expect(result.idempotent).toBe(true);
+    expect(result.anchorId).toBe('existing-anchor');
+    expect(result.onChainTxHash).toBe('tx_existing');
+  });
+
+  it('retries FAILED anchors by resetting status to PENDING and re-invoking', async () => {
+    const svc = new RetirementAuditHashService({} as any, {} as any, {} as any);
+    const existingHash = svc.computeAuditHash(baseInput.auditRecord);
+
+    const failedAnchor = {
+      id: 'failed-anchor',
+      tokenId: 42,
+      auditHash: existingHash,
+      onChainTxHash: null,
+      anchorStatus: 'FAILED',
+      anchoredAt: new Date(),
+    };
+
+    const updateMock = jest.fn()
+      .mockResolvedValueOnce({ ...failedAnchor, anchorStatus: 'PENDING', onChainTxHash: null })
+      .mockResolvedValueOnce({ ...failedAnchor, anchorStatus: 'CONFIRMED', onChainTxHash: 'tx_retry' });
+
+    const { service, retirementTracker } = buildService({
+      prismaAnchor: {
+        findUnique: jest.fn().mockResolvedValue(failedAnchor),
+        update: updateMock,
+      },
+    });
+
+    const result = await service.anchorHash(baseInput);
+
+    expect(retirementTracker.invoke).toHaveBeenCalledTimes(1);
+    expect(result.anchorStatus).toBe('CONFIRMED');
+    expect(result.idempotent).toBe(false);
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// anchorHash — partial failure
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('RetirementAuditHashService — anchorHash (partial failure)', () => {
+  it('marks anchor as FAILED when Soroban invocation throws', async () => {
+    const updateMock = jest.fn().mockImplementation(async ({ data }: any) => ({
+      id: 'anchor-1',
+      tokenId: 42,
+      anchoredAt: new Date(),
+      ...data,
+    }));
+
+    const { service, prisma, eventLogger } = buildService({
+      trackerInvoke: jest.fn().mockRejectedValue(new Error('Network timeout')),
+      prismaAnchor: {
+        findUnique: jest.fn().mockResolvedValue(null),
+        create: jest.fn().mockResolvedValue({
+          id: 'anchor-1',
+          tokenId: 42,
+          auditHash: '',
+          anchorStatus: 'PENDING',
+          anchoredAt: new Date(),
+        }),
+        update: updateMock,
+      },
+    });
+
+    const result = await service.anchorHash(baseInput);
+
+    // DB record must be set to FAILED
+    expect(prisma.retirementAuditHashAnchor.update).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({
+          anchorStatus: 'FAILED',
+          metadata: expect.objectContaining({ error: 'Network timeout' }),
+        }),
+      }),
+    );
+
+    expect(result.anchorStatus).toBe('FAILED');
+    expect(result.onChainTxHash).toBeNull();
+
+    // A companion audit event must still be recorded for the failed attempt
+    expect(eventLogger.recordEvent).toHaveBeenCalledWith(
+      expect.objectContaining({ entityType: 'RetirementAuditHashAnchor' }),
+    );
+  });
+
+  it('does not propagate AuditEvent recording failures', async () => {
+    const { service, eventLogger } = buildService({
+      loggerRecord: jest.fn().mockRejectedValue(new Error('DB down')),
+    });
+
+    // Should not throw even if event logger fails
+    await expect(service.anchorHash(baseInput)).resolves.toBeDefined();
+    expect(eventLogger.recordEvent).toHaveBeenCalled();
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// verifyHash
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('RetirementAuditHashService — verifyHash', () => {
+  it('returns txProofConfirmed=true for a CONFIRMED anchor with an on-chain tx hash', async () => {
+    const confirmedAnchor = {
+      id: 'anchor-1',
+      tokenId: 42,
+      auditHash: 'abc123hash',
+      onChainTxHash: 'tx_proof',
+      anchorStatus: 'CONFIRMED',
+      anchoredAt: new Date(),
+      verifiedAt: null,
+    };
+
+    const { service } = buildService({
+      prismaAnchor: {
+        findFirst: jest.fn().mockResolvedValue(confirmedAnchor),
+        update: jest.fn().mockResolvedValue({ ...confirmedAnchor, verifiedAt: new Date() }),
+      },
+    });
+
+    const result = await service.verifyHash('company-1', 42);
+
+    expect(result.txProofConfirmed).toBe(true);
+    expect(result.auditHash).toBe('abc123hash');
+    expect(result.onChainTxHash).toBe('tx_proof');
+    expect(result.onChainRecord).not.toBeNull();
+  });
+
+  it('returns txProofConfirmed=false for a PENDING anchor', async () => {
+    const pendingAnchor = {
+      id: 'anchor-2',
+      tokenId: 42,
+      auditHash: 'pending_hash',
+      onChainTxHash: null,
+      anchorStatus: 'PENDING',
+      anchoredAt: new Date(),
+      verifiedAt: null,
+    };
+
+    const { service } = buildService({
+      prismaAnchor: {
+        findFirst: jest.fn().mockResolvedValue(pendingAnchor),
+        update: jest.fn().mockResolvedValue(pendingAnchor),
+      },
+    });
+
+    const result = await service.verifyHash('company-1', 42);
+
+    expect(result.txProofConfirmed).toBe(false);
+    expect(result.anchorStatus).toBe('PENDING');
+  });
+
+  it('throws NotFoundException when no anchor record exists', async () => {
+    const { service } = buildService({
+      prismaAnchor: { findFirst: jest.fn().mockResolvedValue(null) },
+    });
+
+    await expect(service.verifyHash('company-1', 99)).rejects.toThrow(
+      NotFoundException,
+    );
+  });
+
+  it('returns onChainRecord=null gracefully when Soroban call fails', async () => {
+    const confirmedAnchor = {
+      id: 'anchor-3',
+      tokenId: 42,
+      auditHash: 'xyz_hash',
+      onChainTxHash: 'tx_ok',
+      anchorStatus: 'CONFIRMED',
+      anchoredAt: new Date(),
+      verifiedAt: null,
+    };
+
+    const { service } = buildService({
+      prismaAnchor: {
+        findFirst: jest.fn().mockResolvedValue(confirmedAnchor),
+        update: jest.fn().mockResolvedValue(confirmedAnchor),
+      },
+      trackerGetRecord: jest.fn().mockRejectedValue(new Error('Soroban RPC down')),
+    });
+
+    const result = await service.verifyHash('company-1', 42);
+
+    expect(result.onChainRecord).toBeNull();
+    // txProofConfirmed is based on the anchor record status, not the RPC call
+    expect(result.txProofConfirmed).toBe(true);
+  });
+
+  it('updates verifiedAt timestamp on each verification call', async () => {
+    const confirmedAnchor = {
+      id: 'anchor-4',
+      tokenId: 42,
+      auditHash: 'hash',
+      onChainTxHash: 'tx_ok',
+      anchorStatus: 'CONFIRMED',
+      anchoredAt: new Date(),
+      verifiedAt: null,
+    };
+
+    const updateMock = jest.fn().mockImplementation(async ({ data }: any) => ({
+      ...confirmedAnchor,
+      ...data,
+    }));
+
+    const { service } = buildService({
+      prismaAnchor: {
+        findFirst: jest.fn().mockResolvedValue(confirmedAnchor),
+        update: updateMock,
+      },
+    });
+
+    const result = await service.verifyHash('company-1', 42);
+
+    expect(updateMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({ verifiedAt: expect.any(Date) }),
+      }),
+    );
+    expect(result.verifiedAt).toBeDefined();
+  });
+});

--- a/corporate-platform/corporate-platform-backend/src/audit-trail/services/retirement-audit-hash.service.ts
+++ b/corporate-platform/corporate-platform-backend/src/audit-trail/services/retirement-audit-hash.service.ts
@@ -1,0 +1,338 @@
+import {
+  ConflictException,
+  Injectable,
+  Logger,
+  NotFoundException,
+} from '@nestjs/common';
+import { createHash } from 'crypto';
+import { PrismaService } from '../../shared/database/prisma.service';
+import { RetirementTrackerService } from '../../stellar/soroban/contracts/retirement-tracker.service';
+import { EventLoggerService } from './event-logger.service';
+import { AuditAction, AuditEventType } from '../interfaces/audit-event.interface';
+import {
+  AnchorHashInput,
+  AnchorHashResult,
+  AnchorStatus,
+  VerifyHashResult,
+} from '../interfaces/retirement-audit-hash.interface';
+import { RETIREMENT_TRACKER_CONTRACT_ID } from '../../stellar/soroban/contracts/contract.interface';
+
+/**
+ * RetirementAuditHashService
+ *
+ * Anchors SHA-256 audit hashes to the Soroban RetirementTracker contract and
+ * provides verification against the resulting on-chain transaction proof.
+ *
+ * Architecture summary:
+ *   1. The full audit record is serialized deterministically (recursive sorted-key
+ *      JSON) and hashed with SHA-256 to produce the `auditHash`.
+ *   2. The hash is stored off-chain in `RetirementAuditHashAnchor` with status PENDING.
+ *   3. The Soroban contract is invoked (`anchor_audit_hash`) in production mode when
+ *      STELLAR_SECRET_KEY is set, producing an on-chain transaction hash as proof.
+ *      In development/simulation mode the ContractCall record still serves as an
+ *      auditable record of the anchoring action.
+ *   4. The anchor record is updated with the on-chain tx hash and final status.
+ *   5. A companion AuditEvent is recorded for full traceability of the anchoring
+ *      action itself.
+ *
+ * Idempotency:
+ *   Duplicate anchor requests for the same (tokenId, auditHash) pair are detected
+ *   via the DB unique constraint and return the existing record instead of
+ *   re-invoking the contract.
+ *
+ * Partial-failure recovery:
+ *   If the DB write succeeds but the Soroban invocation fails, the anchor record
+ *   is updated to status FAILED with the error captured in `metadata`. The caller
+ *   may retry and the idempotency check allows a fresh invocation for FAILED records.
+ */
+@Injectable()
+export class RetirementAuditHashService {
+  private readonly logger = new Logger(RetirementAuditHashService.name);
+
+  private readonly contractId =
+    process.env.RETIREMENT_TRACKER_CONTRACT_ID ||
+    process.env.STELLAR_RETIREMENT_TRACKER_CONTRACT_ID ||
+    RETIREMENT_TRACKER_CONTRACT_ID;
+
+  constructor(
+    private readonly prisma: PrismaService,
+    private readonly retirementTracker: RetirementTrackerService,
+    private readonly eventLogger: EventLoggerService,
+  ) {}
+
+  // ─────────────────────────────────────────────────────────────────────────
+  // Public API
+  // ─────────────────────────────────────────────────────────────────────────
+
+  /**
+   * Generate a SHA-256 audit hash and anchor it to the RetirementTracker contract.
+   *
+   * Returns an existing anchor record (idempotent) when a matching
+   * (tokenId, auditHash) pair already exists with status CONFIRMED.
+   * For FAILED records a fresh on-chain invocation is attempted.
+   */
+  async anchorHash(input: AnchorHashInput): Promise<AnchorHashResult> {
+    const auditHash = this.computeAuditHash(input.auditRecord);
+
+    // ── Idempotency check ────────────────────────────────────────────────
+    const existing = await this.prisma.retirementAuditHashAnchor.findUnique({
+      where: { tokenId_auditHash: { tokenId: input.tokenId, auditHash } },
+    });
+
+    if (existing && existing.anchorStatus === 'CONFIRMED') {
+      this.logger.log(
+        `Idempotent hit: tokenId=${input.tokenId} hash=${auditHash.slice(0, 12)}…`,
+      );
+      return this.toAnchorResult(existing, true);
+    }
+
+    // ── Create or reuse a PENDING/FAILED DB record ───────────────────────
+    let anchor: Awaited<ReturnType<typeof this.prisma.retirementAuditHashAnchor.create>>;
+
+    if (existing) {
+      // FAILED record — reset to PENDING for retry
+      anchor = await this.prisma.retirementAuditHashAnchor.update({
+        where: { id: existing.id },
+        data: {
+          anchorStatus: 'PENDING',
+          onChainTxHash: null,
+          metadata: null,
+        },
+      });
+    } else {
+      anchor = await this.prisma.retirementAuditHashAnchor.create({
+        data: {
+          companyId: input.companyId,
+          tokenId: input.tokenId,
+          auditEventId: input.auditEventId ?? null,
+          auditHash,
+          contractId: this.contractId,
+          anchorStatus: 'PENDING',
+        },
+      });
+    }
+
+    // ── On-chain invocation ──────────────────────────────────────────────
+    let onChainTxHash: string | null = null;
+    let finalStatus: AnchorStatus = 'PENDING';
+
+    try {
+      const result = await this.retirementTracker.invoke({
+        companyId: input.companyId,
+        methodName: 'anchor_audit_hash',
+        args: [
+          { type: 'u32', value: input.tokenId },
+          { type: 'string', value: auditHash },
+        ],
+      });
+
+      onChainTxHash = result.transactionHash ?? null;
+      finalStatus = result.status === 'CONFIRMED' ? 'CONFIRMED' : 'PENDING';
+
+      this.logger.log(
+        `Anchored hash for tokenId=${input.tokenId}: txHash=${onChainTxHash}, status=${finalStatus}`,
+      );
+    } catch (err) {
+      // ── Partial-failure handling ─────────────────────────────────────
+      // DB record exists; mark FAILED with error detail so callers / jobs
+      // can retry or escalate without losing the pending anchor record.
+      const errMsg = this.extractMessage(err);
+      this.logger.error(
+        `On-chain anchor failed for tokenId=${input.tokenId}: ${errMsg}`,
+      );
+      await this.prisma.retirementAuditHashAnchor.update({
+        where: { id: anchor.id },
+        data: {
+          anchorStatus: 'FAILED',
+          metadata: { error: errMsg, failedAt: new Date().toISOString() },
+        },
+      });
+
+      // Still log an audit event so the failed attempt is traceable.
+      await this.recordAuditEvent(input, auditHash, null, 'FAILED');
+
+      return this.toAnchorResult(
+        { ...anchor, anchorStatus: 'FAILED', onChainTxHash: null },
+        false,
+      );
+    }
+
+    // ── Persist the on-chain result ──────────────────────────────────────
+    const updated = await this.prisma.retirementAuditHashAnchor.update({
+      where: { id: anchor.id },
+      data: { onChainTxHash, anchorStatus: finalStatus },
+    });
+
+    // ── Companion audit event ────────────────────────────────────────────
+    await this.recordAuditEvent(input, auditHash, onChainTxHash, finalStatus);
+
+    return this.toAnchorResult(updated, false);
+  }
+
+  /**
+   * Verify the audit hash anchor for a given on-chain token ID.
+   *
+   * Returns the off-chain anchor record and the current on-chain retirement
+   * record. `txProofConfirmed` is true when the stored anchor exists and
+   * its Soroban transaction is confirmed — this is the cryptographic proof
+   * that the anchoring action was accepted on-chain.
+   *
+   * Note: the audit hash itself is NOT stored on-chain; the Soroban contract
+   * is queried for the retirement record to confirm the token exists, while
+   * the transaction hash in the anchor record constitutes the immutable proof.
+   */
+  async verifyHash(
+    companyId: string,
+    tokenId: number,
+  ): Promise<VerifyHashResult> {
+    const anchor = await this.prisma.retirementAuditHashAnchor.findFirst({
+      where: { companyId, tokenId },
+      orderBy: { anchoredAt: 'desc' },
+    });
+
+    if (!anchor) {
+      throw new NotFoundException(
+        `No audit hash anchor found for tokenId=${tokenId} in company ${companyId}`,
+      );
+    }
+
+    // Fetch the on-chain retirement record to prove the token exists.
+    let onChainRecord: Record<string, unknown> | null = null;
+    try {
+      onChainRecord = await this.retirementTracker.getRetirementRecord(
+        anchor.onChainTxHash ?? String(tokenId),
+      );
+    } catch (err) {
+      this.logger.warn(
+        `Could not retrieve on-chain record for tokenId=${tokenId}: ${this.extractMessage(err)}`,
+      );
+    }
+
+    const verifiedAt = new Date();
+    await this.prisma.retirementAuditHashAnchor.update({
+      where: { id: anchor.id },
+      data: { verifiedAt },
+    });
+
+    const txProofConfirmed =
+      anchor.anchorStatus === 'CONFIRMED' && anchor.onChainTxHash !== null;
+
+    return {
+      tokenId,
+      auditHash: anchor.auditHash,
+      onChainRecord,
+      txProofConfirmed,
+      onChainTxHash: anchor.onChainTxHash,
+      anchorStatus: anchor.anchorStatus,
+      anchorId: anchor.id,
+      verifiedAt: verifiedAt.toISOString(),
+    };
+  }
+
+  // ─────────────────────────────────────────────────────────────────────────
+  // Hashing — deterministic serialization
+  // ─────────────────────────────────────────────────────────────────────────
+
+  /**
+   * Compute SHA-256 of the audit record using a stable, deterministic
+   * serialization strategy: keys are sorted recursively at every nesting
+   * level before JSON encoding to eliminate insertion-order variance.
+   */
+  computeAuditHash(record: Record<string, unknown>): string {
+    const canonical = this.stableSerialize(record);
+    return createHash('sha256').update(canonical).digest('hex');
+  }
+
+  // ─────────────────────────────────────────────────────────────────────────
+  // Helpers
+  // ─────────────────────────────────────────────────────────────────────────
+
+  /**
+   * Recursively serialize a value into a deterministic string.
+   * Objects have their keys sorted; arrays preserve order (order is semantic
+   * in arrays).
+   */
+  private stableSerialize(value: unknown): string {
+    if (value === null || value === undefined) {
+      return JSON.stringify(null);
+    }
+
+    if (value instanceof Date) {
+      return JSON.stringify(value.toISOString());
+    }
+
+    if (Array.isArray(value)) {
+      const items = value.map((v) => this.stableSerialize(v)).join(',');
+      return `[${items}]`;
+    }
+
+    if (typeof value === 'object') {
+      const obj = value as Record<string, unknown>;
+      const sorted = Object.keys(obj)
+        .sort()
+        .map((k) => `${JSON.stringify(k)}:${this.stableSerialize(obj[k])}`)
+        .join(',');
+      return `{${sorted}}`;
+    }
+
+    return JSON.stringify(value);
+  }
+
+  private toAnchorResult(
+    anchor: {
+      id: string;
+      tokenId: number;
+      auditHash: string;
+      onChainTxHash?: string | null;
+      anchorStatus: string;
+      anchoredAt: Date;
+    },
+    idempotent: boolean,
+  ): AnchorHashResult {
+    return {
+      anchorId: anchor.id,
+      tokenId: anchor.tokenId,
+      auditHash: anchor.auditHash,
+      onChainTxHash: anchor.onChainTxHash ?? null,
+      idempotent,
+      anchorStatus: anchor.anchorStatus as AnchorStatus,
+      anchoredAt: anchor.anchoredAt.toISOString(),
+    };
+  }
+
+  private async recordAuditEvent(
+    input: AnchorHashInput,
+    auditHash: string,
+    txHash: string | null,
+    status: string,
+  ) {
+    try {
+      await this.eventLogger.recordEvent({
+        companyId: input.companyId,
+        userId: input.userId,
+        eventType: AuditEventType.RETIREMENT,
+        action: AuditAction.CREATE,
+        entityType: 'RetirementAuditHashAnchor',
+        entityId: String(input.tokenId),
+        newState: { auditHash, onChainTxHash: txHash, anchorStatus: status },
+        metadata: {
+          tokenId: input.tokenId,
+          contractId: this.contractId,
+          auditEventId: input.auditEventId,
+        },
+      });
+    } catch (err) {
+      // Log failure but do not propagate — audit-of-audit should never block anchoring.
+      this.logger.warn(`Companion audit event failed: ${this.extractMessage(err)}`);
+    }
+  }
+
+  private extractMessage(err: unknown): string {
+    if (err instanceof Error) return err.message;
+    try {
+      return JSON.stringify(err);
+    } catch {
+      return String(err);
+    }
+  }
+}

--- a/corporate-platform/corporate-platform-backend/src/rbac/constants/permissions.constants.ts
+++ b/corporate-platform/corporate-platform-backend/src/rbac/constants/permissions.constants.ts
@@ -40,6 +40,10 @@ export const SETTINGS_BILLING = 'settings:billing';
 export const ADMIN_USER_MANAGE = 'admin:user-manage';
 export const ADMIN_VIEW_AUDIT_LOGS = 'admin:view-audit-logs';
 
+/** Audit Hash: anchor and verify retirement audit hashes */
+export const AUDIT_HASH_ANCHOR = 'audit-hash:anchor';
+export const AUDIT_HASH_VERIFY = 'audit-hash:verify';
+
 /** All permissions (flat list) */
 export const ALL_PERMISSIONS = [
   PORTFOLIO_VIEW,
@@ -65,6 +69,8 @@ export const ALL_PERMISSIONS = [
   SETTINGS_BILLING,
   ADMIN_USER_MANAGE,
   ADMIN_VIEW_AUDIT_LOGS,
+  AUDIT_HASH_ANCHOR,
+  AUDIT_HASH_VERIFY,
 ] as const;
 
 export type Permission = (typeof ALL_PERMISSIONS)[number];
@@ -93,6 +99,7 @@ export const ROLE_PERMISSIONS: Record<Role, readonly Permission[]> = {
     REPORT_EXPORT,
     COMPLIANCE_VIEW,
     TEAM_VIEW,
+    AUDIT_HASH_VERIFY,
   ],
   manager: [
     PORTFOLIO_VIEW,
@@ -106,6 +113,8 @@ export const ROLE_PERMISSIONS: Record<Role, readonly Permission[]> = {
     COMPLIANCE_VIEW,
     COMPLIANCE_SUBMIT,
     TEAM_VIEW,
+    AUDIT_HASH_ANCHOR,
+    AUDIT_HASH_VERIFY,
   ],
   viewer: [
     PORTFOLIO_VIEW,
@@ -122,5 +131,7 @@ export const ROLE_PERMISSIONS: Record<Role, readonly Permission[]> = {
     COMPLIANCE_VIEW,
     COMPLIANCE_AUDIT,
     ADMIN_VIEW_AUDIT_LOGS,
+    AUDIT_HASH_ANCHOR,
+    AUDIT_HASH_VERIFY,
   ],
 };


### PR DESCRIPTION
Closes #236

---

This PR introduces audit hash anchoring for retirement records, generating SHA-256 hashes and linking them to on-chain transactions for tamper-proof auditability. It adds API endpoints for anchoring and verification, persists anchor data off-chain, and includes tests to ensure reliability and integrity across audit workflows.