### PR TITLE
feat(monitoring): implement NDVI calculator with raster support and e…

### DIFF
--- a/project-portal/project-portal-backend/internal/monitoring/processing/ndvi_calculator.go
+++ b/project-portal/project-portal-backend/internal/monitoring/processing/ndvi_calculator.go
@@ -1,7 +1,210 @@
-//go:build future
-// +build future
+ package processing
 
-package monitoring
+import (
+    "context"
+    "errors"
+    "math"
+    "time"
+)
 
-// This file won't be compiled in normal builds
-// Implementation pending
+const ndviZeroGuard = 1e-12
+
+// NDVIResult holds NDVI pixel values, raster dimensions, computed summary
+// statistics, and metadata for downstream persistence.
+type NDVIResult struct {
+    Pixels     []float64 `json:"pixels"`
+    Width      int       `json:"width,omitempty"`
+    Height     int       `json:"height,omitempty"`
+    PixelCount int       `json:"pixel_count,omitempty"`
+    Min        float64   `json:"min"`
+    Max        float64   `json:"max"`
+    Mean       float64   `json:"mean"`
+    ProjectID  string    `json:"project_id"`
+    Timestamp  time.Time `json:"timestamp"`
+}
+
+// NDVIPersister is an internal persistence contract for storing NDVI results.
+type NDVIPersister interface {
+    SaveNDVI(ctx context.Context, result NDVIResult) error
+}
+
+// PersistNDVI persists an NDVI result through a provided persister.
+func PersistNDVI(ctx context.Context, persister NDVIPersister, result NDVIResult) error {
+    if persister == nil {
+        return errors.New("ndvi persister cannot be nil")
+    }
+    return persister.SaveNDVI(ctx, result)
+}
+
+// ValidateBandData checks one-dimensional NIR and RED bands for shape validity.
+func ValidateBandData(nir, red []float64) error {
+    if nir == nil || red == nil {
+        return errors.New("nir and red slices must not be nil")
+    }
+    if len(nir) == 0 || len(red) == 0 {
+        return errors.New("nir and red slices must not be empty")
+    }
+    if len(nir) != len(red) {
+        return errors.New("nir and red slices must have equal length")
+    }
+    return nil
+}
+
+// ValidateRasterBands checks two-dimensional NIR and RED raster bands for shape validity.
+func ValidateRasterBands(nir, red [][]float64) error {
+    if nir == nil || red == nil {
+        return errors.New("nir and red raster bands must not be nil")
+    }
+    if len(nir) == 0 || len(red) == 0 {
+        return errors.New("nir and red raster bands must not be empty")
+    }
+    if len(nir) != len(red) {
+        return errors.New("nir and red raster bands must have the same height")
+    }
+
+    width := -1
+    for row := range nir {
+        if nir[row] == nil || red[row] == nil {
+            return errors.New("nir and red raster rows must not be nil")
+        }
+        if width < 0 {
+            width = len(nir[row])
+            if width == 0 {
+                return errors.New("nir and red raster rows must not be empty")
+            }
+        }
+        if len(nir[row]) != width || len(red[row]) != width {
+            return errors.New("nir and red raster rows must have the same width")
+        }
+    }
+    return nil
+}
+
+// ComputeNDVI computes NDVI per-pixel from 1D NIR and RED bands.
+// NDVI formula: (NIR - RED) / (NIR + RED).
+func ComputeNDVI(nir, red []float64) ([]float64, error) {
+    if err := ValidateBandData(nir, red); err != nil {
+        return nil, err
+    }
+
+    out := make([]float64, len(nir))
+    for i := range nir {
+        out[i] = computeNDVIValue(nir[i], red[i])
+    }
+    return out, nil
+}
+
+// ComputeNDVIFromRaster computes NDVI per-pixel from 2D NIR and RED raster bands.
+func ComputeNDVIFromRaster(nir, red [][]float64) ([][]float64, error) {
+    if err := ValidateRasterBands(nir, red); err != nil {
+        return nil, err
+    }
+
+    height := len(nir)
+    width := len(nir[0])
+    out := make([][]float64, height)
+    for y := 0; y < height; y++ {
+        out[y] = make([]float64, width)
+        for x := 0; x < width; x++ {
+            out[y][x] = computeNDVIValue(nir[y][x], red[y][x])
+        }
+    }
+    return out, nil
+}
+
+func computeNDVIValue(nir, red float64) float64 {
+    sum := nir + red
+    if math.IsNaN(sum) || math.IsInf(sum, 0) || math.Abs(sum) <= ndviZeroGuard {
+        return 0.0
+    }
+
+    ndvi := (nir - red) / sum
+    if math.IsNaN(ndvi) || math.IsInf(ndvi, 0) {
+        return 0.0
+    }
+    return ndvi
+}
+
+func flattenRaster(raster [][]float64) []float64 {
+    if len(raster) == 0 {
+        return nil
+    }
+
+    height := len(raster)
+    width := len(raster[0])
+    out := make([]float64, 0, height*width)
+    for y := 0; y < height; y++ {
+        out = append(out, raster[y]...)
+    }
+    return out
+}
+
+// SummaryNDVI computes min, max and mean for a slice of NDVI values.
+// Returns zeros for empty input.
+func SummaryNDVI(values []float64) (min, max, mean float64) {
+    if len(values) == 0 {
+        return 0, 0, 0
+    }
+
+    min = math.Inf(1)
+    max = math.Inf(-1)
+    var sum float64
+    for _, v := range values {
+        if v < min {
+            min = v
+        }
+        if v > max {
+            max = v
+        }
+        sum += v
+    }
+    mean = sum / float64(len(values))
+    return min, max, mean
+}
+
+// NewNDVIResult constructs an NDVIResult with computed summary stats and metadata.
+// If width or height are invalid, the result defaults to a 1D raster.
+func NewNDVIResult(pixels []float64, width, height int, projectID string, ts time.Time) NDVIResult {
+    if width <= 0 || height <= 0 || width*height != len(pixels) {
+        width = len(pixels)
+        height = 1
+    }
+
+    min, max, mean := SummaryNDVI(pixels)
+    return NDVIResult{
+        Pixels:     pixels,
+        Width:      width,
+        Height:     height,
+        PixelCount: len(pixels),
+        Min:        min,
+        Max:        max,
+        Mean:       mean,
+        ProjectID:  projectID,
+        Timestamp:  ts,
+    }
+}
+
+// NewNDVIResultFromRaster computes an NDVI result from 2D NIR and RED raster bands.
+func NewNDVIResultFromRaster(nir, red [][]float64, projectID string, ts time.Time) (NDVIResult, error) {
+    pixels2D, err := ComputeNDVIFromRaster(nir, red)
+    if err != nil {
+        return NDVIResult{}, err
+    }
+
+    pixels := flattenRaster(pixels2D)
+    return NewNDVIResult(pixels, len(nir[0]), len(nir), projectID, ts), nil
+}
+
+// MockPersistenceOutline shows a structural example of how results could be persisted.
+// This does NOT perform real persistence; it's a small helper that demonstrates
+// building the NDVIResult with a mock Project ID and Timestamp.
+func MockPersistenceOutline(nir, red []float64) (NDVIResult, error) {
+    pixels, err := ComputeNDVI(nir, red)
+    if err != nil {
+        return NDVIResult{}, err
+    }
+
+    res := NewNDVIResult(pixels, len(pixels), 1, "mock-project-123", time.Now().UTC())
+    return res, nil
+}
+

--- a/project-portal/project-portal-backend/internal/monitoring/processing/ndvi_calculator_test.go
+++ b/project-portal/project-portal-backend/internal/monitoring/processing/ndvi_calculator_test.go
@@ -1,0 +1,203 @@
+package processing
+
+import (
+	"math"
+	"testing"
+	"time"
+)
+
+// approxEqual compares floats with a small tolerance.
+func approxEqual(a, b, tol float64) bool {
+	return math.Abs(a-b) <= tol
+}
+
+func TestComputeNDVI_Table(t *testing.T) {
+	tests := []struct {
+		name     string
+		nir      []float64
+		red      []float64
+		want     []float64
+		wantErr  bool
+		wantMin  float64
+		wantMax  float64
+		wantMean float64
+	}{
+		{
+			name:     "happy path",
+			nir:      []float64{0.6, 0.8, 0.0},
+			red:      []float64{0.2, 0.1, 0.0},
+			want:     []float64{0.5, 0.7777777777777778, 0.0},
+			wantErr:  false,
+			wantMin:  0.0,
+			wantMax:  0.7777777777777778,
+			wantMean: (0.5 + 0.7777777777777778 + 0.0) / 3.0,
+		},
+		{
+			name:    "mismatched lengths",
+			nir:     []float64{0.1},
+			red:     []float64{0.1, 0.2},
+			wantErr: true,
+		},
+		{
+			name:    "empty slices",
+			nir:     []float64{},
+			red:     []float64{},
+			wantErr: true,
+		},
+		{
+			name:     "all zeros division-by-zero guard",
+			nir:      []float64{0.0, 0.0, 0.0},
+			red:      []float64{0.0, 0.0, 0.0},
+			want:     []float64{0.0, 0.0, 0.0},
+			wantErr:  false,
+			wantMin:  0.0,
+			wantMax:  0.0,
+			wantMean: 0.0,
+		},
+		{
+			name:     "negative vegetation index",
+			nir:      []float64{0.1, 0.2},
+			red:      []float64{0.3, 0.4},
+			want:     []float64{-0.5, -0.3333333333333333},
+			wantErr:  false,
+			wantMin:  -0.5,
+			wantMax:  -0.3333333333333333,
+			wantMean: (-0.5 + -0.3333333333333333) / 2.0,
+		},
+		{
+			name:    "invalid numeric values produce zeros",
+			nir:     []float64{math.NaN(), 1.0},
+			red:     []float64{0.1, math.Inf(1)},
+			want:    []float64{0.0, 0.0},
+			wantErr: false,
+			wantMin: 0.0,
+			wantMax: 0.0,
+			wantMean: 0.0,
+		},
+	}
+
+	tol := 1e-9
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := ComputeNDVI(tc.nir, tc.red)
+			if tc.wantErr {
+				if err == nil {
+					t.Fatalf("expected error but got nil")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+
+			if len(got) != len(tc.want) {
+				t.Fatalf("length mismatch: got %d want %d", len(got), len(tc.want))
+			}
+
+			for i := range got {
+				if !approxEqual(got[i], tc.want[i], tol) {
+					t.Fatalf("index %d: got %v want %v", i, got[i], tc.want[i])
+				}
+			}
+
+			res := NewNDVIResult(got, len(got), 1, "test-project", time.Now())
+			if !approxEqual(res.Min, tc.wantMin, tol) {
+				t.Fatalf("min mismatch: got %v want %v", res.Min, tc.wantMin)
+			}
+			if !approxEqual(res.Max, tc.wantMax, tol) {
+				t.Fatalf("max mismatch: got %v want %v", res.Max, tc.wantMax)
+			}
+			if !approxEqual(res.Mean, tc.wantMean, tol) {
+				t.Fatalf("mean mismatch: got %v want %v", res.Mean, tc.wantMean)
+			}
+			if res.PixelCount != len(got) {
+				t.Fatalf("pixel count mismatch: got %d want %d", res.PixelCount, len(got))
+			}
+		})
+	}
+}
+
+func TestComputeNDVIFromRaster(t *testing.T) {
+	nir := [][]float64{
+		{0.6, 0.8},
+		{0.2, 0.0},
+	}
+	red := [][]float64{
+		{0.2, 0.1},
+		{0.2, 0.0},
+	}
+	want := [][]float64{
+		{0.5, 0.7777777777777778},
+		{0.0, 0.0},
+	}
+
+	got, err := ComputeNDVIFromRaster(nir, red)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if len(got) != len(want) {
+		t.Fatalf("height mismatch: got %d want %d", len(got), len(want))
+	}
+
+	for y := range got {
+		if len(got[y]) != len(want[y]) {
+			t.Fatalf("width mismatch at row %d: got %d want %d", y, len(got[y]), len(want[y]))
+		}
+		for x := range got[y] {
+			if !approxEqual(got[y][x], want[y][x], 1e-9) {
+				t.Fatalf("pixel [%d][%d] = %v want %v", y, x, got[y][x], want[y][x])
+			}
+		}
+	}
+}
+
+func TestNewNDVIResultFromRaster(t *testing.T) {
+	nir := [][]float64{{0.5, 0.5}, {0.3, 0.1}}
+	red := [][]float64{{0.1, 0.1}, {0.2, 0.0}}
+
+	res, err := NewNDVIResultFromRaster(nir, red, "project-1", time.Date(2026, 5, 28, 0, 0, 0, 0, time.UTC))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if res.Width != 2 || res.Height != 2 || res.PixelCount != 4 {
+		t.Fatalf("unexpected dimensions: %dx%d count=%d", res.Width, res.Height, res.PixelCount)
+	}
+	if res.ProjectID != "project-1" {
+		t.Fatalf("unexpected project id: %s", res.ProjectID)
+	}
+	if !res.Timestamp.Equal(time.Date(2026, 5, 28, 0, 0, 0, 0, time.UTC)) {
+		t.Fatalf("unexpected timestamp: %v", res.Timestamp)
+	}
+	if res.Min >= res.Max {
+		t.Fatalf("expected min < max, got min=%v max=%v", res.Min, res.Max)
+	}
+}
+
+func TestValidateRasterBands_Errors(t *testing.T) {
+	tests := []struct {
+		name string
+		nir  [][]float64
+		red  [][]float64
+	}{
+		{
+			name: "mismatched height",
+			nir:  [][]float64{{0.1}},
+			red:  [][]float64{{0.1}, {0.2}},
+		},
+		{
+			name: "row width mismatch",
+			nir:  [][]float64{{0.1, 0.2}},
+			red:  [][]float64{{0.1}},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if err := ValidateRasterBands(tc.nir, tc.red); err == nil {
+				t.Fatalf("expected validation error for %s", tc.name)
+			}
+		})
+	}
+}


### PR DESCRIPTION
# close #317
## Implement NDVI calculator for issue #317

## Summary

This PR implements the core NDVI calculation module for `project-portal-backend` and removes the previous `future`-gated stub behavior by adding production-ready processing logic and validation.

## Related issue

- Fixes: `#317` Implement NDVI calculator

## Changed files

- `internal/monitoring/processing/ndvi_calculator.go`
- `internal/monitoring/processing/ndvi_calculator_test.go`

## What changed

- Added `ComputeNDVI` to calculate NDVI per pixel from 1D NIR and RED bands
- Added `ComputeNDVIFromRaster` to calculate NDVI from 2D raster NIR/RED inputs
- Added validation for:
  - nil or empty NIR / RED bands
  - mismatched band lengths
  - mismatched raster heights and widths
  - invalid raster row shapes
- Implemented safe NDVI computation with handling for:
  - division-by-zero
  - `NaN`
  - infinite values
- Added `NDVIResult` metadata with:
  - `Width`
  - `Height`
  - `PixelCount`
  - `Min`, `Max`, `Mean`
  - `ProjectID`
  - `Timestamp`
- Added persistence contract via `NDVIPersister` and `PersistNDVI` helper
- Added helper `NewNDVIResultFromRaster` to build result objects directly from raster input
- Added comprehensive unit tests covering:
  - happy path computation
  - invalid band shapes
  - empty input
  - all-zero values
  - negative NDVI values
  - invalid numeric values
  - raster computation
  - raster validation failures

## What is not included

- Direct database persistence wiring
- Full monitoring pipeline integration
- External GeoTIFF/image format ingestion

This PR focuses on implementing the NDVI processing core and preparing a clean contract for persistence and downstream integration.

## Verification

Run:

```bash
go test ./internal/monitoring/processing -v