### PR TITLE
Implement replay-safe event sequencing for off-chain indexers

### DIFF
--- a/stellar-core/carbon-asset-factory/contracts/carbon_asset/README.md
+++ b/stellar-core/carbon-asset-factory/contracts/carbon_asset/README.md
@@ -23,9 +23,10 @@ The Carbon Asset contract is CarbonScribe's primary issuance and lifecycle engin
 4. [Initialization Parameters](#initialization-parameters)
 5. [Public Interface](#public-interface)
 6. [Dynamic Credit Readiness](#dynamic-credit-readiness)
-7. [Build and Test](#build-and-test)
-8. [Testnet Deployment](#testnet-deployment)
-9. [Security Notes](#security-notes)
+7. [Event Sequencing for Off-Chain Indexers](#event-sequencing-for-off-chain-indexers)
+8. [Build and Test](#build-and-test)
+9. [Testnet Deployment](#testnet-deployment)
+10. [Security Notes](#security-notes)
 
 ## System Role
 
@@ -151,6 +152,60 @@ The contract already includes on-chain quality score storage and oracle-authoriz
 1. Connect satellite and IoT oracle feeds to trusted updater identities.
 2. Define score-to-price policy in the marketplace layer.
 3. Version and audit oracle update policy via governance controls.
+
+## Event Sequencing for Off-Chain Indexers
+
+All events emitted by the Carbon Asset contract include a `sequence` field that provides replay-safe, monotonic ordering for off-chain indexers. This feature enables:
+
+- **Replay Protection**: Indexers can detect and reject duplicate events by tracking processed sequence numbers
+- **Deterministic Ordering**: Events can be ordered consistently across different indexer implementations
+- **Idempotent Processing**: Indexers can safely reprocess events without double-counting
+
+### How It Works
+
+The contract maintains an `EventSequence` counter in instance storage that:
+- Initializes to 0 on contract deployment
+- Increments by 1 for each event emission
+- Persists across contract upgrades
+- Is included in all event types: `MintEvent`, `TransferEvent`, `StatusChangeEvent`, `QualityScoreUpdatedEvent`, `ApproveEvent`, `Sep41TransferEvent`, and `Sep41BurnEvent`
+
+### Event Structure
+
+All events now include a `sequence: u64` field as the first parameter:
+
+```rust
+#[contractevent]
+pub struct MintEvent {
+    pub sequence: u64,
+    pub token_id: u32,
+    pub owner: Address,
+    pub project_id: String,
+    pub vintage_year: u64,
+    pub methodology_id: u32,
+}
+```
+
+### Indexer Integration
+
+Off-chain indexers should:
+1. Track the highest processed sequence number per contract instance
+2. Reject events with sequence numbers less than or equal to the last processed sequence
+3. Use the sequence field to order events when processing out-of-order blocks
+4. Store sequence numbers in their database to enable idempotent reprocessing
+
+### Example Indexer Logic
+
+```python
+last_sequence = get_last_processed_sequence(contract_address)
+
+for event in events:
+    if event.sequence <= last_sequence:
+        continue  # Skip already processed event
+    
+    process_event(event)
+    last_sequence = event.sequence
+    save_sequence(contract_address, last_sequence)
+```
 
 ## Build and Test
 

--- a/stellar-core/carbon-asset-factory/contracts/carbon_asset/src/events.rs
+++ b/stellar-core/carbon-asset-factory/contracts/carbon_asset/src/events.rs
@@ -4,6 +4,7 @@ use crate::types::AssetStatus;
 
 #[contractevent]
 pub struct MintEvent {
+    pub sequence: u64,
     pub token_id: u32,
     pub owner: Address,
     pub project_id: String,
@@ -13,6 +14,7 @@ pub struct MintEvent {
 
 #[contractevent]
 pub struct TransferEvent {
+    pub sequence: u64,
     pub token_id: u32,
     pub from: Address,
     pub to: Address,
@@ -20,6 +22,7 @@ pub struct TransferEvent {
 
 #[contractevent]
 pub struct StatusChangeEvent {
+    pub sequence: u64,
     pub token_id: u32,
     pub old_status: Option<AssetStatus>,
     pub new_status: AssetStatus,
@@ -28,6 +31,7 @@ pub struct StatusChangeEvent {
 
 #[contractevent]
 pub struct QualityScoreUpdatedEvent {
+    pub sequence: u64,
     pub token_id: u32,
     pub old_score: i128,
     pub new_score: i128,
@@ -37,6 +41,7 @@ pub struct QualityScoreUpdatedEvent {
 // SEP-41 style events
 #[contractevent]
 pub struct ApproveEvent {
+    pub sequence: u64,
     pub from: Address,
     pub spender: Address,
     pub amount: i128,
@@ -45,6 +50,7 @@ pub struct ApproveEvent {
 
 #[contractevent]
 pub struct Sep41TransferEvent {
+    pub sequence: u64,
     pub from: Address,
     pub to: Address,
     pub amount: i128,
@@ -52,6 +58,7 @@ pub struct Sep41TransferEvent {
 
 #[contractevent]
 pub struct Sep41BurnEvent {
+    pub sequence: u64,
     pub from: Address,
     pub amount: i128,
 }

--- a/stellar-core/carbon-asset-factory/contracts/carbon_asset/src/lib.rs
+++ b/stellar-core/carbon-asset-factory/contracts/carbon_asset/src/lib.rs
@@ -55,6 +55,7 @@ impl CarbonAsset {
             .instance()
             .set(&DataKey::HostJurisdiction, &host_jurisdiction);
         env.storage().instance().set(&DataKey::NextTokenId, &1u32);
+        env.storage().instance().set(&DataKey::EventSequence, &0u64);
 
         Ok(())
     }
@@ -102,7 +103,17 @@ impl CarbonAsset {
             .persistent()
             .set(&DataKey::Burned(token_id), &false);
 
+        let sequence: u64 = env
+            .storage()
+            .instance()
+            .get(&DataKey::EventSequence)
+            .unwrap_or(0u64);
+        let mint_sequence = sequence + 1;
+        env.storage()
+            .instance()
+            .set(&DataKey::EventSequence, &mint_sequence);
         MintEvent {
+            sequence: mint_sequence,
             token_id,
             owner: owner.clone(),
             project_id: metadata.project_id.clone(),
@@ -111,7 +122,17 @@ impl CarbonAsset {
         }
         .publish(&env);
 
+        let sequence: u64 = env
+            .storage()
+            .instance()
+            .get(&DataKey::EventSequence)
+            .unwrap_or(0u64);
+        let status_sequence = sequence + 1;
+        env.storage()
+            .instance()
+            .set(&DataKey::EventSequence, &status_sequence);
         StatusChangeEvent {
+            sequence: status_sequence,
             token_id,
             old_status: None,
             new_status: AssetStatus::Issued,
@@ -160,7 +181,17 @@ impl CarbonAsset {
         };
         env.storage().persistent().set(&key, &data);
 
+        let sequence: u64 = env
+            .storage()
+            .instance()
+            .get(&DataKey::EventSequence)
+            .unwrap_or(0u64);
+        let next_sequence = sequence + 1;
+        env.storage()
+            .instance()
+            .set(&DataKey::EventSequence, &next_sequence);
         ApproveEvent {
+            sequence: next_sequence,
             from,
             spender,
             amount,
@@ -386,7 +417,17 @@ impl CarbonAsset {
             .persistent()
             .set(&DataKey::QualityScore(token_id), &new_score);
 
+        let sequence: u64 = env
+            .storage()
+            .instance()
+            .get(&DataKey::EventSequence)
+            .unwrap_or(0u64);
+        let next_sequence = sequence + 1;
+        env.storage()
+            .instance()
+            .set(&DataKey::EventSequence, &next_sequence);
         QualityScoreUpdatedEvent {
+            sequence: next_sequence,
             token_id,
             old_score,
             new_score,
@@ -517,6 +558,13 @@ impl CarbonAsset {
         env.storage().instance().get(&DataKey::Oracle)
     }
 
+    pub fn get_event_sequence(env: Env) -> u64 {
+        env.storage()
+            .instance()
+            .get(&DataKey::EventSequence)
+            .unwrap_or(0u64)
+    }
+
     pub fn owner_of(env: Env, token_id: u32) -> Result<Address, ContractError> {
         let burned: bool = env
             .storage()
@@ -614,7 +662,17 @@ impl CarbonAsset {
             .persistent()
             .set(&DataKey::Owner(token_id), &to);
 
+        let sequence: u64 = env
+            .storage()
+            .instance()
+            .get(&DataKey::EventSequence)
+            .unwrap_or(0u64);
+        let next_sequence = sequence + 1;
+        env.storage()
+            .instance()
+            .set(&DataKey::EventSequence, &next_sequence);
         TransferEvent {
+            sequence: next_sequence,
             token_id,
             from: from.clone(),
             to: to.clone(),
@@ -645,7 +703,16 @@ impl CarbonAsset {
             Self::transfer_token_internal(env.clone(), from.clone(), to.clone(), token_id, false)?;
         }
 
-        Sep41TransferEvent { from, to, amount }.publish(&env);
+        let sequence: u64 = env
+            .storage()
+            .instance()
+            .get(&DataKey::EventSequence)
+            .unwrap_or(0u64);
+        let next_sequence = sequence + 1;
+        env.storage()
+            .instance()
+            .set(&DataKey::EventSequence, &next_sequence);
+        Sep41TransferEvent { sequence: next_sequence, from, to, amount }.publish(&env);
 
         Ok(())
     }
@@ -665,7 +732,16 @@ impl CarbonAsset {
             Self::burn_token(env.clone(), token_id, from.clone())?;
         }
 
-        Sep41BurnEvent { from, amount }.publish(&env);
+        let sequence: u64 = env
+            .storage()
+            .instance()
+            .get(&DataKey::EventSequence)
+            .unwrap_or(0u64);
+        let next_sequence = sequence + 1;
+        env.storage()
+            .instance()
+            .set(&DataKey::EventSequence, &next_sequence);
+        Sep41BurnEvent { sequence: next_sequence, from, amount }.publish(&env);
 
         Ok(())
     }
@@ -757,7 +833,17 @@ impl CarbonAsset {
             .persistent()
             .set(&DataKey::Status(token_id), &new_status);
 
+        let sequence: u64 = env
+            .storage()
+            .instance()
+            .get(&DataKey::EventSequence)
+            .unwrap_or(0u64);
+        let next_sequence = sequence + 1;
+        env.storage()
+            .instance()
+            .set(&DataKey::EventSequence, &next_sequence);
         StatusChangeEvent {
+            sequence: next_sequence,
             token_id,
             old_status: Some(current),
             new_status,

--- a/stellar-core/carbon-asset-factory/contracts/carbon_asset/src/storage.rs
+++ b/stellar-core/carbon-asset-factory/contracts/carbon_asset/src/storage.rs
@@ -8,6 +8,7 @@ pub enum DataKey {
     Symbol,
     Decimals,
     NextTokenId,
+    EventSequence,
     RetirementTracker,
     RegulatoryCheck,
     HostJurisdiction,

--- a/stellar-core/carbon-asset-factory/contracts/carbon_asset/src/test.rs
+++ b/stellar-core/carbon-asset-factory/contracts/carbon_asset/src/test.rs
@@ -109,3 +109,31 @@ fn test_transfer_to_retirement_tracker_sets_status() {
     client.transfer(&owner, &retirement_tracker, &1);
     assert_eq!(client.get_status(&token_id), AssetStatus::Retired);
 }
+
+#[test]
+fn test_event_sequence_persistence_in_storage() {
+    let (env, admin, retirement_tracker, owner) = setup_env();
+    let contract_id = env.register(CarbonAsset, ());
+    let client = CarbonAssetClient::new(&env, &contract_id);
+
+    client.initialize(
+        &admin,
+        &String::from_str(&env, "Carbon Asset"),
+        &String::from_str(&env, "C01"),
+        &retirement_tracker,
+        &String::from_str(&env, "US"),
+    );
+
+    let meta = CarbonAssetMetadata {
+        project_id: String::from_str(&env, "PROJ-1"),
+        vintage_year: 1704067200,
+        methodology_id: 1,
+        geo_hash: BytesN::from_array(&env, &[7u8; 32]),
+    };
+
+    client.mint(&admin, &owner, &meta);
+
+    // Check sequence incremented to 2 (MintEvent + StatusChangeEvent)
+    let sequence = client.get_event_sequence();
+    assert_eq!(sequence, 2);
+}


### PR DESCRIPTION
Closes #306

---

- Add EventSequence storage key in instance storage
- Add sequence field to all event structs (MintEvent, TransferEvent, StatusChangeEvent, QualityScoreUpdatedEvent, ApproveEvent, Sep41TransferEvent, Sep41BurnEvent)
- Initialize sequence counter to 0 in initialize() function
- Inline sequence increment logic in all event emissions
- Add public get_event_sequence() getter function
- Add unit test for sequence persistence
- Update README with indexer integration documentation