### PR TITLE
Replace Synthetic Retirement Tx Hashes with Event Nonce Fallback

### DIFF
--- a/stellar-core/carbon-asset-factory/contracts/retirement_tracker/Cargo.toml
+++ b/stellar-core/carbon-asset-factory/contracts/retirement_tracker/Cargo.toml
@@ -10,5 +10,8 @@ crate-type = ["cdylib", "rlib"]
 [dependencies]
 soroban-sdk = { workspace = true }
 
+[dev-dependencies]
+soroban-sdk = { workspace = true, features = ["testutils"] }
+
 [features]
 testutils = ["soroban-sdk/testutils"]

--- a/stellar-core/carbon-asset-factory/contracts/retirement_tracker/README.md
+++ b/stellar-core/carbon-asset-factory/contracts/retirement_tracker/README.md
@@ -13,7 +13,7 @@ The Retirement Tracker contract is CarbonScribe's finality layer for carbon offs
 - Immutable retirement records per token id
 - Entity-based retirement indexing for reporting
 - Linked contract governance for upgradeable asset references
-- Event emission for real-time compliance pipelines
+- Event emission with contract-scoped nonces for real-time compliance pipelines
 
 ## Table of Contents
 
@@ -85,11 +85,15 @@ initialize(env, admin, carbon_asset_contract)
 
 ```rust
 retire(env, token_id, retiring_entity, reason)
+retire_with_tx_hash(env, token_id, retiring_entity, reason, tx_hash)
 batch_retire(env, token_ids, retiring_entity, reason)
+batch_retire_with_tx_hashes(env, token_ids, retiring_entity, reason, tx_hashes)
 ```
 
-- `retire`: executes one retirement and returns the created record
-- `batch_retire`: attempts each token and returns only successful retirements
+- `retire`: executes one retirement with nonce fallback and returns the created record
+- `retire_with_tx_hash`: executes one retirement with a caller-supplied actual transaction hash
+- `batch_retire`: attempts each token with nonce fallback and returns only successful retirements
+- `batch_retire_with_tx_hashes`: attempts each token with caller-supplied transaction hashes
 
 ### Ledger Queries
 
@@ -97,6 +101,7 @@ batch_retire(env, token_ids, retiring_entity, reason)
 is_retired(env, token_id)
 get_retirement_record(env, token_id)
 get_retirements_by_entity(env, retiring_entity)
+get_event_nonce(env)
 ```
 
 ### Admin Controls
@@ -114,10 +119,17 @@ Each `RetirementRecord` stores:
 - token id
 - retiring entity address
 - ledger timestamp
-- derived transaction hash
+- actual transaction hash when supplied
+- contract-scoped event nonce
 - optional reason string for reporting context
 
 This schema supports corporate disclosures, anti-double-counting checks, and public retirement proof.
+
+## Event Uniqueness
+
+The contract does not synthesize transaction hashes. When an integration has the actual transaction hash, it should call `retire_with_tx_hash` or `batch_retire_with_tx_hashes`. Otherwise, the contract records `tx_hash: None` and assigns a strictly increasing `event_nonce`.
+
+`event_nonce` is stored in instance storage, increments only for successful retirement writes, and is included in both retirement records and retirement events. Off-chain indexers can use it for deterministic ordering and replay-safe uniqueness.
 
 ## Build and Test
 

--- a/stellar-core/carbon-asset-factory/contracts/retirement_tracker/src/lib.rs
+++ b/stellar-core/carbon-asset-factory/contracts/retirement_tracker/src/lib.rs
@@ -1,7 +1,7 @@
 #![no_std]
 use soroban_sdk::{
-    contract, contracterror, contractevent, contractimpl, contracttype, Address, Bytes, BytesN,
-    Env, IntoVal, String, Symbol, Vec,
+    contract, contracterror, contractevent, contractimpl, contracttype, Address, BytesN, Env,
+    IntoVal, String, Symbol, Vec,
 };
 
 // ========================================================================
@@ -12,11 +12,12 @@ use soroban_sdk::{
 #[derive(Clone)]
 #[contracttype]
 pub struct RetirementRecord {
-    pub token_id: u32,            // ID of the retired CarbonAsset
-    pub retiring_entity: Address, // Stellar account who retired the credit
-    pub timestamp: u64,           // Ledger timestamp of retirement
-    pub tx_hash: BytesN<32>,      // Hash of the retirement transaction
-    pub reason: Option<String>,   // Optional field for corporate reporting
+    pub token_id: u32,               // ID of the retired CarbonAsset
+    pub retiring_entity: Address,    // Stellar account who retired the credit
+    pub timestamp: u64,              // Ledger timestamp of retirement
+    pub tx_hash: Option<BytesN<32>>, // Actual transaction hash when supplied by the caller
+    pub event_nonce: u64,            // Contract-scoped unique event sequence
+    pub reason: Option<String>,      // Optional field for corporate reporting
 }
 
 /// Storage keys for the contract
@@ -25,6 +26,7 @@ pub struct RetirementRecord {
 pub enum DataKey {
     Admin,
     CarbonAssetContract,
+    EventNonce,
     RetirementLedger(u32), // token_id -> RetirementRecord
     EntityIndex(Address),  // retiring_entity -> Vec<u32>
 }
@@ -42,6 +44,7 @@ pub enum ContractError {
     InvalidTokenId = 4,
     BurnFailed = 5,
     ContractNotInitialized = 6,
+    EventNonceOverflow = 7,
 }
 
 // ========================================================================
@@ -53,7 +56,8 @@ pub struct RetirementEvent {
     pub token_id: u32,
     pub retiring_entity: Address,
     pub timestamp: u64,
-    pub tx_hash: BytesN<32>,
+    pub tx_hash: Option<BytesN<32>>,
+    pub event_nonce: u64,
 }
 
 #[contractevent]
@@ -89,6 +93,7 @@ impl RetirementTracker {
         env.storage()
             .instance()
             .set(&DataKey::CarbonAssetContract, &carbon_asset_contract);
+        env.storage().instance().set(&DataKey::EventNonce, &0u64);
     }
 
     /// Retire a single carbon credit token
@@ -111,9 +116,30 @@ impl RetirementTracker {
         retiring_entity: Address,
         reason: Option<String>,
     ) -> Result<RetirementRecord, ContractError> {
-        // Verify caller is authenticated
         retiring_entity.require_auth();
+        Self::retire_internal(env, token_id, retiring_entity, reason, None)
+    }
 
+    /// Retire a single carbon credit token with the actual transaction hash
+    /// supplied by the caller or integration layer.
+    pub fn retire_with_tx_hash(
+        env: Env,
+        token_id: u32,
+        retiring_entity: Address,
+        reason: Option<String>,
+        tx_hash: BytesN<32>,
+    ) -> Result<RetirementRecord, ContractError> {
+        retiring_entity.require_auth();
+        Self::retire_internal(env, token_id, retiring_entity, reason, Some(tx_hash))
+    }
+
+    fn retire_internal(
+        env: Env,
+        token_id: u32,
+        retiring_entity: Address,
+        reason: Option<String>,
+        tx_hash: Option<BytesN<32>>,
+    ) -> Result<RetirementRecord, ContractError> {
         // Check if token is already retired
         let ledger_key = DataKey::RetirementLedger(token_id);
         if env.storage().persistent().has(&ledger_key) {
@@ -130,23 +156,6 @@ impl RetirementTracker {
         // Get current timestamp
         let timestamp = env.ledger().timestamp();
 
-        // Generate a unique transaction hash from current ledger state
-        // This combines ledger sequence, timestamp, and token_id for uniqueness
-        // Note: In production, you might want to pass the actual transaction hash as a parameter
-        // For now, we create a deterministic hash from available ledger data
-        let ledger_seq = env.ledger().sequence();
-
-        // Create hash input from components as a byte array
-        // We'll manually construct bytes from token_id, timestamp, and ledger_seq
-        let mut hash_bytes = [0u8; 20];
-        hash_bytes[0..4].copy_from_slice(&token_id.to_be_bytes());
-        hash_bytes[4..12].copy_from_slice(&timestamp.to_be_bytes());
-        hash_bytes[12..20].copy_from_slice(&ledger_seq.to_be_bytes());
-
-        let hash_input = Bytes::from_array(&env, &hash_bytes);
-        let hash = env.crypto().sha256(&hash_input);
-        let tx_hash = BytesN::from_array(&env, &hash.to_array());
-
         // Call burn_token on CarbonAsset contract
         // The contract must be pre-authorized as a burner on the CarbonAsset contract
         // We assume CarbonAsset has a burn_token function that accepts (token_id: u32, from: Address)
@@ -157,12 +166,15 @@ impl RetirementTracker {
         burn_args.push_back(retiring_entity.clone().into_val(&env));
         env.invoke_contract::<()>(&carbon_asset_contract, &burn_symbol, burn_args);
 
+        let event_nonce = Self::next_event_nonce(&env)?;
+
         // Create retirement record
         let record = RetirementRecord {
             token_id,
             retiring_entity: retiring_entity.clone(),
             timestamp,
             tx_hash: tx_hash.clone(),
+            event_nonce,
             reason: reason.clone(),
         };
 
@@ -187,6 +199,7 @@ impl RetirementTracker {
             retiring_entity: retiring_entity.clone(),
             timestamp,
             tx_hash,
+            event_nonce,
         }
         .publish(&env);
         Ok(record)
@@ -219,11 +232,47 @@ impl RetirementTracker {
 
             // Attempt to retire each token
             // Continue even if one fails
-            if let Ok(record) = Self::retire(
+            if let Ok(record) = Self::retire_internal(
                 env.clone(),
                 token_id,
                 retiring_entity.clone(),
                 reason.clone(),
+                None,
+            ) {
+                results.push_back(record);
+            }
+        }
+
+        results
+    }
+
+    /// Retire multiple carbon credit tokens with caller-supplied transaction
+    /// hashes. Each successful retirement receives its own event nonce.
+    pub fn batch_retire_with_tx_hashes(
+        env: Env,
+        token_ids: Vec<u32>,
+        retiring_entity: Address,
+        reason: Option<String>,
+        tx_hashes: Vec<BytesN<32>>,
+    ) -> Vec<RetirementRecord> {
+        retiring_entity.require_auth();
+
+        let mut results = Vec::new(&env);
+
+        for i in 0..token_ids.len() {
+            if i >= tx_hashes.len() {
+                break;
+            }
+
+            let token_id = token_ids.get(i).unwrap();
+            let tx_hash = tx_hashes.get(i).unwrap();
+
+            if let Ok(record) = Self::retire_internal(
+                env.clone(),
+                token_id,
+                retiring_entity.clone(),
+                reason.clone(),
+                Some(tx_hash),
             ) {
                 results.push_back(record);
             }
@@ -269,6 +318,14 @@ impl RetirementTracker {
             .persistent()
             .get(&entity_key)
             .unwrap_or(Vec::new(&env))
+    }
+
+    /// Get the latest contract-scoped event nonce.
+    pub fn get_event_nonce(env: Env) -> u64 {
+        env.storage()
+            .instance()
+            .get(&DataKey::EventNonce)
+            .unwrap_or(0u64)
     }
 
     // ========================================================================
@@ -328,5 +385,120 @@ impl RetirementTracker {
     /// Get the current CarbonAsset contract address
     pub fn get_carbon_asset_contract(env: Env) -> Option<Address> {
         env.storage().instance().get(&DataKey::CarbonAssetContract)
+    }
+
+    fn next_event_nonce(env: &Env) -> Result<u64, ContractError> {
+        let current = env
+            .storage()
+            .instance()
+            .get(&DataKey::EventNonce)
+            .unwrap_or(0u64);
+        let next = current
+            .checked_add(1)
+            .ok_or(ContractError::EventNonceOverflow)?;
+        env.storage().instance().set(&DataKey::EventNonce, &next);
+        Ok(next)
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::{RetirementTracker, RetirementTrackerClient};
+    use soroban_sdk::testutils::Address as _;
+    use soroban_sdk::{contract, contractimpl, Address, BytesN, Env, String, Vec};
+
+    #[contract]
+    pub struct MockCarbonAsset;
+
+    #[contractimpl]
+    impl MockCarbonAsset {
+        pub fn burn_token(_env: Env, _token_id: u32, _from: Address) {}
+    }
+
+    fn setup() -> (Env, RetirementTrackerClient<'static>, Address) {
+        let env = Env::default();
+        env.mock_all_auths();
+
+        let admin = Address::generate(&env);
+        let retiring_entity = Address::generate(&env);
+        let asset_contract = env.register(MockCarbonAsset, ());
+        let tracker_contract = env.register(RetirementTracker, ());
+        let client = RetirementTrackerClient::new(&env, &tracker_contract);
+
+        client.initialize(&admin, &asset_contract);
+
+        (env, client, retiring_entity)
+    }
+
+    #[test]
+    fn retire_with_tx_hash_records_actual_hash_and_nonce() {
+        let (env, client, retiring_entity) = setup();
+        let tx_hash = BytesN::from_array(&env, &[7u8; 32]);
+
+        let record = client.retire_with_tx_hash(
+            &1,
+            &retiring_entity,
+            &Some(String::from_str(&env, "annual offset")),
+            &tx_hash,
+        );
+
+        assert_eq!(record.token_id, 1);
+        assert_eq!(record.tx_hash, Some(tx_hash.clone()));
+        assert_eq!(record.event_nonce, 1);
+        assert_eq!(client.get_event_nonce(), 1);
+
+        let stored = client.get_retirement_record(&1).unwrap();
+        assert_eq!(stored.tx_hash, Some(tx_hash));
+        assert_eq!(stored.event_nonce, 1);
+    }
+
+    #[test]
+    fn retire_without_tx_hash_uses_nonce_fallback() {
+        let (_env, client, retiring_entity) = setup();
+
+        let first = client.retire(&1, &retiring_entity, &None);
+        let second = client.retire(&2, &retiring_entity, &None);
+
+        assert_eq!(first.tx_hash, None);
+        assert_eq!(first.event_nonce, 1);
+        assert_eq!(second.tx_hash, None);
+        assert_eq!(second.event_nonce, 2);
+        assert_eq!(client.get_event_nonce(), 2);
+    }
+
+    #[test]
+    fn duplicate_retirement_is_rejected_without_consuming_nonce() {
+        let (_env, client, retiring_entity) = setup();
+
+        let record = client.retire(&1, &retiring_entity, &None);
+        assert_eq!(record.event_nonce, 1);
+
+        let duplicate = client.try_retire(&1, &retiring_entity, &None);
+        assert!(duplicate.is_err());
+        assert_eq!(client.get_event_nonce(), 1);
+    }
+
+    #[test]
+    fn batch_retire_with_tx_hashes_assigns_ordered_nonces() {
+        let (env, client, retiring_entity) = setup();
+        let mut token_ids = Vec::new(&env);
+        token_ids.push_back(1);
+        token_ids.push_back(2);
+
+        let first_hash = BytesN::from_array(&env, &[1u8; 32]);
+        let second_hash = BytesN::from_array(&env, &[2u8; 32]);
+        let mut tx_hashes = Vec::new(&env);
+        tx_hashes.push_back(first_hash.clone());
+        tx_hashes.push_back(second_hash.clone());
+
+        let records =
+            client.batch_retire_with_tx_hashes(&token_ids, &retiring_entity, &None, &tx_hashes);
+
+        assert_eq!(records.len(), 2);
+        assert_eq!(records.get(0).unwrap().tx_hash, Some(first_hash));
+        assert_eq!(records.get(0).unwrap().event_nonce, 1);
+        assert_eq!(records.get(1).unwrap().tx_hash, Some(second_hash));
+        assert_eq!(records.get(1).unwrap().event_nonce, 2);
+        assert_eq!(client.get_event_nonce(), 2);
     }
 }


### PR DESCRIPTION
closes #307 

## Summary

- Removed synthetic transaction hash generation from the retirement tracker contract.
- Added caller-supplied actual transaction hash support through `retire_with_tx_hash` and `batch_retire_with_tx_hashes`.
- Added a contract-scoped, strictly increasing `event_nonce` fallback for retirement records and events.
- Centralized retirement writes through one internal path so tx-hash and nonce fallback flows share the same validation, burn invocation, storage writes, and event emission.
- Added nonce overflow protection and ensured duplicate retirement attempts do not consume a nonce.
- Added tests for actual tx hash recording, nonce fallback ordering, duplicate retirement protection, and batch nonce ordering.
- Updated retirement tracker documentation to describe tx hash and nonce usage.

## Why

The previous implementation derived a pseudo transaction hash from ledger data, which could be misleading for off-chain consumers. This change stores the real transaction hash when supplied by an integration and otherwise uses `event_nonce` as the deterministic replay-safe identifier.

## Indexer Impact

Off-chain indexers can use `event_nonce` for uniqueness and ordering across retirement events, while `tx_hash` remains available as optional traceability metadata when the caller provides it.
