### PR TITLE
Implement SMS notification channel with AWS SNS and Twilio integrations

### DIFF
--- a/project-portal/project-portal-backend/.env.example
+++ b/project-portal/project-portal-backend/.env.example
@@ -45,6 +45,13 @@ NOTIFICATION_DLQ_URL=https://sqs.us-east-1.amazonaws.com/your-account/notificati
 NOTIFICATION_DEFAULT_QUIET_START=22:00
 NOTIFICATION_DEFAULT_QUIET_END=08:00
 
+# SMS Notification Configuration
+SMS_PROVIDER=mock # mock, aws_sns, or twilio
+AWS_SNS_SMS_SENDER_ID=CarbonScribe
+TWILIO_ACCOUNT_SID=your_twilio_account_sid
+TWILIO_AUTH_TOKEN=your_twilio_auth_token
+TWILIO_FROM_NUMBER=your_twilio_from_phone_number
+
 # JWT Configuration (for WebSocket authentication)
 JWT_SECRET=your_jwt_secret_key_here
 

--- a/project-portal/project-portal-backend/cmd/api/main.go
+++ b/project-portal/project-portal-backend/cmd/api/main.go
@@ -23,11 +23,13 @@ import (
 	"carbon-scribe/project-portal/project-portal-backend/internal/integration"
 	integrationstellar "carbon-scribe/project-portal/project-portal-backend/internal/integration/stellar"
 	"carbon-scribe/project-portal/project-portal-backend/internal/notifications"
+	"carbon-scribe/project-portal/project-portal-backend/internal/notifications/channels"
 	"carbon-scribe/project-portal/project-portal-backend/internal/project"
 	"carbon-scribe/project-portal/project-portal-backend/internal/project/inventory"
 	"carbon-scribe/project-portal/project-portal-backend/internal/project/methodology"
 	"carbon-scribe/project-portal/project-portal-backend/internal/project/quality"
 	"carbon-scribe/project-portal/project-portal-backend/internal/reports"
+	"carbon-scribe/project-portal/project-portal-backend/pkg/aws"
 	"carbon-scribe/project-portal/project-portal-backend/internal/search"
 	"carbon-scribe/project-portal/project-portal-backend/internal/seed"
 	"carbon-scribe/project-portal/project-portal-backend/internal/settings"
@@ -198,6 +200,33 @@ func main() {
 	}
 	notificationsRepo := notifications.NewMongoRepository(notificationMongoClient, cfg.Notifications.MongoDatabase)
 	notificationsService := notifications.NewService(notificationsRepo)
+
+	// Set up the SMS sender based on configuration
+	var smsSender channels.SMSSender
+	switch strings.ToLower(cfg.Notifications.SMSProvider) {
+	case "aws_sns":
+		var initErr error
+		smsSender, initErr = channels.NewAWSSNSSender(aws.SNSConfig{
+			Region:          cfg.AWS.Region,
+			AccessKeyID:     cfg.AWS.AccessKeyID,
+			SecretAccessKey: cfg.AWS.SecretAccessKey,
+			Endpoint:        cfg.AWS.Endpoint,
+			SenderID:        cfg.Notifications.AWSSNSSenderID,
+		})
+		if initErr != nil {
+			log.Fatalf("❌ Failed to initialize AWS SNS SMS Sender: %v", initErr)
+		}
+	case "twilio":
+		smsSender = channels.NewTwilioSender(
+			cfg.Notifications.TwilioAccountSID,
+			cfg.Notifications.TwilioAuthToken,
+			cfg.Notifications.TwilioFromNumber,
+		)
+	default:
+		smsSender = &channels.MockSMSSender{}
+	}
+	notificationsService.SetSMSSender(smsSender)
+
 	notificationsHandler := notifications.NewHandler(notificationsService)
 
 	// Initialize inventory service for on-chain credit querying

--- a/project-portal/project-portal-backend/go.mod
+++ b/project-portal/project-portal-backend/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/credentials v1.19.9
 	github.com/aws/aws-sdk-go-v2/feature/s3/manager v1.22.2
 	github.com/aws/aws-sdk-go-v2/service/s3 v1.96.0
+	github.com/aws/aws-sdk-go-v2/service/sns v1.33.0
 	github.com/elastic/go-elasticsearch/v8 v8.19.1
 	github.com/gin-gonic/gin v1.11.0
 	github.com/golang-jwt/jwt/v5 v5.3.0

--- a/project-portal/project-portal-backend/go.mod
+++ b/project-portal/project-portal-backend/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/credentials v1.19.9
 	github.com/aws/aws-sdk-go-v2/feature/s3/manager v1.22.2
 	github.com/aws/aws-sdk-go-v2/service/s3 v1.96.0
-	github.com/aws/aws-sdk-go-v2/service/sns v1.33.0
+	github.com/aws/aws-sdk-go-v2/service/sns v1.31.3
 	github.com/elastic/go-elasticsearch/v8 v8.19.1
 	github.com/gin-gonic/gin v1.11.0
 	github.com/golang-jwt/jwt/v5 v5.3.0

--- a/project-portal/project-portal-backend/go.sum
+++ b/project-portal/project-portal-backend/go.sum
@@ -306,6 +306,8 @@ gorm.io/driver/sqlite v1.6.0 h1:WHRRrIiulaPiPFmDcod6prc4l2VGVWHz80KspNsxSfQ=
 gorm.io/driver/sqlite v1.6.0/go.mod h1:AO9V1qIQddBESngQUKWL9yoH93HIeA1X6V633rBwyT8=
 gorm.io/driver/sqlserver v1.6.0 h1:VZOBQVsVhkHU/NzNhRJKoANt5pZGQAS1Bwc6m6dgfnc=
 gorm.io/driver/sqlserver v1.6.0/go.mod h1:WQzt4IJo/WHKnckU9jXBLMJIVNMVeTu25dnOzehntWw=
-gorm.io/gorm v1.25.7/go.mod h1:hbnx/Oo0ChWMn1BIhpy1oYozzpM15i4YPuHDmfYtwg8=
 gorm.io/gorm v1.31.1 h1:7CA8FTFz/gRfgqgpeKIBcervUn3xSyPUmr6B2WXJ7kg=
 gorm.io/gorm v1.31.1/go.mod h1:XyQVbO2k6YkOis7C2437jSit3SsDK72s7n7rsSHd+Gs=
+github.com/aws/aws-sdk-go-v2/service/sns v1.31.3 h1:eSTEdxkfle2G98FE+Xl3db/XAXXVTJPNQo9K/Ar8oAI=
+github.com/aws/aws-sdk-go-v2/service/sns v1.31.3/go.mod h1:1dn0delSO3J69THuty5iwP0US2Glt0mx2qBBlI13pvw=
+

--- a/project-portal/project-portal-backend/internal/config/config.go
+++ b/project-portal/project-portal-backend/internal/config/config.go
@@ -91,6 +91,11 @@ type NotificationsConfig struct {
 	MongoDatabase     string
 	MongoEnabled      bool
 	ReconnectQueueMax int
+	SMSProvider       string
+	AWSSNSSenderID    string
+	TwilioAccountSID  string
+	TwilioAuthToken   string
+	TwilioFromNumber  string
 }
 
 // Load loads configuration from environment variables
@@ -193,6 +198,11 @@ func Load() (*Config, error) {
 			MongoDatabase:     getEnvOrDefault("NOTIFICATIONS_MONGO_DB", "carbon_scribe_notifications"),
 			MongoEnabled:      getEnvOrDefault("NOTIFICATIONS_STORAGE", "mongo") == "mongo",
 			ReconnectQueueMax: getIntOrDefault("NOTIFICATIONS_RECONNECT_QUEUE_MAX", 100),
+			SMSProvider:       getEnvOrDefault("SMS_PROVIDER", "mock"),
+			AWSSNSSenderID:    getEnvOrDefault("AWS_SNS_SMS_SENDER_ID", "CarbonScribe"),
+			TwilioAccountSID:  os.Getenv("TWILIO_ACCOUNT_SID"),
+			TwilioAuthToken:   os.Getenv("TWILIO_AUTH_TOKEN"),
+			TwilioFromNumber:  os.Getenv("TWILIO_FROM_NUMBER"),
 		},
 	}, nil
 }

--- a/project-portal/project-portal-backend/internal/notifications/channels/sms.go
+++ b/project-portal/project-portal-backend/internal/notifications/channels/sms.go
@@ -1,7 +1,100 @@
-//go:build future
-// +build future
+package channels
 
-package notifications
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
 
-// This file won't be compiled in normal builds
-// Implementation pending
+	"carbon-scribe/project-portal/project-portal-backend/pkg/aws"
+)
+
+// SMSSender defines the interface for sending SMS notifications.
+type SMSSender interface {
+	Send(ctx context.Context, to string, body string) (string, error)
+}
+
+// MockSMSSender is a mock provider for local development and unit tests.
+type MockSMSSender struct{}
+
+func (m *MockSMSSender) Send(ctx context.Context, to string, body string) (string, error) {
+	if to == "" {
+		return "", errors.New("recipient phone number is required")
+	}
+	if strings.Contains(to, "invalid") || strings.Contains(to, "fail") {
+		return "", errors.New("invalid phone number")
+	}
+	return "mock-msg-id-" + fmt.Sprintf("%d", time.Now().UnixNano()), nil
+}
+
+// AWSSNSSender sends SMS using AWS SNS.
+type AWSSNSSender struct {
+	client *aws.SNSClient
+}
+
+func NewAWSSNSSender(cfg aws.SNSConfig) (*AWSSNSSender, error) {
+	client, err := aws.NewSNSClient(cfg)
+	if err != nil {
+		return nil, err
+	}
+	return &AWSSNSSender{client: client}, nil
+}
+
+func (a *AWSSNSSender) Send(ctx context.Context, to string, body string) (string, error) {
+	return a.client.PublishSMS(ctx, to, body)
+}
+
+// TwilioSender sends SMS using Twilio HTTP API.
+type TwilioSender struct {
+	accountSID string
+	authToken  string
+	fromNumber string
+	httpClient *http.Client
+}
+
+func NewTwilioSender(accountSID, authToken, fromNumber string) *TwilioSender {
+	return &TwilioSender{
+		accountSID: accountSID,
+		authToken:  authToken,
+		fromNumber: fromNumber,
+		httpClient: &http.Client{Timeout: 10 * time.Second},
+	}
+}
+
+func (t *TwilioSender) Send(ctx context.Context, to string, body string) (string, error) {
+	if t.accountSID == "" || t.authToken == "" || t.fromNumber == "" {
+		return "", errors.New("twilio credentials or from number not configured")
+	}
+
+	apiURL := fmt.Sprintf("https://api.twilio.com/2010-04-01/Accounts/%s/Messages.json", t.accountSID)
+
+	data := url.Values{}
+	data.Set("To", to)
+	data.Set("From", t.fromNumber)
+	data.Set("Body", body)
+
+	req, err := http.NewRequestWithContext(ctx, "POST", apiURL, strings.NewReader(data.Encode()))
+	if err != nil {
+		return "", err
+	}
+
+	req.SetBasicAuth(t.accountSID, t.authToken)
+	req.Header.Add("Content-Type", "application/x-www-form-urlencoded")
+
+	resp, err := t.httpClient.Do(req)
+	if err != nil {
+		return "", err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		bodyBytes, _ := io.ReadAll(resp.Body)
+		return "", fmt.Errorf("twilio API returned status %d: %s", resp.StatusCode, string(bodyBytes))
+	}
+
+	return "twilio-msg-id-ok", nil
+}

--- a/project-portal/project-portal-backend/internal/notifications/channels/sms_test.go
+++ b/project-portal/project-portal-backend/internal/notifications/channels/sms_test.go
@@ -1,0 +1,104 @@
+package channels
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestMockSMSSender(t *testing.T) {
+	sender := &MockSMSSender{}
+
+	t.Run("success send", func(t *testing.T) {
+		msgID, err := sender.Send(context.Background(), "+1234567890", "Test message")
+		assert.NoError(t, err)
+		assert.Contains(t, msgID, "mock-msg-id-")
+	})
+
+	t.Run("missing recipient number", func(t *testing.T) {
+		_, err := sender.Send(context.Background(), "", "Test message")
+		assert.Error(t, err)
+		assert.Equal(t, "recipient phone number is required", err.Error())
+	})
+
+	t.Run("invalid recipient number error", func(t *testing.T) {
+		_, err := sender.Send(context.Background(), "invalid-number", "Test message")
+		assert.Error(t, err)
+		assert.Equal(t, "invalid phone number", err.Error())
+	})
+}
+
+func TestTwilioSender(t *testing.T) {
+	t.Run("invalid config", func(t *testing.T) {
+		sender := NewTwilioSender("", "", "")
+		_, err := sender.Send(context.Background(), "+1234567890", "Hello")
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "credentials or from number not configured")
+	})
+
+	t.Run("successful api call", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			assert.Equal(t, "POST", r.Method)
+			assert.Equal(t, "application/x-www-form-urlencoded", r.Header.Get("Content-Type"))
+			username, password, ok := r.BasicAuth()
+			assert.True(t, ok)
+			assert.Equal(t, "ACxxxxxx", username)
+			assert.Equal(t, "auth_token_secret", password)
+
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`{"sid": "SM123456", "status": "queued"}`))
+		}))
+		defer server.Close()
+
+		sender := NewTwilioSender("ACxxxxxx", "auth_token_secret", "+188888888")
+		// Point to local test server
+		originalTransport := sender.httpClient.Transport
+		defer func() { sender.httpClient.Transport = originalTransport }()
+
+		sender.httpClient.Transport = &mockRoundTripper{
+			roundTrip: func(req *http.Request) (*http.Response, error) {
+				// Rewrite destination to point to the local test server
+				req.URL.Scheme = "http"
+				req.URL.Host = server.Listener.Addr().String()
+				return http.DefaultTransport.RoundTrip(req)
+			},
+		}
+
+		msgID, err := sender.Send(context.Background(), "+1234567890", "Hello Twilio")
+		assert.NoError(t, err)
+		assert.Equal(t, "twilio-msg-id-ok", msgID)
+	})
+
+	t.Run("failed api call", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusBadRequest)
+			_, _ = w.Write([]byte(`{"message": "Invalid number"}`))
+		}))
+		defer server.Close()
+
+		sender := NewTwilioSender("ACxxxxxx", "auth_token_secret", "+188888888")
+		sender.httpClient.Transport = &mockRoundTripper{
+			roundTrip: func(req *http.Request) (*http.Response, error) {
+				req.URL.Scheme = "http"
+				req.URL.Host = server.Listener.Addr().String()
+				return http.DefaultTransport.RoundTrip(req)
+			},
+		}
+
+		_, err := sender.Send(context.Background(), "+1234567890", "Hello Twilio")
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "twilio API returned status 400")
+	})
+}
+
+type mockRoundTripper struct {
+	roundTrip func(*http.Request) (*http.Response, error)
+}
+
+func (m *mockRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
+	return m.roundTrip(req)
+}

--- a/project-portal/project-portal-backend/internal/notifications/channels/sms_test.go
+++ b/project-portal/project-portal-backend/internal/notifications/channels/sms_test.go
@@ -7,7 +7,6 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 )
 
 func TestMockSMSSender(t *testing.T) {

--- a/project-portal/project-portal-backend/internal/notifications/service.go
+++ b/project-portal/project-portal-backend/internal/notifications/service.go
@@ -8,6 +8,8 @@ import (
 	"strings"
 	"time"
 
+	"carbon-scribe/project-portal/project-portal-backend/internal/notifications/channels"
+
 	"github.com/google/uuid"
 )
 
@@ -15,6 +17,7 @@ type Service struct {
 	repo          Repository
 	retryLimit    int
 	defaultLocale string
+	smsSender     channels.SMSSender
 }
 
 func NewService(repo Repository) *Service {
@@ -22,7 +25,12 @@ func NewService(repo Repository) *Service {
 		repo:          repo,
 		retryLimit:    3,
 		defaultLocale: "en",
+		smsSender:     &channels.MockSMSSender{},
 	}
+}
+
+func (s *Service) SetSMSSender(sender channels.SMSSender) {
+	s.smsSender = sender
 }
 
 func (s *Service) ListUserNotifications(ctx context.Context, userID string, limit int64) ([]Notification, error) {
@@ -73,12 +81,54 @@ func (s *Service) SendNotification(ctx context.Context, req SendNotificationRequ
 
 	finalStatus := StatusSent
 	for _, channel := range req.Channels {
-		attemptStatus, providerResponse := s.mockDeliver(channel, req.Destinations, subject, content)
+		chUpper := strings.ToUpper(channel)
+		var attemptStatus string
+		var providerResponse map[string]interface{}
+		var providerMsgID string
+
+		if chUpper == ChannelSMS {
+			to := ""
+			if req.Destinations != nil {
+				to = req.Destinations[ChannelSMS]
+			}
+			if to == "" {
+				attemptStatus = StatusFailed
+				providerResponse = map[string]interface{}{"error": "missing SMS destination number"}
+			} else {
+				var err error
+				var msgID string
+				// Call SMSSender with retry logic
+				for attempt := 0; attempt <= s.retryLimit; attempt++ {
+					msgID, err = s.smsSender.Send(ctx, to, content)
+					if err == nil {
+						break
+					}
+					if attempt < s.retryLimit {
+						time.Sleep(time.Duration((attempt+1)*100) * time.Millisecond)
+					}
+				}
+				if err != nil {
+					attemptStatus = StatusFailed
+					providerResponse = map[string]interface{}{"error": err.Error()}
+				} else {
+					attemptStatus = StatusDelivered
+					providerResponse = map[string]interface{}{
+						"message_id": msgID,
+						"provider":   "sms",
+						"delivered":  true,
+					}
+					providerMsgID = msgID
+				}
+			}
+		} else {
+			attemptStatus, providerResponse = s.mockDeliver(channel, req.Destinations, subject, content)
+		}
+
 		attempt := &DeliveryAttempt{
 			AttemptID:        uuid.NewString(),
 			NotificationID:   n.ID,
 			UserID:           req.UserID,
-			Channel:          strings.ToUpper(channel),
+			Channel:          chUpper,
 			Status:           attemptStatus,
 			ProviderResponse: providerResponse,
 			RetryCount:       0,
@@ -86,7 +136,11 @@ func (s *Service) SendNotification(ctx context.Context, req SendNotificationRequ
 		}
 
 		if attemptStatus == StatusSent || attemptStatus == StatusDelivered {
-			attempt.ProviderMessageID = uuid.NewString()
+			if providerMsgID != "" {
+				attempt.ProviderMessageID = providerMsgID
+			} else {
+				attempt.ProviderMessageID = uuid.NewString()
+			}
 			attempt.FinalStatus = StatusDelivered
 		} else {
 			attempt.FinalStatus = StatusFailed

--- a/project-portal/project-portal-backend/pkg/aws/sns_client.go
+++ b/project-portal/project-portal-backend/pkg/aws/sns_client.go
@@ -1,7 +1,85 @@
-//go:build future
-// +build future
-
 package aws
 
-// This file won't be compiled in normal builds
-// Implementation pending
+import (
+	"context"
+	"fmt"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/config"
+	"github.com/aws/aws-sdk-go-v2/credentials"
+	"github.com/aws/aws-sdk-go-v2/service/sns"
+	"github.com/aws/aws-sdk-go-v2/service/sns/types"
+)
+
+type SNSConfig struct {
+	Region          string
+	AccessKeyID     string
+	SecretAccessKey string
+	Endpoint        string
+	SenderID        string
+}
+
+type SNSClient struct {
+	client   *sns.Client
+	senderID string
+}
+
+func NewSNSClient(cfg SNSConfig) (*SNSClient, error) {
+	opts := []func(*config.LoadOptions) error{
+		config.WithRegion(cfg.Region),
+	}
+
+	if cfg.AccessKeyID != "" && cfg.SecretAccessKey != "" {
+		opts = append(opts, config.WithCredentialsProvider(
+			credentials.NewStaticCredentialsProvider(cfg.AccessKeyID, cfg.SecretAccessKey, ""),
+		))
+	}
+
+	awsCfg, err := config.LoadDefaultConfig(context.Background(), opts...)
+	if err != nil {
+		return nil, fmt.Errorf("failed to load AWS SNS config: %w", err)
+	}
+
+	var snsClientOpts []func(*sns.Options)
+	if cfg.Endpoint != "" {
+		snsClientOpts = append(snsClientOpts, func(o *sns.Options) {
+			o.BaseEndpoint = aws.String(cfg.Endpoint)
+		})
+	}
+
+	client := sns.NewFromConfig(awsCfg, snsClientOpts...)
+	return &SNSClient{
+		client:   client,
+		senderID: cfg.SenderID,
+	}, nil
+}
+
+func (s *SNSClient) PublishSMS(ctx context.Context, to string, message string) (string, error) {
+	input := &sns.PublishInput{
+		Message:     aws.String(message),
+		PhoneNumber: aws.String(to),
+	}
+
+	attributes := make(map[string]types.MessageAttributeValue)
+	if s.senderID != "" {
+		attributes["AWS.SNS.SMS.SenderID"] = types.MessageAttributeValue{
+			DataType:    aws.String("String"),
+			StringValue: aws.String(s.senderID),
+		}
+	}
+	// Default to transactional for alert delivery reliability
+	attributes["AWS.SNS.SMS.SMSType"] = types.MessageAttributeValue{
+		DataType:    aws.String("String"),
+		StringValue: aws.String("Transactional"),
+	}
+	input.MessageAttributes = attributes
+
+	out, err := s.client.Publish(ctx, input)
+	if err != nil {
+		return "", fmt.Errorf("failed to publish SNS SMS: %w", err)
+	}
+	if out.MessageId == nil {
+		return "", fmt.Errorf("publish response missing message ID")
+	}
+	return *out.MessageId, nil
+}


### PR DESCRIPTION
Closes #319

---

I added the SMS channel implementations and included a Mock provider (for testing/local development), a Twilio provider (using Twilio's HTTP API directly to minimize dependency footprint), and an AWS SNS provider.