### PR TITLE
feat(ipfs): remove mock Pinata credential defaults and enforce strict startup validation

### DIFF
--- a/corporate-platform/corporate-platform-backend/.env.example
+++ b/corporate-platform/corporate-platform-backend/.env.example
@@ -81,3 +81,14 @@ AUDIT_STELLAR_ANCHOR_ENABLED=false
 AUDIT_ANCHOR_RATE_LIMIT_MAX=30
 # Window size in milliseconds.
 AUDIT_ANCHOR_RATE_LIMIT_WINDOW_MS=60000
+
+
+# Pinata IPFS Configuration
+# Required credentials for production decentralized storage. Mock configurations have been removed.
+PINATA_API_KEY=your_pinata_api_key_here
+PINATA_SECRET_KEY=your_pinata_secret_key_here
+PINATA_JWT=your_pinata_jwt_bearer_token_here
+
+# Optional overrides
+# PINATA_GATEWAY=https://gateway.pinata.cloud/ipfs/
+# PINATA_TIMEOUT_MS=20000

--- a/corporate-platform/corporate-platform-backend/package-lock.json
+++ b/corporate-platform/corporate-platform-backend/package-lock.json
@@ -11,6 +11,7 @@
       "license": "UNLICENSED",
       "dependencies": {
         "@nestjs/common": "^10.0.0",
+        "@nestjs/config": "^4.0.4",
         "@nestjs/core": "^10.0.0",
         "@nestjs/jwt": "^10.0.0",
         "@nestjs/mongoose": "^11.0.4",
@@ -265,6 +266,7 @@
       "integrity": "sha512-e7jT4DxYvIDLk1ZHmU/m/mB19rex9sv0c2ftBtjSBv+kVM/902eh0fINUzD7UwLLNR+jU585GxUJ8/EBfAM5fw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.27.1",
         "@babel/generator": "^7.28.5",
@@ -837,7 +839,8 @@
       "resolved": "https://registry.npmjs.org/@electric-sql/pglite/-/pglite-0.3.15.tgz",
       "integrity": "sha512-Cj++n1Mekf9ETfdc16TlDi+cDDQF0W7EcbyRHYOAeZdsAe8M/FJg18itDTSwyHfar2WIezawM9o0EKaRGVKygQ==",
       "devOptional": true,
-      "license": "Apache-2.0"
+      "license": "Apache-2.0",
+      "peer": true
     },
     "node_modules/@electric-sql/pglite-socket": {
       "version": "0.0.20",
@@ -1892,6 +1895,7 @@
       "resolved": "https://registry.npmjs.org/@nestjs/common/-/common-10.4.20.tgz",
       "integrity": "sha512-hxJxZF7jcKGuUzM9EYbuES80Z/36piJbiqmPy86mk8qOn5gglFebBTvcx7PWVbRNSb4gngASYnefBj/Y2HAzpQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "file-type": "20.4.1",
         "iterare": "1.2.1",
@@ -1917,12 +1921,34 @@
         }
       }
     },
+    "node_modules/@nestjs/config": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/@nestjs/config/-/config-4.0.4.tgz",
+      "integrity": "sha512-CJPjNitr0bAufSEnRe2N+JbnVmMmDoo6hvKCPzXgZoGwJSmp/dZPk9f/RMbuD/+Q1ZJPjwsRpq0vxna++Knwow==",
+      "license": "MIT",
+      "dependencies": {
+        "dotenv": "17.4.1",
+        "dotenv-expand": "12.0.3",
+        "lodash": "4.18.1"
+      },
+      "peerDependencies": {
+        "@nestjs/common": "^10.0.0 || ^11.0.0",
+        "rxjs": "^7.1.0"
+      }
+    },
+    "node_modules/@nestjs/config/node_modules/lodash": {
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
+      "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
+      "license": "MIT"
+    },
     "node_modules/@nestjs/core": {
       "version": "10.4.20",
       "resolved": "https://registry.npmjs.org/@nestjs/core/-/core-10.4.20.tgz",
       "integrity": "sha512-kRdtyKA3+Tu70N3RQ4JgmO1E3LzAMs/eppj7SfjabC7TgqNWoS4RLhWl4BqmsNVmjj6D5jgfPVtHtgYkU3AfpQ==",
       "hasInstallScript": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@nuxtjs/opencollective": "0.3.2",
         "fast-safe-stringify": "2.1.1",
@@ -2067,6 +2093,7 @@
       "resolved": "https://registry.npmjs.org/@nestjs/platform-express/-/platform-express-10.4.20.tgz",
       "integrity": "sha512-rh97mX3rimyf4xLMLHuTOBKe6UD8LOJ14VlJ1F/PTd6C6ZK9Ak6EHuJvdaGcSFQhd3ZMBh3I6CuujKGW9pNdIg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "body-parser": "1.20.3",
         "cors": "2.8.5",
@@ -2254,6 +2281,7 @@
       "resolved": "https://registry.npmjs.org/@nestjs/websockets/-/websockets-10.4.22.tgz",
       "integrity": "sha512-OLd4i0Faq7vgdtB5vVUrJ54hWEtcXy9poJ6n7kbbh/5ms+KffUl+wwGsbe7uSXLrkoyI8xXU6fZPkFArI+XiRg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "iterare": "1.2.1",
         "object-hash": "3.0.0",
@@ -2890,6 +2918,7 @@
       "integrity": "sha512-FXx2pKgId/WyYo2jXw63kk7/+TY7u7AziEJxJAnSFzHlqTAS3Ync6SvgYAN/k4/PQpnnVuzoMuVnByKK2qp0ag==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/estree": "*",
         "@types/json-schema": "*"
@@ -3036,6 +3065,7 @@
       "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.27.tgz",
       "integrity": "sha512-N2clP5pJhB2YnZJ3PIHFk5RkygRX5WO/5f0WC08tp0wd+sv0rsJk3MqWn3CbNmT2J505a5336jaQj4ph1AdMug==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "undici-types": "~6.21.0"
       }
@@ -3255,6 +3285,7 @@
       "integrity": "sha512-hM5faZwg7aVNa819m/5r7D0h0c9yC4DUlWAOvHAtISdFTc8xB86VmX5Xqabrama3wIPJ/q9RbGS1worb6JfnMg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.50.1",
         "@typescript-eslint/types": "8.50.1",
@@ -3654,6 +3685,7 @@
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -3667,7 +3699,6 @@
       "integrity": "sha512-wKmbr/DDiIXzEOiWrTTUcDm24kQ2vGfZQvM2fwg2vXqR5uW6aapr7ObPtj1th32b9u90/Pf4AItvdTh42fBmVQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=10.13.0"
       },
@@ -3704,6 +3735,7 @@
       "integrity": "sha512-sRu1kpcO9yLtYxBKvqfTeh9KzZEwO3STyX1HT+4CaDzC6HpTGYhIhPIzj9XuKU7KYDwnaeh5hcOwjy1QuJzBPA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
         "json-schema-traverse": "^1.0.0",
@@ -4298,6 +4330,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -4700,13 +4733,15 @@
       "version": "0.5.1",
       "resolved": "https://registry.npmjs.org/class-transformer/-/class-transformer-0.5.1.tgz",
       "integrity": "sha512-SQa1Ws6hUbfC98vKGxZH3KFY0Y1lm5Zm0SY8XX9zbK7FJCyVEac3ATW0RIpwzW+oOfmHE5PMPufDG9hCfoEOMw==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/class-validator": {
       "version": "0.14.3",
       "resolved": "https://registry.npmjs.org/class-validator/-/class-validator-0.14.3.tgz",
       "integrity": "sha512-rXXekcjofVN1LTOSw+u4u9WXVEUvNBVjORW154q/IdmYWy1nMbOU9aNtZB0t8m+FJQ9q91jlr2f9CwwUFdFMRA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/validator": "^13.15.3",
         "libphonenumber-js": "^1.11.1",
@@ -5099,8 +5134,7 @@
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
       "devOptional": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/csv-stringify": {
       "version": "6.6.0",
@@ -5358,9 +5392,36 @@
       }
     },
     "node_modules/dotenv": {
-      "version": "17.3.1",
-      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-17.3.1.tgz",
-      "integrity": "sha512-IO8C/dzEb6O3F9/twg6ZLXz164a2fhTnEWb95H23Dm4OuN+92NmEAlTrupP9VW6Jm3sO26tQlqyvyi4CsnY9GA==",
+      "version": "17.4.1",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-17.4.1.tgz",
+      "integrity": "sha512-k8DaKGP6r1G30Lx8V4+pCsLzKr8vLmV2paqEj1Y55GdAgJuIqpRp5FfajGF8KtwMxCz9qJc6wUIJnm053d/WCw==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://dotenvx.com"
+      }
+    },
+    "node_modules/dotenv-expand": {
+      "version": "12.0.3",
+      "resolved": "https://registry.npmjs.org/dotenv-expand/-/dotenv-expand-12.0.3.tgz",
+      "integrity": "sha512-uc47g4b+4k/M/SeaW1y4OApx+mtLWl92l5LMPP0GNXctZqELk+YGgOPIIC5elYmUH4OuoK3JLhuRUYegeySiFA==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "dotenv": "^16.4.5"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://dotenvx.com"
+      }
+    },
+    "node_modules/dotenv-expand/node_modules/dotenv": {
+      "version": "16.6.1",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.6.1.tgz",
+      "integrity": "sha512-uBq4egWHTcTt33a72vpSG0z3HnPuIl6NqYcTrKEg2azoEyl2hpW0zqlxysq2pK9HlDIHyHyakeYaYnSAwd8bow==",
       "license": "BSD-2-Clause",
       "engines": {
         "node": ">=12"
@@ -5568,8 +5629,7 @@
       "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.1.0.tgz",
       "integrity": "sha512-n27zTYMjYu1aj4MjCWzSP7G9r75utsaoc8m61weK+W8JMBGGQybd43GstCXZ3WNmSFtGT9wi59qQTW6mhTR5LQ==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/es-object-atoms": {
       "version": "1.1.1",
@@ -5634,6 +5694,7 @@
       "deprecated": "This version is no longer supported. Please see https://eslint.org/version-support for other options.",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.6.1",
@@ -5690,6 +5751,7 @@
       "integrity": "sha512-iI1f+D2ViGn+uvv5HuHVUamg8ll4tN+JRHGc6IJi4TP9Kl976C57fzPXgseXNs8v0iA8aSJpHsTWjDb9QJamGQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "eslint-config-prettier": "bin/cli.js"
       },
@@ -6920,6 +6982,7 @@
       "integrity": "sha512-U7tt8JsyrxSRKspfhtLET79pU8K+tInj5QZXs1jSugO1Vq5dFj3kmZsRldo29mTBfcjDRVRXrEZ6LS63Cog9ZA==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=16.9.0"
       }
@@ -7665,6 +7728,7 @@
       "integrity": "sha512-NIy3oAFp9shda19hy4HK0HRTWKtPJmGdnvywu01nOqNC2vZg+Z+fvJDxpMQA88eb2I9EcafcdjYgsDthnYTvGw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@jest/core": "^29.7.0",
         "@jest/types": "^29.6.3",
@@ -9125,6 +9189,7 @@
       "resolved": "https://registry.npmjs.org/mongoose/-/mongoose-9.6.3.tgz",
       "integrity": "sha512-vI6dTTlQnfMCyyQ5TrvhG0bCRs4dq5e1uFNPtOOWsOhn0fSg8AoIHjfyyCYr8aybyvPs845dRHGxsC3w/fHcBA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "kareem": "3.3.0",
         "mongodb": "~7.2",
@@ -9663,6 +9728,7 @@
       "resolved": "https://registry.npmjs.org/passport/-/passport-0.7.0.tgz",
       "integrity": "sha512-cPLl+qZpSc+ireUvt+IzqbED1cHHkDoVYMo30jbJIdOOjQ1MQYZBPiNvmi8UM6lJuOpTPXJGZQk0DtC4y61MYQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "passport-strategy": "1.x.x",
         "pause": "0.0.1",
@@ -9819,6 +9885,7 @@
       "resolved": "https://registry.npmjs.org/pg/-/pg-8.18.0.tgz",
       "integrity": "sha512-xqrUDL1b9MbkydY/s+VZ6v+xiMUmOUk7SS9d/1kpyQxoJ6U9AO1oIJyUWVZojbfe5Cc/oluutcgFG4L9RDP1iQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "pg-connection-string": "^2.11.0",
         "pg-pool": "^3.11.0",
@@ -10116,6 +10183,7 @@
       "integrity": "sha512-v6UNi1+3hSlVvv8fSaoUbggEM5VErKmmpGA7Pl3HF8V6uKY7rvClBOJlH6yNwQtfTueNkGVpOv/mtWL9L4bgRA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "prettier": "bin/prettier.cjs"
       },
@@ -10174,6 +10242,7 @@
       "devOptional": true,
       "hasInstallScript": true,
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@prisma/config": "7.5.0",
         "@prisma/dev": "0.20.0",
@@ -10456,7 +10525,8 @@
       "version": "0.1.14",
       "resolved": "https://registry.npmjs.org/reflect-metadata/-/reflect-metadata-0.1.14.tgz",
       "integrity": "sha512-ZhYeb6nRaXCfhnndflDK8qI6ZQ/YcWZCISRAWICW9XYqMUwjZM9Z0DveWX/ABN01oxSHwVxKQmxeYZSsm0jh5A==",
-      "license": "Apache-2.0"
+      "license": "Apache-2.0",
+      "peer": true
     },
     "node_modules/regexp-to-ast": {
       "version": "0.5.0",
@@ -10752,6 +10822,7 @@
       "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.2.tgz",
       "integrity": "sha512-dhKf903U/PQZY6boNNtAGdWbG85WAbjT/1xYoZIC7FAY0yWapOBQVsVrDl58W86//e1VpMNBtRV4MaXfdMySFA==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "tslib": "^2.1.0"
       }
@@ -10804,8 +10875,7 @@
       "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.27.0.tgz",
       "integrity": "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==",
       "devOptional": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/schema-utils": {
       "version": "3.3.0",
@@ -10832,6 +10902,7 @@
       "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
         "fast-json-stable-stringify": "^2.0.0",
@@ -12060,6 +12131,7 @@
       "integrity": "sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@cspotcode/source-map-support": "^0.8.0",
         "@tsconfig/node10": "^1.0.7",
@@ -12226,6 +12298,7 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "devOptional": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -12562,7 +12635,6 @@
       "integrity": "sha512-2NxwbF/hZ0KpepYN0cNbo+FN6XoK7GaHlQhgx/hIZl6Va0bF45RQOOwhLIy8lQDbuCiadSLCBnH2CFYquit5bw==",
       "dev": true,
       "license": "BSD-2-Clause",
-      "peer": true,
       "dependencies": {
         "esrecurse": "^4.3.0",
         "estraverse": "^4.1.1"
@@ -12577,7 +12649,6 @@
       "integrity": "sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw==",
       "dev": true,
       "license": "BSD-2-Clause",
-      "peer": true,
       "engines": {
         "node": ">=4.0"
       }
@@ -12588,7 +12659,6 @@
       "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">= 0.6"
       }
@@ -12599,7 +12669,6 @@
       "integrity": "sha512-eflK8wEtyOE6+hsaRVPxvUKYCpRgzLqDTb8krvAsRIwOGlHoSgYLgBXoubGgLd2fT41/OUYdb48v4k4WWHQurA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/json-schema": "^7.0.9",
         "ajv": "^8.9.0",

--- a/corporate-platform/corporate-platform-backend/package.json
+++ b/corporate-platform/corporate-platform-backend/package.json
@@ -31,6 +31,7 @@
   },
   "dependencies": {
     "@nestjs/common": "^10.0.0",
+    "@nestjs/config": "^4.0.4",
     "@nestjs/core": "^10.0.0",
     "@nestjs/jwt": "^10.0.0",
     "@nestjs/mongoose": "^11.0.4",

--- a/corporate-platform/corporate-platform-backend/src/config/validation/config.schema.ts
+++ b/corporate-platform/corporate-platform-backend/src/config/validation/config.schema.ts
@@ -40,4 +40,22 @@ export const configSchema = Joi.object({
   IPFS_GATEWAY: Joi.string().uri().allow(''),
   CONFIG_FILE: Joi.string().allow(''),
   CONFIG_WATCH_FILE: Joi.string().allow(''),
+
+  // Pinata IPFS Configuration Validation
+  PINATA_API_KEY: Joi.string().required().messages({
+    'any.required':
+      'PINATA_API_KEY is missing. Please configure valid Pinata credentials.',
+  }),
+  PINATA_SECRET_KEY: Joi.string().required().messages({
+    'any.required':
+      'PINATA_SECRET_KEY is missing. Please configure valid Pinata credentials.',
+  }),
+  PINATA_JWT: Joi.string().required().messages({
+    'any.required':
+      'PINATA_JWT is missing. Please configure valid Pinata credentials.',
+  }),
+  PINATA_GATEWAY: Joi.string()
+    .uri()
+    .default('https://gateway.pinata.cloud/ipfs/'),
+  PINATA_TIMEOUT_MS: Joi.number().integer().min(1000).default(20000),
 });

--- a/corporate-platform/corporate-platform-backend/src/ipfs/ipfs.config.ts
+++ b/corporate-platform/corporate-platform-backend/src/ipfs/ipfs.config.ts
@@ -1,14 +1,33 @@
 import { Injectable } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
 
 @Injectable()
 export class IpfsConfig {
-  readonly apiKey = process.env.PINATA_API_KEY || 'mock-pinata-api-key';
-  readonly secretKey =
-    process.env.PINATA_SECRET_KEY || 'mock-pinata-secret-key';
-  readonly jwt = process.env.PINATA_JWT || 'mock-pinata-jwt';
-  readonly gateway =
-    process.env.PINATA_GATEWAY || 'https://gateway.pinata.cloud/ipfs/';
-  readonly fallback =
-    process.env.IPFS_GATEWAY_FALLBACK || 'https://ipfs.io/ipfs/';
-  readonly timeout = Number(process.env.PINATA_TIMEOUT_MS || 20000);
+  constructor(private readonly configService: ConfigService) {}
+
+  get apiKey(): string {
+    return this.configService.get<string>('PINATA_API_KEY');
+  }
+
+  get secretKey(): string {
+    return this.configService.get<string>('PINATA_SECRET_KEY');
+  }
+
+  get jwt(): string {
+    return this.configService.get<string>('PINATA_JWT');
+  }
+
+  get gateway(): string {
+    return this.configService.get<string>('PINATA_GATEWAY');
+  }
+
+  get fallback(): string {
+    return (
+      this.configService.get<string>('IPFS_GATEWAY') || 'https://ipfs.io/ipfs/'
+    );
+  }
+
+  get timeout(): number {
+    return this.configService.get<number>('PINATA_TIMEOUT_MS');
+  }
 }

--- a/corporate-platform/corporate-platform-backend/src/ipfs/ipfs.module.ts
+++ b/corporate-platform/corporate-platform-backend/src/ipfs/ipfs.module.ts
@@ -1,6 +1,7 @@
 import { Module } from '@nestjs/common';
 import { IpfsService } from './ipfs.service';
 import { IpfsConfig } from './ipfs.config';
+import { PinataHealthService } from './pinata-health.service';
 import { UploadService } from './services/upload.service';
 import { RetrievalService } from './services/retrieval.service';
 import { PinningService } from './services/pinning.service';
@@ -14,6 +15,7 @@ import { IPFS_PROVIDER } from './interfaces/ipfs-provider.interface';
   imports: [DatabaseModule],
   providers: [
     IpfsConfig,
+    PinataHealthService,
     // Register the active provider via injection token.
     // To switch providers, replace PinataProvider with another IIpfsProvider implementation.
     {

--- a/corporate-platform/corporate-platform-backend/src/ipfs/ipfs.service.spec.ts
+++ b/corporate-platform/corporate-platform-backend/src/ipfs/ipfs.service.spec.ts
@@ -1,11 +1,25 @@
 import { IpfsService } from './ipfs.service';
 import { IpfsConfig } from './ipfs.config';
 
+const mockConfigService = {
+  get: jest.fn((key: string) => {
+    const config: Record<string, any> = {
+      PINATA_API_KEY: 'test-key',
+      PINATA_SECRET_KEY: 'test-secret',
+      PINATA_JWT: 'test-jwt',
+      PINATA_GATEWAY: 'https://gateway.pinata.cloud/ipfs/',
+      IPFS_GATEWAY: 'https://ipfs.io/ipfs/',
+      PINATA_TIMEOUT_MS: 20000,
+    };
+    return config[key];
+  }),
+} as any;
+
 describe('IpfsService', () => {
   let service: IpfsService;
 
   beforeAll(() => {
-    const config = new IpfsConfig();
+    const config = new IpfsConfig(mockConfigService);
     service = new IpfsService(config);
   });
 

--- a/corporate-platform/corporate-platform-backend/src/ipfs/pinata-health.service.ts
+++ b/corporate-platform/corporate-platform-backend/src/ipfs/pinata-health.service.ts
@@ -1,0 +1,38 @@
+import { Injectable, OnModuleInit, Logger } from '@nestjs/common';
+import { IpfsConfig } from './ipfs.config';
+
+@Injectable()
+export class PinataHealthService implements OnModuleInit {
+  private readonly logger = new Logger(PinataHealthService.name);
+
+  constructor(private readonly ipfsConfig: IpfsConfig) {}
+
+  async onModuleInit() {
+    this.logger.log('Validating Pinata API credential connectivity...');
+    try {
+      const response = await fetch(
+        'https://api.pinata.cloud/data/testAuthentication',
+        {
+          method: 'GET',
+          headers: {
+            Authorization: `Bearer ${this.ipfsConfig.jwt}`,
+          },
+          signal: AbortSignal.timeout(this.ipfsConfig.timeout),
+        },
+      );
+
+      if (!response.ok) {
+        const errorText = await response.text();
+        throw new Error(`Pinata status ${response.status}: ${errorText}`);
+      }
+
+      this.logger.log('Pinata credential health check passed successfully.');
+    } catch (error) {
+      this.logger.error(
+        `CRITICAL FATAL: Pinata startup health check failed. Ensure PINATA_JWT is valid. Error: ${error.message}`,
+      );
+      // Fail fast and prevent startup
+      process.exit(1);
+    }
+  }
+}

--- a/corporate-platform/corporate-platform-backend/src/ipfs/services/retrieval.service.spec.ts
+++ b/corporate-platform/corporate-platform-backend/src/ipfs/services/retrieval.service.spec.ts
@@ -3,6 +3,20 @@ import { createHash } from 'crypto';
 import { RetrievalService } from './retrieval.service';
 import { IpfsConfig } from '../ipfs.config';
 
+const mockConfigService = {
+  get: jest.fn((key: string) => {
+    const config: Record<string, any> = {
+      PINATA_API_KEY: 'test-key',
+      PINATA_SECRET_KEY: 'test-secret',
+      PINATA_JWT: 'test-jwt',
+      PINATA_GATEWAY: 'https://gateway.pinata.cloud/ipfs/',
+      IPFS_GATEWAY: 'https://ipfs.io/ipfs/',
+      PINATA_TIMEOUT_MS: 20000,
+    };
+    return config[key];
+  }),
+} as any;
+
 describe('RetrievalService hash verification', () => {
   const mockIpfs = {
     validateCid: jest.fn(),
@@ -19,7 +33,11 @@ describe('RetrievalService hash verification', () => {
 
   beforeEach(() => {
     jest.clearAllMocks();
-    service = new RetrievalService(mockIpfs, new IpfsConfig(), mockPrisma);
+    service = new RetrievalService(
+      mockIpfs,
+      new IpfsConfig(mockConfigService),
+      mockPrisma,
+    );
     mockIpfs.validateCid.mockReturnValue(true);
     mockIpfs.gatewayForCid.mockReturnValue(
       'https://gateway.pinata.cloud/ipfs/cid123',

--- a/corporate-platform/corporate-platform-backend/src/ipfs/services/upload.service.spec.ts
+++ b/corporate-platform/corporate-platform-backend/src/ipfs/services/upload.service.spec.ts
@@ -2,6 +2,20 @@ import { createHash } from 'crypto';
 import { UploadService } from './upload.service';
 import { IpfsConfig } from '../ipfs.config';
 
+const mockConfigService = {
+  get: jest.fn((key: string) => {
+    const config: Record<string, any> = {
+      PINATA_API_KEY: 'test-key',
+      PINATA_SECRET_KEY: 'test-secret',
+      PINATA_JWT: 'test-jwt',
+      PINATA_GATEWAY: 'https://gateway.pinata.cloud/ipfs/',
+      IPFS_GATEWAY: 'https://ipfs.io/ipfs/',
+      PINATA_TIMEOUT_MS: 20000,
+    };
+    return config[key];
+  }),
+} as any;
+
 jest.mock('clamscan', () => {
   return jest.fn().mockImplementation(() => ({
     init: jest.fn().mockResolvedValue({
@@ -35,7 +49,11 @@ describe('UploadService hash persistence', () => {
 
   beforeEach(() => {
     jest.clearAllMocks();
-    service = new UploadService(new IpfsConfig(), mockPrisma, mockProvider);
+    service = new UploadService(
+      new IpfsConfig(mockConfigService),
+      mockPrisma,
+      mockProvider,
+    );
     mockPrisma.ipfsDocument.findFirst.mockResolvedValue(null);
     mockPrisma.ipfsDocument.create.mockResolvedValue({
       id: 'doc1',


### PR DESCRIPTION
Description:
This PR addresses critical vulnerabilities where missing or incomplete environment configurations could allow the IPFS storage context to fail silently in production environments using dummy fallbacks.

We removed permissive defaults, added rigorous scheme checks during initial module instantiation via Joi, and introduced a fail-fast application startup block using a lifecycle-hook connectivity test against Pinata's verification endpoint.

Changes:

- Core Config (src/ipfs/ipfs.config.ts): Decoupled direct process.env lookups and hardcoded string fallbacks (mock-pinata-*). Now injects NestJS ConfigService strictly.
- Validation Schema (src/config/validation/config.schema.ts): Appended mandatory rules requiring explicit instantiation of PINATA_API_KEY, PINATA_SECRET_KEY, and PINATA_JWT. Added runtime fallbacks for optional configurations (PINATA_GATEWAY, PINATA_TIMEOUT_MS).
- Health Check Guard (src/ipfs/pinata-health.service.ts): Implemented a startup health-check using OnModuleInit which validates token authenticity on boot against https://api.pinata.cloud/data/testAuthentication. Triggers process.exit(1) immediately if validation yields an unsafe configuration state.
- Dependencies & Blueprints: Added @nestjs/config into dependencies; populated documentation blocks within .env.example.
- Testing Specs: Updated ipfs.service.spec.ts, retrieval.service.spec.ts, and upload.service.spec.ts units to pass mocked configurations down constructor lines cleanly.

Closes #396 