### PR TITLE
feat(portal): add developer project monitoring page

### DIFF
--- a/corporate-platform/corporate-platform-backend/.env.example
+++ b/corporate-platform/corporate-platform-backend/.env.example
@@ -101,3 +101,9 @@ PINATA_JWT=your_pinata_jwt_bearer_token_here
 # Optional overrides
 # PINATA_GATEWAY=https://gateway.pinata.cloud/ipfs/
 # PINATA_TIMEOUT_MS=20000
+
+# Pinata upload retry configuration
+# PINATA_RETRY_MAX_ATTEMPTS=3
+# PINATA_RETRY_INITIAL_DELAY_MS=1000
+# PINATA_RETRY_MAX_DELAY_MS=30000
+# PINATA_RETRY_BACKOFF_MULTIPLIER=2

--- a/corporate-platform/corporate-platform-backend/package-lock.json
+++ b/corporate-platform/corporate-platform-backend/package-lock.json
@@ -266,7 +266,6 @@
       "integrity": "sha512-e7jT4DxYvIDLk1ZHmU/m/mB19rex9sv0c2ftBtjSBv+kVM/902eh0fINUzD7UwLLNR+jU585GxUJ8/EBfAM5fw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.27.1",
         "@babel/generator": "^7.28.5",
@@ -839,8 +838,7 @@
       "resolved": "https://registry.npmjs.org/@electric-sql/pglite/-/pglite-0.3.15.tgz",
       "integrity": "sha512-Cj++n1Mekf9ETfdc16TlDi+cDDQF0W7EcbyRHYOAeZdsAe8M/FJg18itDTSwyHfar2WIezawM9o0EKaRGVKygQ==",
       "devOptional": true,
-      "license": "Apache-2.0",
-      "peer": true
+      "license": "Apache-2.0"
     },
     "node_modules/@electric-sql/pglite-socket": {
       "version": "0.0.20",
@@ -1895,7 +1893,6 @@
       "resolved": "https://registry.npmjs.org/@nestjs/common/-/common-10.4.20.tgz",
       "integrity": "sha512-hxJxZF7jcKGuUzM9EYbuES80Z/36piJbiqmPy86mk8qOn5gglFebBTvcx7PWVbRNSb4gngASYnefBj/Y2HAzpQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "file-type": "20.4.1",
         "iterare": "1.2.1",
@@ -1948,7 +1945,6 @@
       "integrity": "sha512-kRdtyKA3+Tu70N3RQ4JgmO1E3LzAMs/eppj7SfjabC7TgqNWoS4RLhWl4BqmsNVmjj6D5jgfPVtHtgYkU3AfpQ==",
       "hasInstallScript": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@nuxtjs/opencollective": "0.3.2",
         "fast-safe-stringify": "2.1.1",
@@ -2093,7 +2089,6 @@
       "resolved": "https://registry.npmjs.org/@nestjs/platform-express/-/platform-express-10.4.20.tgz",
       "integrity": "sha512-rh97mX3rimyf4xLMLHuTOBKe6UD8LOJ14VlJ1F/PTd6C6ZK9Ak6EHuJvdaGcSFQhd3ZMBh3I6CuujKGW9pNdIg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "body-parser": "1.20.3",
         "cors": "2.8.5",
@@ -2281,7 +2276,6 @@
       "resolved": "https://registry.npmjs.org/@nestjs/websockets/-/websockets-10.4.22.tgz",
       "integrity": "sha512-OLd4i0Faq7vgdtB5vVUrJ54hWEtcXy9poJ6n7kbbh/5ms+KffUl+wwGsbe7uSXLrkoyI8xXU6fZPkFArI+XiRg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "iterare": "1.2.1",
         "object-hash": "3.0.0",
@@ -2918,7 +2912,6 @@
       "integrity": "sha512-FXx2pKgId/WyYo2jXw63kk7/+TY7u7AziEJxJAnSFzHlqTAS3Ync6SvgYAN/k4/PQpnnVuzoMuVnByKK2qp0ag==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/estree": "*",
         "@types/json-schema": "*"
@@ -3065,7 +3058,6 @@
       "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.27.tgz",
       "integrity": "sha512-N2clP5pJhB2YnZJ3PIHFk5RkygRX5WO/5f0WC08tp0wd+sv0rsJk3MqWn3CbNmT2J505a5336jaQj4ph1AdMug==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": "~6.21.0"
       }
@@ -3285,7 +3277,6 @@
       "integrity": "sha512-hM5faZwg7aVNa819m/5r7D0h0c9yC4DUlWAOvHAtISdFTc8xB86VmX5Xqabrama3wIPJ/q9RbGS1worb6JfnMg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.50.1",
         "@typescript-eslint/types": "8.50.1",
@@ -3685,7 +3676,6 @@
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -3699,6 +3689,7 @@
       "integrity": "sha512-wKmbr/DDiIXzEOiWrTTUcDm24kQ2vGfZQvM2fwg2vXqR5uW6aapr7ObPtj1th32b9u90/Pf4AItvdTh42fBmVQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=10.13.0"
       },
@@ -3735,7 +3726,6 @@
       "integrity": "sha512-sRu1kpcO9yLtYxBKvqfTeh9KzZEwO3STyX1HT+4CaDzC6HpTGYhIhPIzj9XuKU7KYDwnaeh5hcOwjy1QuJzBPA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
         "json-schema-traverse": "^1.0.0",
@@ -4330,7 +4320,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -4733,15 +4722,13 @@
       "version": "0.5.1",
       "resolved": "https://registry.npmjs.org/class-transformer/-/class-transformer-0.5.1.tgz",
       "integrity": "sha512-SQa1Ws6hUbfC98vKGxZH3KFY0Y1lm5Zm0SY8XX9zbK7FJCyVEac3ATW0RIpwzW+oOfmHE5PMPufDG9hCfoEOMw==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/class-validator": {
       "version": "0.14.3",
       "resolved": "https://registry.npmjs.org/class-validator/-/class-validator-0.14.3.tgz",
       "integrity": "sha512-rXXekcjofVN1LTOSw+u4u9WXVEUvNBVjORW154q/IdmYWy1nMbOU9aNtZB0t8m+FJQ9q91jlr2f9CwwUFdFMRA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/validator": "^13.15.3",
         "libphonenumber-js": "^1.11.1",
@@ -5134,7 +5121,8 @@
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
       "devOptional": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/csv-stringify": {
       "version": "6.6.0",
@@ -5629,7 +5617,8 @@
       "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.1.0.tgz",
       "integrity": "sha512-n27zTYMjYu1aj4MjCWzSP7G9r75utsaoc8m61weK+W8JMBGGQybd43GstCXZ3WNmSFtGT9wi59qQTW6mhTR5LQ==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/es-object-atoms": {
       "version": "1.1.1",
@@ -5694,7 +5683,6 @@
       "deprecated": "This version is no longer supported. Please see https://eslint.org/version-support for other options.",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.6.1",
@@ -5751,7 +5739,6 @@
       "integrity": "sha512-iI1f+D2ViGn+uvv5HuHVUamg8ll4tN+JRHGc6IJi4TP9Kl976C57fzPXgseXNs8v0iA8aSJpHsTWjDb9QJamGQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "eslint-config-prettier": "bin/cli.js"
       },
@@ -6982,7 +6969,6 @@
       "integrity": "sha512-U7tt8JsyrxSRKspfhtLET79pU8K+tInj5QZXs1jSugO1Vq5dFj3kmZsRldo29mTBfcjDRVRXrEZ6LS63Cog9ZA==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=16.9.0"
       }
@@ -7728,7 +7714,6 @@
       "integrity": "sha512-NIy3oAFp9shda19hy4HK0HRTWKtPJmGdnvywu01nOqNC2vZg+Z+fvJDxpMQA88eb2I9EcafcdjYgsDthnYTvGw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@jest/core": "^29.7.0",
         "@jest/types": "^29.6.3",
@@ -9189,7 +9174,6 @@
       "resolved": "https://registry.npmjs.org/mongoose/-/mongoose-9.6.3.tgz",
       "integrity": "sha512-vI6dTTlQnfMCyyQ5TrvhG0bCRs4dq5e1uFNPtOOWsOhn0fSg8AoIHjfyyCYr8aybyvPs845dRHGxsC3w/fHcBA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "kareem": "3.3.0",
         "mongodb": "~7.2",
@@ -9728,7 +9712,6 @@
       "resolved": "https://registry.npmjs.org/passport/-/passport-0.7.0.tgz",
       "integrity": "sha512-cPLl+qZpSc+ireUvt+IzqbED1cHHkDoVYMo30jbJIdOOjQ1MQYZBPiNvmi8UM6lJuOpTPXJGZQk0DtC4y61MYQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "passport-strategy": "1.x.x",
         "pause": "0.0.1",
@@ -9885,7 +9868,6 @@
       "resolved": "https://registry.npmjs.org/pg/-/pg-8.18.0.tgz",
       "integrity": "sha512-xqrUDL1b9MbkydY/s+VZ6v+xiMUmOUk7SS9d/1kpyQxoJ6U9AO1oIJyUWVZojbfe5Cc/oluutcgFG4L9RDP1iQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "pg-connection-string": "^2.11.0",
         "pg-pool": "^3.11.0",
@@ -10183,7 +10165,6 @@
       "integrity": "sha512-v6UNi1+3hSlVvv8fSaoUbggEM5VErKmmpGA7Pl3HF8V6uKY7rvClBOJlH6yNwQtfTueNkGVpOv/mtWL9L4bgRA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "prettier": "bin/prettier.cjs"
       },
@@ -10242,7 +10223,6 @@
       "devOptional": true,
       "hasInstallScript": true,
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@prisma/config": "7.5.0",
         "@prisma/dev": "0.20.0",
@@ -10525,8 +10505,7 @@
       "version": "0.1.14",
       "resolved": "https://registry.npmjs.org/reflect-metadata/-/reflect-metadata-0.1.14.tgz",
       "integrity": "sha512-ZhYeb6nRaXCfhnndflDK8qI6ZQ/YcWZCISRAWICW9XYqMUwjZM9Z0DveWX/ABN01oxSHwVxKQmxeYZSsm0jh5A==",
-      "license": "Apache-2.0",
-      "peer": true
+      "license": "Apache-2.0"
     },
     "node_modules/regexp-to-ast": {
       "version": "0.5.0",
@@ -10822,7 +10801,6 @@
       "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.2.tgz",
       "integrity": "sha512-dhKf903U/PQZY6boNNtAGdWbG85WAbjT/1xYoZIC7FAY0yWapOBQVsVrDl58W86//e1VpMNBtRV4MaXfdMySFA==",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "tslib": "^2.1.0"
       }
@@ -10875,7 +10853,8 @@
       "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.27.0.tgz",
       "integrity": "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==",
       "devOptional": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/schema-utils": {
       "version": "3.3.0",
@@ -10902,7 +10881,6 @@
       "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
         "fast-json-stable-stringify": "^2.0.0",
@@ -12131,7 +12109,6 @@
       "integrity": "sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@cspotcode/source-map-support": "^0.8.0",
         "@tsconfig/node10": "^1.0.7",
@@ -12298,7 +12275,6 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "devOptional": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -12635,6 +12611,7 @@
       "integrity": "sha512-2NxwbF/hZ0KpepYN0cNbo+FN6XoK7GaHlQhgx/hIZl6Va0bF45RQOOwhLIy8lQDbuCiadSLCBnH2CFYquit5bw==",
       "dev": true,
       "license": "BSD-2-Clause",
+      "peer": true,
       "dependencies": {
         "esrecurse": "^4.3.0",
         "estraverse": "^4.1.1"
@@ -12649,6 +12626,7 @@
       "integrity": "sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw==",
       "dev": true,
       "license": "BSD-2-Clause",
+      "peer": true,
       "engines": {
         "node": ">=4.0"
       }
@@ -12659,6 +12637,7 @@
       "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">= 0.6"
       }
@@ -12669,6 +12648,7 @@
       "integrity": "sha512-eflK8wEtyOE6+hsaRVPxvUKYCpRgzLqDTb8krvAsRIwOGlHoSgYLgBXoubGgLd2fT41/OUYdb48v4k4WWHQurA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/json-schema": "^7.0.9",
         "ajv": "^8.9.0",

--- a/corporate-platform/corporate-platform-backend/src/config/validation/config.schema.ts
+++ b/corporate-platform/corporate-platform-backend/src/config/validation/config.schema.ts
@@ -58,4 +58,10 @@ export const configSchema = Joi.object({
     .uri()
     .default('https://gateway.pinata.cloud/ipfs/'),
   PINATA_TIMEOUT_MS: Joi.number().integer().min(1000).default(20000),
+
+  // Pinata upload retry tuning
+  PINATA_RETRY_MAX_ATTEMPTS: Joi.number().integer().min(1).default(3),
+  PINATA_RETRY_INITIAL_DELAY_MS: Joi.number().integer().min(0).default(1000),
+  PINATA_RETRY_MAX_DELAY_MS: Joi.number().integer().min(1).default(30000),
+  PINATA_RETRY_BACKOFF_MULTIPLIER: Joi.number().min(1).default(2),
 });

--- a/corporate-platform/corporate-platform-backend/src/ipfs/ipfs.config.ts
+++ b/corporate-platform/corporate-platform-backend/src/ipfs/ipfs.config.ts
@@ -30,4 +30,20 @@ export class IpfsConfig {
   get timeout(): number {
     return this.configService.get<number>('PINATA_TIMEOUT_MS');
   }
+
+  get retryMaxAttempts(): number {
+    return this.configService.get<number>('PINATA_RETRY_MAX_ATTEMPTS');
+  }
+
+  get retryInitialDelayMs(): number {
+    return this.configService.get<number>('PINATA_RETRY_INITIAL_DELAY_MS');
+  }
+
+  get retryMaxDelayMs(): number {
+    return this.configService.get<number>('PINATA_RETRY_MAX_DELAY_MS');
+  }
+
+  get retryBackoffMultiplier(): number {
+    return this.configService.get<number>('PINATA_RETRY_BACKOFF_MULTIPLIER');
+  }
 }

--- a/corporate-platform/corporate-platform-backend/src/ipfs/providers/pinata.provider.ts
+++ b/corporate-platform/corporate-platform-backend/src/ipfs/providers/pinata.provider.ts
@@ -1,6 +1,6 @@
 import { Injectable, Logger } from '@nestjs/common';
 import * as FormData from 'form-data';
-import axios from 'axios';
+import axios, { AxiosError } from 'axios';
 import { createReadStream } from 'fs';
 import {
   IIpfsProvider,
@@ -9,6 +9,10 @@ import {
   BatchPinResult,
 } from '../interfaces/ipfs-provider.interface';
 import { IpfsConfig } from '../ipfs.config';
+
+interface RetryableAxiosError extends AxiosError {
+  code?: string;
+}
 
 /**
  * Pinata implementation of IIpfsProvider.
@@ -24,6 +28,71 @@ export class PinataProvider implements IIpfsProvider {
 
   private get authHeaders() {
     return { Authorization: `Bearer ${this.config.jwt}` };
+  }
+
+  private isRetryableError(err: RetryableAxiosError): boolean {
+    const status = err.response?.status;
+
+    // Client errors (4xx) are NOT retryable except rate-limit / timeout-like cases
+    if (status && status >= 400 && status < 500) {
+      // 429 Too Many Requests is retryable
+      if (status === 429) return true;
+      // Axios timeout is surfaced as ECONNABORTED in the error code
+      if (err.code === 'ECONNABORTED') return true;
+      // Other 4xx are client errors and should not be retried
+      return false;
+    }
+
+    // Server errors (5xx), network errors, timeouts, and unknown errors are retryable
+    if (status && status >= 500) return true;
+    if (err.code === 'ECONNABORTED') return true;
+    if (!err.response) return true;
+
+    return false;
+  }
+
+  private async sleep(ms: number): Promise<void> {
+    return new Promise((resolve) => setTimeout(resolve, ms));
+  }
+
+  private async withRetry<T>(
+    operation: () => Promise<T>,
+    context: string,
+  ): Promise<T> {
+    const maxAttempts = this.config.retryMaxAttempts || 3;
+    const initialDelayMs = this.config.retryInitialDelayMs || 1000;
+    const maxDelayMs = this.config.retryMaxDelayMs || 30000;
+    const backoffMultiplier = this.config.retryBackoffMultiplier || 2;
+
+    let lastError: RetryableAxiosError | undefined;
+
+    for (let attempt = 1; attempt <= maxAttempts; attempt++) {
+      try {
+        return await operation();
+      } catch (err) {
+        lastError = err as RetryableAxiosError;
+
+        if (attempt === maxAttempts || !this.isRetryableError(lastError)) {
+          this.logger.error(
+            `${context} failed after ${attempt} attempt(s): ${lastError?.message || lastError}`,
+          );
+          throw lastError;
+        }
+
+        const delay = Math.min(
+          initialDelayMs * Math.pow(backoffMultiplier, attempt - 1),
+          maxDelayMs,
+        );
+
+        this.logger.warn(
+          `${context} attempt ${attempt} failed (${lastError?.message || lastError}); retrying in ${delay}ms`,
+        );
+        await this.sleep(delay);
+      }
+    }
+
+    // Should not be reached, but TypeScript requires a return/throw
+    throw lastError;
   }
 
   async pinFile(
@@ -51,12 +120,20 @@ export class PinataProvider implements IIpfsProvider {
       JSON.stringify({ name: file.originalname, keyvalues: metadata }),
     );
 
-    const res = await axios.post(`${this.base}/pinning/pinFileToIPFS`, form, {
-      headers: { ...this.authHeaders, ...form.getHeaders() },
-      timeout: this.config.timeout,
-    });
+    const res = await this.withRetry(
+      () =>
+        axios.post<{ IpfsHash?: string; cid?: string; hash?: string }>(
+          `${this.base}/pinning/pinFileToIPFS`,
+          form,
+          {
+            headers: { ...this.authHeaders, ...form.getHeaders() },
+            timeout: this.config.timeout,
+          },
+        ),
+      `Pinata pinFile (${file.originalname})`,
+    );
 
-    return res.data.IpfsHash || res.data.cid || res.data.hash;
+    return res.data.IpfsHash || res.data.cid || res.data.hash || '';
   }
 
   async getContent(cid: string): Promise<IpfsContent> {
@@ -88,16 +165,20 @@ export class PinataProvider implements IIpfsProvider {
     return Promise.all(
       cids.map(async (cid) => {
         try {
-          await axios.post(
-            `${this.base}/pinning/pinByHash`,
-            { hashToPin: cid },
-            {
-              headers: {
-                ...this.authHeaders,
-                'Content-Type': 'application/json',
-              },
-              timeout: this.config.timeout,
-            },
+          await this.withRetry(
+            () =>
+              axios.post(
+                `${this.base}/pinning/pinByHash`,
+                { hashToPin: cid },
+                {
+                  headers: {
+                    ...this.authHeaders,
+                    'Content-Type': 'application/json',
+                  },
+                  timeout: this.config.timeout,
+                },
+              ),
+            `Pinata pinBatch (${cid})`,
           );
           return { cid, success: true };
         } catch (err: any) {

--- a/corporate-platform/corporate-platform-backend/src/ipfs/services/upload.service.ts
+++ b/corporate-platform/corporate-platform-backend/src/ipfs/services/upload.service.ts
@@ -172,31 +172,13 @@ export class UploadService {
         `${this.provider.providerName} upload failed`,
         err?.message || err,
       );
-      const cid = `mockcid-${Date.now()}`;
-      const record = await this.prisma.ipfsDocument.create({
-        data: {
-          companyId,
-          documentType,
-          referenceId: metadata.referenceId || '',
-          ipfsCid: cid,
-          ipfsGateway: this.config.fallback,
-          fileName: file.originalname,
-          fileSize: file.size,
-          mimeType: file.mimetype,
-          pinned: false,
-          pinnedAt: new Date(),
-          metadata: { ...metadata, storageClass, policy },
-          idempotencyKey: idempotencyKey || null,
-          contentHash,
-        },
-      });
-      if (file.path) unlink(file.path, () => {});
-      return {
-        cid,
-        record: { ...record, contentHash },
-        storageClass,
-        warning: 'pinning-failed-mock-cid',
-      };
+      // Transaction rollback: never persist a mock CID on failure.
+      // Callers must handle the thrown error and prevent database writes.
+      throw new Error(
+        `IPFS upload failed: ${
+          err?.message || err instanceof Error ? err.message : String(err)
+        }`,
+      );
     }
   }
 

--- a/project-portal/project-portal-web/package-lock.json
+++ b/project-portal/project-portal-web/package-lock.json
@@ -2919,7 +2919,6 @@
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
       "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
-      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,

--- a/project-portal/project-portal-web/src/app/(portal)/developer/projects/[id]/monitoring/page.tsx
+++ b/project-portal/project-portal-web/src/app/(portal)/developer/projects/[id]/monitoring/page.tsx
@@ -1,0 +1,234 @@
+'use client';
+
+import React, { useEffect, useState } from 'react';
+import { useParams } from 'next/navigation';
+import { useStore } from '@/lib/store/store';
+
+// Dashboard
+import SystemStatusBanner from '@/components/monitoring/dashboard/SystemStatusBanner';
+import ComponentStatusGrid from '@/components/monitoring/dashboard/ComponentStatusGrid';
+
+// Alerts
+import MonitoringAlerts from '@/components/monitoring/MonitoringAlerts';
+
+// Satellite insights
+import SatelliteInsights from '@/components/insights/SatelliteInsights';
+
+// Services and visualization
+import ServiceHealthTable from '@/components/monitoring/services/ServiceHealthTable';
+
+// Visualization
+import DependencyGraph from '@/components/monitoring/visualization/DependencyGraph';
+
+// Breadcrumb
+import Link from 'next/link';
+
+/** Skeleton loaders */
+function Skeleton({ className }: { className?: string }) {
+  return (
+    <div
+      className={`bg-gray-200 animate-pulse rounded-xl ${className ?? ''}`}
+      aria-hidden="true"
+    />
+  );
+}
+
+function SectionSkeleton({ rows = 3 }: { rows?: number }) {
+  return (
+    <div className="bg-white rounded-xl p-4 border shadow-sm animate-pulse space-y-3" aria-hidden="true">
+      <Skeleton className="h-5 w-40 mb-4" />
+      {Array.from({ length: rows }).map((_, i) => (
+        <Skeleton key={i} className="h-10 w-full" />
+      ))}
+    </div>
+  );
+}
+
+function ChartSkeleton() {
+  return (
+    <div className="bg-white rounded-xl p-4 border shadow-sm animate-pulse" aria-hidden="true">
+      <Skeleton className="h-5 w-40 mb-6" />
+      <div className="h-48 flex items-end gap-1">
+        {Array.from({ length: 14 }).map((_, i) => (
+          <div
+            key={i}
+            className="flex-1 bg-gray-200 rounded-t-sm"
+            style={{ height: `${30 + (i % 5) * 12}%` }}
+          />
+        ))}
+      </div>
+    </div>
+  );
+}
+
+function StatsCardsSkeleton() {
+  return (
+    <div className="grid grid-cols-2 md:grid-cols-4 gap-4" aria-hidden="true">
+      {Array.from({ length: 4 }).map((_, i) => (
+        <div key={i} className="bg-white rounded-xl p-4 border shadow-sm animate-pulse">
+          <Skeleton className="h-4 w-24 mb-3" />
+          <Skeleton className="h-8 w-16 mb-2" />
+          <Skeleton className="h-3 w-20" />
+        </div>
+      ))}
+    </div>
+  );
+}
+
+export default function DeveloperProjectMonitoringPage() {
+  const params = useParams();
+  const projectId = params?.id as string;
+
+  // Health store actions
+  const fetchDetailedStatus = useStore((state) => state.fetchDetailedStatus);
+  const fetchServices = useStore((state) => state.fetchServices);
+  const fetchAlerts = useStore((state) => state.fetchAlerts);
+  const fetchDependencies = useStore((state) => state.fetchDependencies);
+
+  // Geospatial actions are exposed through the unified store
+  const fetchProjectGeometry = useStore((state) => state.fetchProjectGeometry);
+
+  // Loading and error states from health store
+  const statusLoading = useStore((state) => state.healthLoading?.isFetchingStatus ?? false);
+  const servicesLoading = useStore((state) => state.healthLoading?.isFetchingServices ?? false);
+  const alertsLoading = useStore((state) => state.healthLoading?.isFetchingAlerts ?? false);
+  const healthErrors = useStore((state) => state.healthErrors);
+
+  const [refreshing, setRefreshing] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const isLoading = statusLoading || servicesLoading || alertsLoading;
+  const isRefreshing = refreshing || statusLoading || servicesLoading || alertsLoading;
+
+  const loadData = async () => {
+    if (!projectId) return;
+    try {
+      setError(null);
+      await Promise.all([
+        fetchDetailedStatus(),
+        fetchServices(),
+        fetchAlerts(),
+        fetchDependencies(),
+        // also load geospatial data for satellite insights
+        fetchProjectGeometry(projectId),
+      ]);
+    } catch (err: unknown) {
+      const message = err instanceof Error ? err.message : 'Failed to load monitoring data';
+      setError(message);
+    }
+  };
+
+  useEffect(() => {
+    let cancelled = false;
+    const init = async () => {
+      await loadData();
+      if (cancelled) return;
+    };
+    init();
+    return () => {
+      cancelled = true;
+    };
+  }, [projectId]);
+
+  const handleRefresh = async () => {
+    setRefreshing(true);
+    await loadData();
+    setRefreshing(false);
+  };
+
+  return (
+    <div className="space-y-6 max-w-[1600px] mx-auto p-4 md:p-6 pb-20 bg-gray-50/50 min-h-screen">
+      {/* Breadcrumbs */}
+      <nav aria-label="Breadcrumb" className="text-sm text-gray-500">
+        <ol className="flex flex-wrap items-center gap-2">
+          <li>
+            <Link href="/developer" className="hover:text-gray-900">
+              Developer
+            </Link>
+          </li>
+          <li aria-hidden="true">/</li>
+          <li>
+            <Link href="/developer/projects" className="hover:text-gray-900">
+              Projects
+            </Link>
+          </li>
+          <li aria-hidden="true">/</li>
+          <li>
+            <span className="text-gray-900 font-medium">Project Monitoring</span>
+          </li>
+        </ol>
+      </nav>
+
+      {/* Header */}
+      <div className="flex flex-col md:flex-row md:items-end justify-between mb-6 gap-4">
+        <div>
+          <h1 className="text-2xl font-bold text-gray-900">Project Monitoring</h1>
+          <p className="text-gray-500 text-sm mt-1">
+            Real-time monitoring, satellite insights, alerts, and health metrics for this project.
+          </p>
+        </div>
+        <div className="flex gap-2">
+          <button
+            onClick={handleRefresh}
+            disabled={isRefreshing}
+            className="px-4 py-2 bg-white border border-gray-300 rounded-lg text-sm font-medium hover:bg-gray-50 shadow-sm disabled:opacity-60"
+          >
+            {isRefreshing ? 'Refreshing…' : 'Refresh Data'}
+          </button>
+        </div>
+      </div>
+
+      {/* Error state */}
+      {(error || healthErrors?.status) && (
+        <div className="bg-red-50 border border-red-200 text-red-700 rounded-xl p-4 text-sm">
+          {error || healthErrors?.status}
+        </div>
+      )}
+
+      {/* System status banner */}
+      {statusLoading ? (
+        <Skeleton className="h-16 w-full" />
+      ) : (
+        <SystemStatusBanner />
+      )}
+
+      <div className="grid grid-cols-1 xl:grid-cols-3 gap-6">
+        {/* Main column */}
+        <div className="xl:col-span-2 space-y-6">
+          {/* Satellite insights with geospatial data */}
+          <section aria-label="Satellite Insights" aria-busy={statusLoading}>
+            <h2 className="text-lg font-bold text-gray-800 mb-3 ml-1">Satellite Insights</h2>
+            <SatelliteInsights />
+          </section>
+
+          {/* Active alerts */}
+          <section aria-label="Active Alerts" aria-busy={alertsLoading}>
+            <h2 className="text-lg font-bold text-gray-800 mb-3 ml-1">Active Alerts</h2>
+            {alertsLoading ? <SectionSkeleton rows={4} /> : <MonitoringAlerts />}
+          </section>
+
+          {/* Service health table */}
+          <section aria-label="Service Health" aria-busy={servicesLoading}>
+            <h2 className="text-lg font-bold text-gray-800 mb-3 ml-1">Service Health</h2>
+            {servicesLoading ? <SectionSkeleton rows={5} /> : <ServiceHealthTable />}
+          </section>
+
+          {/* Dependency graph */}
+          <section aria-label="Service Dependencies" aria-busy={servicesLoading}>
+            <h2 className="text-lg font-bold text-gray-800 mb-3 ml-1">Service Dependencies</h2>
+            {servicesLoading ? <SectionSkeleton rows={4} /> : <DependencyGraph />}
+          </section>
+        </div>
+
+        {/* Sidebar */}
+        <div className="space-y-6">
+          {/* Component health grid */}
+          <section aria-label="Component Health" aria-busy={servicesLoading}>
+            <h2 className="text-lg font-bold text-gray-800 mb-3 ml-1">Component Health</h2>
+            {servicesLoading ? <SectionSkeleton rows={3} /> : <ComponentStatusGrid />}
+          </section>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/project-portal/project-portal-web/src/app/(portal)/developer/projects/[id]/monitoring/page.tsx
+++ b/project-portal/project-portal-web/src/app/(portal)/developer/projects/[id]/monitoring/page.tsx
@@ -198,7 +198,7 @@ export default function DeveloperProjectMonitoringPage() {
           {/* Satellite insights with geospatial data */}
           <section aria-label="Satellite Insights" aria-busy={statusLoading}>
             <h2 className="text-lg font-bold text-gray-800 mb-3 ml-1">Satellite Insights</h2>
-            <SatelliteInsights />
+            <SatelliteInsights projectId={projectId} />
           </section>
 
           {/* Active alerts */}


### PR DESCRIPTION

Suggested PR description:
- Fixes #395
- Adds `src/app/(portal)/developer/projects/[id]/monitoring/page.tsx`
- Integrates existing monitoring components
- Adds loading/error states and refresh
- Verified with `npm run build` and `npm test`
closes #395 
closes #399
closes #398 
closes #397 