### PR TITLE
refactor: normalize frontend auth token storage keys

### DIFF
--- a/corporate-platform/corporate-platform-web/src/components/retirement/RetirementCertificate.tsx
+++ b/corporate-platform/corporate-platform-web/src/components/retirement/RetirementCertificate.tsx
@@ -54,7 +54,7 @@ export default function RetirementCertificate({
     if (!record) return;
     const url = retirementService.getCertificateDownloadUrl(record.id);
     const token =
-      typeof window !== 'undefined' ? localStorage.getItem('accessToken') : null;
+      typeof window !== 'undefined' ? localStorage.getItem('cs_access_token') : null;
 
     const res = await fetch(url, {
       headers: token ? { Authorization: `Bearer ${token}` } : {},

--- a/corporate-platform/corporate-platform-web/src/lib/auth/token-storage.ts
+++ b/corporate-platform/corporate-platform-web/src/lib/auth/token-storage.ts
@@ -43,7 +43,23 @@ export function getAccessToken(): string | null {
   if (typeof window === 'undefined') return null;
   
   try {
-    return localStorage.getItem(ACCESS_TOKEN_KEY);
+    let token = localStorage.getItem(ACCESS_TOKEN_KEY);
+    
+    // Migration from legacy keys
+    if (!token) {
+      const legacyKeys = ['accessToken', 'access_token'];
+      for (const key of legacyKeys) {
+        const legacyToken = localStorage.getItem(key);
+        if (legacyToken) {
+          token = legacyToken;
+          localStorage.setItem(ACCESS_TOKEN_KEY, token);
+          legacyKeys.forEach(k => localStorage.removeItem(k));
+          break;
+        }
+      }
+    }
+    
+    return token;
   } catch (error) {
     console.error('Failed to get access token:', error);
     return null;

--- a/corporate-platform/corporate-platform-web/src/lib/teamApi.ts
+++ b/corporate-platform/corporate-platform-web/src/lib/teamApi.ts
@@ -19,7 +19,7 @@ const TEAM_BASE = `${BASE_URL}/api/v1/team`
 
 function getAuthHeaders(): HeadersInit {
   const token =
-    typeof window !== 'undefined' ? localStorage.getItem('access_token') : null
+    typeof window !== 'undefined' ? localStorage.getItem('cs_access_token') : null
   return {
     'Content-Type': 'application/json',
     ...(token ? { Authorization: `Bearer ${token}` } : {}),

--- a/corporate-platform/corporate-platform-web/src/services/api-client.ts
+++ b/corporate-platform/corporate-platform-web/src/services/api-client.ts
@@ -29,7 +29,7 @@ class ApiClient {
    */
   private getAuthToken(): string | null {
     if (typeof window !== 'undefined') {
-      return localStorage.getItem('accessToken');
+      return localStorage.getItem('cs_access_token');
     }
     return null;
   }

--- a/corporate-platform/corporate-platform-web/src/services/compliance.service.ts
+++ b/corporate-platform/corporate-platform-web/src/services/compliance.service.ts
@@ -55,7 +55,7 @@ class ComplianceService {
     try {
       const token =
         typeof window !== 'undefined'
-          ? localStorage.getItem('accessToken')
+          ? localStorage.getItem('cs_access_token')
           : null;
       const headers: HeadersInit = {
         Authorization: token ? `Bearer ${token}` : '',

--- a/corporate-platform/corporate-platform-web/src/services/ipfs.service.ts
+++ b/corporate-platform/corporate-platform-web/src/services/ipfs.service.ts
@@ -28,7 +28,7 @@ class IpfsService {
 
   private getAuthToken(): string | null {
     if (typeof window === 'undefined') return null;
-    return localStorage.getItem('accessToken');
+    return localStorage.getItem('cs_access_token');
   }
 
   async uploadDocument(

--- a/corporate-platform/corporate-platform-web/src/services/retirement.service.ts
+++ b/corporate-platform/corporate-platform-web/src/services/retirement.service.ts
@@ -138,7 +138,7 @@ class RetirementService {
   async exportCsv(): Promise<Blob | null> {
     const token =
       typeof window !== 'undefined'
-        ? localStorage.getItem('accessToken')
+        ? localStorage.getItem('cs_access_token')
         : null;
     const base =
       process.env.NEXT_PUBLIC_API_URL || 'http://localhost:3001/api/v1';


### PR DESCRIPTION
This PR standardizes the authentication token storage key across the frontend to eliminate confusion and reduce the risk of authentication bugs caused by inconsistent keys (accessToken, access_token, etc.).

Key changes:
- Set cs_access_token as the single canonical storage key for authentication tokens.
- Added an automatic migration step in token-storage.ts to seamlessly transition existing sessions.
- On first use, the utility checks for legacy keys, migrates the token to the new cs_access_token key, and purges the old legacy keys to prevent future conflicts.

This normalization prepares the codebase for more robust and consistent token management practices.

close #348