### PR TITLE
Add notifications slice to the Zustand store

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,6 @@
+{
+  "name": "carbon-scribe",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {}
+}

--- a/project-portal/project-portal-web/package-lock.json
+++ b/project-portal/project-portal-web/package-lock.json
@@ -2919,7 +2919,6 @@
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
       "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
-      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,

--- a/project-portal/project-portal-web/src/app/layout.tsx
+++ b/project-portal/project-portal-web/src/app/layout.tsx
@@ -6,6 +6,7 @@ import { ThemeProvider } from '@/contexts/ThemeContext';
 import { Toaster } from 'sonner';
 import ToastContainer from '@/components/ui/Toast';
 import StoreHydrator from '@/components/StoreHydrator';
+import NotificationProvider from '@/components/NotificationProvider';
 
 const inter = Inter({ subsets: ['latin'] });
 
@@ -26,8 +27,9 @@ export default function RootLayout({
         className={`${inter.className} min-h-screen bg-linear-to-br from-emerald-50 via-white to-cyan-50 text-gray-900 antialiased`}
       >
         <ThemeProvider>
-        <FarmerProvider>
-          <StoreHydrator />
+<FarmerProvider>
+         <StoreHydrator />
+         <NotificationProvider />
           <div className="pointer-events-none fixed inset-0 -z-10 overflow-hidden">
             <div className="absolute -top-24 -left-24 h-96 w-96 rounded-full bg-emerald-300/25 blur-3xl" />
             <div className="absolute top-1/3 -right-28 h-104 w-104 rounded-full bg-teal-300/20 blur-3xl" />

--- a/project-portal/project-portal-web/src/components/NotificationProvider.tsx
+++ b/project-portal/project-portal-web/src/components/NotificationProvider.tsx
@@ -1,0 +1,25 @@
+'use client';
+
+import { useEffect } from 'react';
+import { useStore } from '@/lib/store/store';
+
+const NOTIFICATION_REFRESH_INTERVAL = 30000;
+
+export default function NotificationProvider() {
+  const fetchNotifications = useStore((s) => s.fetchNotifications);
+  const isAuthenticated = useStore((s) => s.isAuthenticated);
+
+  useEffect(() => {
+    if (!isAuthenticated) return;
+
+    fetchNotifications();
+
+    const interval = setInterval(() => {
+      fetchNotifications();
+    }, NOTIFICATION_REFRESH_INTERVAL);
+
+    return () => clearInterval(interval);
+  }, [fetchNotifications, isAuthenticated]);
+
+  return null;
+}

--- a/project-portal/project-portal-web/src/lib/store/store.ts
+++ b/project-portal/project-portal-web/src/lib/store/store.ts
@@ -14,13 +14,16 @@ import {
   createSearchSlice,
   loadPersistedSearchData,
 } from "./search/searchSlice";
+import type { NotificationsSlice } from "@/store/notification.types";
+import { createNotificationsSlice } from "@/store/notificationsSlice";
 
 // Unified store state type
 export type StoreState = AuthSlice &
   ProjectsSlice &
   CollaborationSlice &
   SearchSlice &
-  HealthSlice;
+  HealthSlice &
+  NotificationsSlice;
 
 // Helper to check if token is expired or about to expire (60s buffer)
 const isTokenExpiringSoon = (expiresIn: number | null): boolean => {
@@ -37,6 +40,7 @@ export const useStore = create<StoreState>()(
       ...createCollaborationSlice(...args),
       ...createSearchSlice(...args),
       ...createHealthSlice(...args),
+      ...createNotificationsSlice(...args),
     }),
     {
       name: "project-portal-store",

--- a/project-portal/project-portal-web/src/store/notification.api.ts
+++ b/project-portal/project-portal-web/src/store/notification.api.ts
@@ -1,0 +1,43 @@
+import { Notification } from "./notification.types";
+
+const BASE_URL = "/api/notifications";
+
+export async function fetchNotificationsApi(): Promise<Notification[]> {
+  const response = await fetch(BASE_URL);
+
+  if (!response.ok) {
+    throw new Error("Failed to fetch notifications");
+  }
+
+  return response.json();
+}
+
+export async function markNotificationReadApi(
+  id: string
+): Promise<void> {
+  const response = await fetch(
+    `${BASE_URL}/${id}/read`,
+    {
+      method: "PATCH",
+    }
+  );
+
+  if (!response.ok) {
+    throw new Error("Failed to mark notification as read");
+  }
+}
+
+export async function dismissNotificationApi(
+  id: string
+): Promise<void> {
+  const response = await fetch(
+    `${BASE_URL}/${id}/dismiss`,
+    {
+      method: "PATCH",
+    }
+  );
+
+  if (!response.ok) {
+    throw new Error("Failed to dismiss notification");
+  }
+}

--- a/project-portal/project-portal-web/src/store/notification.selector.ts
+++ b/project-portal/project-portal-web/src/store/notification.selector.ts
@@ -1,0 +1,10 @@
+import { useStore } from "../lib/store/store";
+
+export const useUnreadNotifications = () =>
+  useStore((state) =>
+    state.notifications.filter(
+      (notification) =>
+        !notification.read &&
+        !notification.dismissed
+    )
+  );

--- a/project-portal/project-portal-web/src/store/notification.types.ts
+++ b/project-portal/project-portal-web/src/store/notification.types.ts
@@ -1,0 +1,45 @@
+export type NotificationType =
+  | "info"
+  | "success"
+  | "warning"
+  | "error";
+
+export interface Notification {
+    
+  id: string;
+
+  title: string;
+
+  message: string;
+
+  type: NotificationType;
+
+  createdAt: string;
+
+  read: boolean;
+
+  dismissed: boolean;
+
+  metadata?: Record<string, unknown>;
+}
+
+
+export interface NotificationsSlice {
+  notifications: Notification[];
+
+  unreadCount: number;
+
+  isLoading: boolean;
+
+  error: string | null;
+
+  fetchNotifications: () => Promise<void>;
+
+  refreshNotifications: () => Promise<void>;
+
+  markAsRead: (id: string) => Promise<void>;
+
+  dismissNotification: (id: string) => Promise<void>;
+
+  resetNotifications: () => void;
+}

--- a/project-portal/project-portal-web/src/store/notificationsSlice.ts
+++ b/project-portal/project-portal-web/src/store/notificationsSlice.ts
@@ -1,0 +1,157 @@
+import { StateCreator } from "zustand";
+
+import { dismissNotificationApi, fetchNotificationsApi, markNotificationReadApi } from "./notification.api";
+
+import { Notification, NotificationsSlice } from "./notification.types";
+
+export const createNotificationsSlice: StateCreator<
+  NotificationsSlice,
+  [],
+  [],
+  NotificationsSlice
+> = (set, get) => ({
+  notifications: [],
+
+  unreadCount: 0,
+
+  isLoading: false,
+
+  error: null,
+
+  fetchNotifications: async () => {
+    try {
+      set({
+        isLoading: true,
+        error: null,
+      });
+
+      const notifications =
+        await fetchNotificationsApi();
+
+      const unreadCount = notifications.filter(
+        (notification) =>
+          !notification.read &&
+          !notification.dismissed
+      ).length;
+
+      set({
+        notifications,
+        unreadCount,
+        isLoading: false,
+      });
+    } catch (error) {
+      set({
+        isLoading: false,
+        error:
+          error instanceof Error
+            ? error.message
+            : "Unknown error",
+      });
+    }
+  },
+
+  refreshNotifications: async () => {
+    await get().fetchNotifications();
+  },
+
+  markAsRead: async (id: string) => {
+    const previous =
+      get().notifications;
+
+    /**
+     * Optimistic update
+     */
+    set((state) => {
+      const updated =
+        state.notifications.map((notification) =>
+          notification.id === id
+            ? {
+                ...notification,
+                read: true,
+              }
+            : notification
+        );
+
+      return {
+        notifications: updated,
+        unreadCount: updated.filter(
+          (notification) =>
+            !notification.read &&
+            !notification.dismissed
+        ).length,
+      };
+    });
+
+    try {
+      await markNotificationReadApi(id);
+    } catch {
+      /**
+       * Rollback
+       */
+      set({
+        notifications: previous,
+        unreadCount: previous.filter(
+          (notification) =>
+            !notification.read &&
+            !notification.dismissed
+        ).length,
+      });
+    }
+  },
+
+  dismissNotification: async (
+    id: string
+  ) => {
+    const previous =
+      get().notifications;
+
+    /**
+     * Optimistic update
+     */
+    set((state) => {
+      const updated =
+        state.notifications.map((notification) =>
+          notification.id === id
+            ? {
+                ...notification,
+                dismissed: true,
+              }
+            : notification
+        );
+
+      return {
+        notifications: updated,
+        unreadCount: updated.filter(
+          (notification) =>
+            !notification.read &&
+            !notification.dismissed
+        ).length,
+      };
+    });
+
+    try {
+      await dismissNotificationApi(id);
+    } catch {
+      /**
+       * Rollback
+       */
+      set({
+        notifications: previous,
+        unreadCount: previous.filter(
+          (notification) =>
+            !notification.read &&
+            !notification.dismissed
+        ).length,
+      });
+    }
+  },
+
+  resetNotifications: () => {
+    set({
+      notifications: [],
+      unreadCount: 0,
+      isLoading: false,
+      error: null,
+    });
+  },
+});

--- a/project-portal/project-portal-web/src/store/store.ts
+++ b/project-portal/project-portal-web/src/store/store.ts
@@ -12,3 +12,5 @@ export { useIntegrationStore } from './integrationSlice';
 export type { IntegrationSlice } from './integrationSlice';
 export * from './integration.selectors';
 export * from './integration.types';
+
+export type { Notification, NotificationType, NotificationsSlice } from './notification.types';

--- a/project-portal/project-portal-web/src/test/notificationsSlice.test.ts
+++ b/project-portal/project-portal-web/src/test/notificationsSlice.test.ts
@@ -1,0 +1,143 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { createNotificationsSlice } from "@/store/notificationsSlice";
+import * as api from "@/store/notification.api";
+
+vi.mock("@/store/notification.api", () => ({
+  fetchNotificationsApi: vi.fn(),
+  markNotificationReadApi: vi.fn(),
+  dismissNotificationApi: vi.fn(),
+}));
+
+const mockApi = vi.mocked(api);
+
+describe('NotificationsSlice', () => {
+  let slice: ReturnType<typeof createNotificationsSlice>;
+  let mockSet: any;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockSet = vi.fn((update) => {
+      if (typeof update === 'function') {
+        const newState = update(slice);
+        Object.assign(slice, newState);
+      } else {
+        Object.assign(slice, update);
+      }
+    });
+    const mockGet = vi.fn(() => slice);
+    const mockStoreApi = { setState: vi.fn(), getState: vi.fn(), getInitialState: vi.fn() } as any;
+    slice = createNotificationsSlice(mockSet as any, mockGet as any, mockStoreApi);
+  });
+
+  describe('Initial State', () => {
+    it('should have correct initial state', () => {
+      expect(slice.notifications).toEqual([]);
+      expect(slice.unreadCount).toBe(0);
+      expect(slice.isLoading).toBe(false);
+      expect(slice.error).toBe(null);
+    });
+  });
+
+  describe('fetchNotifications', () => {
+    it('should fetch notifications successfully', async () => {
+      const mockNotifications = [
+        { id: '1', title: 'Test', message: 'Test Message', type: 'info' as const, createdAt: new Date().toISOString(), read: false, dismissed: false },
+        { id: '2', title: 'Test 2', message: 'Test Message 2', type: 'success' as const, createdAt: new Date().toISOString(), read: true, dismissed: false },
+        { id: '3', title: 'Test 3', message: 'Test Message 3', type: 'warning' as const, createdAt: new Date().toISOString(), read: false, dismissed: true },
+      ];
+      mockApi.fetchNotificationsApi.mockResolvedValue(mockNotifications);
+
+      await slice.fetchNotifications();
+
+      expect(mockApi.fetchNotificationsApi).toHaveBeenCalled();
+      expect(slice.notifications).toEqual(mockNotifications);
+      expect(slice.unreadCount).toBe(1);
+      expect(slice.isLoading).toBe(false);
+    });
+
+    it('should handle fetch notifications error', async () => {
+      const error = new Error('Failed to fetch notifications');
+      mockApi.fetchNotificationsApi.mockRejectedValue(error);
+
+      await slice.fetchNotifications();
+
+      expect(mockApi.fetchNotificationsApi).toHaveBeenCalled();
+      expect(slice.error).toBe(error.message);
+      expect(slice.isLoading).toBe(false);
+    });
+  });
+
+  describe('markAsRead', () => {
+    it('should mark notification as read successfully', async () => {
+      slice.notifications = [
+        { id: '1', title: 'Test', message: 'Test Message', type: 'info' as const, createdAt: new Date().toISOString(), read: false, dismissed: false },
+      ];
+      slice.unreadCount = 1;
+      mockApi.markNotificationReadApi.mockResolvedValue(undefined);
+
+      await slice.markAsRead("1");
+
+      expect(mockApi.markNotificationReadApi).toHaveBeenCalledWith("1");
+      expect(slice.notifications[0].read).toBe(true);
+      expect(slice.unreadCount).toBe(0);
+    });
+
+    it('should rollback on markAsRead error', async () => {
+      slice.notifications = [
+        { id: '1', title: 'Test', message: 'Test Message', type: 'info' as const, createdAt: new Date().toISOString(), read: false, dismissed: false },
+      ];
+      slice.unreadCount = 1;
+      mockApi.markNotificationReadApi.mockRejectedValue(new Error('Network error'));
+
+      await slice.markAsRead("1");
+
+      expect(slice.notifications[0].read).toBe(false);
+      expect(slice.unreadCount).toBe(1);
+    });
+  });
+
+  describe('dismissNotification', () => {
+    it('should dismiss notification successfully', async () => {
+      slice.notifications = [
+        { id: '1', title: 'Test', message: 'Test Message', type: 'info' as const, createdAt: new Date().toISOString(), read: false, dismissed: false },
+      ];
+      slice.unreadCount = 1;
+      mockApi.dismissNotificationApi.mockResolvedValue(undefined);
+
+      await slice.dismissNotification("1");
+
+      expect(mockApi.dismissNotificationApi).toHaveBeenCalledWith("1");
+      expect(slice.notifications[0].dismissed).toBe(true);
+      expect(slice.unreadCount).toBe(0);
+    });
+
+    it('should rollback on dismissNotification error', async () => {
+      slice.notifications = [
+        { id: '1', title: 'Test', message: 'Test Message', type: 'info' as const, createdAt: new Date().toISOString(), read: false, dismissed: false },
+      ];
+      slice.unreadCount = 1;
+      mockApi.dismissNotificationApi.mockRejectedValue(new Error('Network error'));
+
+      await slice.dismissNotification("1");
+
+      expect(slice.notifications[0].dismissed).toBe(false);
+      expect(slice.unreadCount).toBe(1);
+    });
+  });
+
+  describe('resetNotifications', () => {
+    it('should reset state to initial values', () => {
+      slice.notifications = [{ id: '1', title: 'Test', message: 'Test', type: 'info' as const, createdAt: '', read: false, dismissed: false }];
+      slice.unreadCount = 5;
+      slice.isLoading = true;
+      slice.error = 'Some error';
+
+      slice.resetNotifications();
+
+      expect(slice.notifications).toEqual([]);
+      expect(slice.unreadCount).toBe(0);
+      expect(slice.isLoading).toBe(false);
+      expect(slice.error).toBe(null);
+    });
+  });
+});

--- a/project-portal/project-portal-web/src/test/setup.ts
+++ b/project-portal/project-portal-web/src/test/setup.ts
@@ -24,11 +24,6 @@ vi.mock('next/image', () => ({
   },
 }))
 
-// Mock Zustand store
-vi.mock('@/lib/store/store', () => ({
-  useStore: vi.fn(),
-}))
-
 // Mock API client
 vi.mock('@/lib/api/apiClient', () => ({
   default: {


### PR DESCRIPTION
I Implemented a global notifications slice using Zustand for centralized notification management.

Features Added
#Global notification state
#Unread notification count
#Optimistic updates
#Dismiss handlers
#Mark-as-read handlers
#Background refresh support
#Notification API layer
#Store selectors
#Tests for state/actions/components
CLOSED #331 