### PR TITLE
feat: add centralized client-side error reporting

### DIFF
--- a/corporate-platform/corporate-platform-web/.env.example
+++ b/corporate-platform/corporate-platform-web/.env.example
@@ -32,3 +32,16 @@ NEXT_PUBLIC_CONNECTIVITY_CHECK_INTERVAL=30000
 NEXT_PUBLIC_MAX_QUEUE_SIZE=100
 # Maximum retry attempts for queued requests
 NEXT_PUBLIC_QUEUE_MAX_RETRIES=3
+
+# Error Reporting Configuration
+# Endpoint to forward structured error payloads (leave blank to disable remote reporting)
+NEXT_PUBLIC_ERROR_REPORTING_ENDPOINT=
+
+# Max errors forwarded per rate-limit window (default: 50)
+NEXT_PUBLIC_ERROR_RATE_LIMIT_MAX=50
+
+# Rate-limit window in milliseconds (default: 60000 = 1 minute)
+NEXT_PUBLIC_ERROR_RATE_LIMIT_WINDOW_MS=60000
+
+# Minimum severity to log to console in development: info | warning | error | critical (default: warning)
+NEXT_PUBLIC_ERROR_DEV_MIN_SEVERITY=warning

--- a/corporate-platform/corporate-platform-web/src/app/analytics/error.tsx
+++ b/corporate-platform/corporate-platform-web/src/app/analytics/error.tsx
@@ -1,6 +1,7 @@
 'use client'; // Error components must be Client Components
 
 import { useEffect } from 'react';
+import { reportError } from '@/lib/telemetry/errorReporter';
 
 export default function Error({
   error,
@@ -10,7 +11,7 @@ export default function Error({
   reset: () => void;
 }) {
   useEffect(() => {
-    console.error(error);
+    reportError(error, 'analytics/error', 'error');
   }, [error]);
 
   return (

--- a/corporate-platform/corporate-platform-web/src/app/compliance/error.tsx
+++ b/corporate-platform/corporate-platform-web/src/app/compliance/error.tsx
@@ -1,6 +1,7 @@
 'use client'; // Error components must be Client Components
 
 import { useEffect } from 'react';
+import { reportError } from '@/lib/telemetry/errorReporter';
 
 export default function Error({
   error,
@@ -10,7 +11,7 @@ export default function Error({
   reset: () => void;
 }) {
   useEffect(() => {
-    console.error(error);
+    reportError(error, 'compliance/error', 'error');
   }, [error]);
 
   return (

--- a/corporate-platform/corporate-platform-web/src/app/documents/error.tsx
+++ b/corporate-platform/corporate-platform-web/src/app/documents/error.tsx
@@ -1,6 +1,7 @@
 'use client'; // Error components must be Client Components
 
 import { useEffect } from 'react';
+import { reportError } from '@/lib/telemetry/errorReporter';
 
 export default function Error({
   error,
@@ -10,7 +11,7 @@ export default function Error({
   reset: () => void;
 }) {
   useEffect(() => {
-    console.error(error);
+    reportError(error, 'documents/error', 'error');
   }, [error]);
 
   return (

--- a/corporate-platform/corporate-platform-web/src/app/marketplace/error.tsx
+++ b/corporate-platform/corporate-platform-web/src/app/marketplace/error.tsx
@@ -1,6 +1,7 @@
 'use client'; // Error components must be Client Components
 
 import { useEffect } from 'react';
+import { reportError } from '@/lib/telemetry/errorReporter';
 
 export default function Error({
   error,
@@ -10,7 +11,7 @@ export default function Error({
   reset: () => void;
 }) {
   useEffect(() => {
-    console.error(error);
+    reportError(error, 'marketplace/error', 'error');
   }, [error]);
 
   return (

--- a/corporate-platform/corporate-platform-web/src/app/portfolio/error.tsx
+++ b/corporate-platform/corporate-platform-web/src/app/portfolio/error.tsx
@@ -1,6 +1,7 @@
 'use client'; // Error components must be Client Components
 
 import { useEffect } from 'react';
+import { reportError } from '@/lib/telemetry/errorReporter';
 
 export default function Error({
   error,
@@ -10,7 +11,7 @@ export default function Error({
   reset: () => void;
 }) {
   useEffect(() => {
-    console.error(error);
+    reportError(error, 'portfolio/error', 'error');
   }, [error]);
 
   return (

--- a/corporate-platform/corporate-platform-web/src/app/projects/error.tsx
+++ b/corporate-platform/corporate-platform-web/src/app/projects/error.tsx
@@ -1,6 +1,7 @@
 'use client'; // Error components must be Client Components
 
 import { useEffect } from 'react';
+import { reportError } from '@/lib/telemetry/errorReporter';
 
 export default function Error({
   error,
@@ -10,7 +11,7 @@ export default function Error({
   reset: () => void;
 }) {
   useEffect(() => {
-    console.error(error);
+    reportError(error, 'projects/error', 'error');
   }, [error]);
 
   return (

--- a/corporate-platform/corporate-platform-web/src/app/reporting/error.tsx
+++ b/corporate-platform/corporate-platform-web/src/app/reporting/error.tsx
@@ -1,6 +1,7 @@
 'use client'; // Error components must be Client Components
 
 import { useEffect } from 'react';
+import { reportError } from '@/lib/telemetry/errorReporter';
 
 export default function Error({
   error,
@@ -10,7 +11,7 @@ export default function Error({
   reset: () => void;
 }) {
   useEffect(() => {
-    console.error(error);
+    reportError(error, 'reporting/error', 'error');
   }, [error]);
 
   return (

--- a/corporate-platform/corporate-platform-web/src/app/retirement/error.tsx
+++ b/corporate-platform/corporate-platform-web/src/app/retirement/error.tsx
@@ -1,6 +1,7 @@
 'use client'; // Error components must be Client Components
 
 import { useEffect } from 'react';
+import { reportError } from '@/lib/telemetry/errorReporter';
 
 export default function Error({
   error,
@@ -10,7 +11,7 @@ export default function Error({
   reset: () => void;
 }) {
   useEffect(() => {
-    console.error(error);
+    reportError(error, 'retirement/error', 'error');
   }, [error]);
 
   return (

--- a/corporate-platform/corporate-platform-web/src/app/settings/error.tsx
+++ b/corporate-platform/corporate-platform-web/src/app/settings/error.tsx
@@ -1,6 +1,7 @@
 'use client'; // Error components must be Client Components
 
 import { useEffect } from 'react';
+import { reportError } from '@/lib/telemetry/errorReporter';
 
 export default function Error({
   error,
@@ -10,7 +11,7 @@ export default function Error({
   reset: () => void;
 }) {
   useEffect(() => {
-    console.error(error);
+    reportError(error, 'settings/error', 'error');
   }, [error]);
 
   return (

--- a/corporate-platform/corporate-platform-web/src/app/team/error.tsx
+++ b/corporate-platform/corporate-platform-web/src/app/team/error.tsx
@@ -1,6 +1,7 @@
 'use client'; // Error components must be Client Components
 
 import { useEffect } from 'react';
+import { reportError } from '@/lib/telemetry/errorReporter';
 
 export default function Error({
   error,
@@ -10,7 +11,7 @@ export default function Error({
   reset: () => void;
 }) {
   useEffect(() => {
-    console.error(error);
+    reportError(error, 'team/error', 'error');
   }, [error]);
 
   return (

--- a/corporate-platform/corporate-platform-web/src/components/audit/AuditTrailViewer.tsx
+++ b/corporate-platform/corporate-platform-web/src/components/audit/AuditTrailViewer.tsx
@@ -4,6 +4,7 @@ import React, { useState, useEffect } from 'react';
 import { queryAuditEvents, exportAuditEvents } from '@/lib/api/audit.api';
 import type { AuditEvent, AuditQueryParams, AuditEventType, AuditAction } from '@/types/audit.types';
 import { formatDate, formatEventType, formatAction } from '@/lib/utils/audit-formatters';
+import { reportError } from '@/lib/telemetry/errorReporter';
 
 interface AuditTrailViewerProps {
   entityType?: string;
@@ -55,7 +56,7 @@ export default function AuditTrailViewer({ entityType, entityId, compact }: Audi
       a.click();
       window.URL.revokeObjectURL(url);
     } catch (err) {
-      console.error('Export failed:', err);
+      reportError(err, 'AuditTrailViewer', 'error', { operation: 'export', format });
     }
   };
 

--- a/corporate-platform/corporate-platform-web/src/components/audit/ChainIntegrityChecker.tsx
+++ b/corporate-platform/corporate-platform-web/src/components/audit/ChainIntegrityChecker.tsx
@@ -4,6 +4,7 @@ import React, { useState } from 'react';
 import { checkChainIntegrity, anchorAuditTrail } from '@/lib/api/audit.api';
 import type { ChainIntegrityResult } from '@/types/audit.types';
 import { Shield, ShieldCheck, ShieldX, Loader2, Link } from 'lucide-react';
+import { reportError } from '@/lib/telemetry/errorReporter';
 
 export default function ChainIntegrityChecker() {
   const [checking, setChecking] = useState(false);
@@ -16,7 +17,7 @@ export default function ChainIntegrityChecker() {
       const data = await checkChainIntegrity();
       setResult(data);
     } catch (error) {
-      console.error('Chain integrity check failed:', error);
+      reportError(error, 'ChainIntegrityChecker', 'error', { operation: 'checkIntegrity' });
     } finally {
       setChecking(false);
     }
@@ -28,7 +29,7 @@ export default function ChainIntegrityChecker() {
       const response = await anchorAuditTrail();
       alert(`Successfully anchored to Stellar! TX: ${response.transactionHash}`);
     } catch (error) {
-      console.error('Anchoring failed:', error);
+      reportError(error, 'ChainIntegrityChecker', 'error', { operation: 'anchorTrail' });
       alert('Failed to anchor audit trail to blockchain');
     } finally {
       setAnchoring(false);

--- a/corporate-platform/corporate-platform-web/src/components/audit/EventDetails.tsx
+++ b/corporate-platform/corporate-platform-web/src/components/audit/EventDetails.tsx
@@ -5,6 +5,7 @@ import { verifyAuditEvent } from '@/lib/api/audit.api';
 import type { AuditEvent, VerificationResult } from '@/types/audit.types';
 import { formatDate, formatEventType, formatAction, formatHash } from '@/lib/utils/audit-formatters';
 import { Shield, ShieldCheck, ShieldX, Loader2 } from 'lucide-react';
+import { reportError } from '@/lib/telemetry/errorReporter';
 
 interface EventDetailsProps {
   event: AuditEvent;
@@ -21,7 +22,7 @@ export default function EventDetails({ event, onClose }: EventDetailsProps) {
       const result = await verifyAuditEvent(event.id);
       setVerification(result);
     } catch (error) {
-      console.error('Verification failed:', error);
+      reportError(error, 'EventDetails', 'error', { operation: 'verifyEvent', eventId: event.id });
     } finally {
       setVerifying(false);
     }

--- a/corporate-platform/corporate-platform-web/src/components/layout/CorporateNavbar.tsx
+++ b/corporate-platform/corporate-platform-web/src/components/layout/CorporateNavbar.tsx
@@ -5,6 +5,7 @@ import { Search, Bell, Settings, User, ChevronDown, Menu, X, LogOut } from 'luci
 import { useTheme } from '@/hooks/useTheme'
 import { useCorporate } from '@/contexts/CorporateContext'
 import { useAuth } from '@/contexts/AuthContext'
+import { reportError } from '@/lib/telemetry/errorReporter'
 
 export default function CorporateNavbar() {
   const [isMobileMenuOpen, setIsMobileMenuOpen] = useState(false)
@@ -17,7 +18,7 @@ export default function CorporateNavbar() {
     try {
       await logout()
     } catch (error) {
-      console.error('Logout failed:', error)
+      reportError(error, 'CorporateNavbar', 'warning', { operation: 'logout' })
     }
   }
 

--- a/corporate-platform/corporate-platform-web/src/contexts/AuthContext.tsx
+++ b/corporate-platform/corporate-platform-web/src/contexts/AuthContext.tsx
@@ -31,6 +31,7 @@ import {
   getUser,
   hasRefreshToken,
 } from '@/lib/auth/token-storage';
+import { reportError } from '@/lib/telemetry/errorReporter';
 
 interface AuthContextType {
   user: AuthUser | null;
@@ -75,7 +76,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
       setUser(profile)
       return profile
     } catch (error) {
-      console.error('Profile sync failed:', error)
+      reportError(error, 'AuthContext', 'error', { operation: 'syncProfile' })
       return null;
     }
   }, []);
@@ -105,7 +106,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
           setUser(null);
         }
       } catch (error) {
-        console.error('Auth initialization failed:', error);
+        reportError(error, 'AuthContext', 'error', { operation: 'initAuth' });
         clearAuthData();
         setUser(null);
       } finally {
@@ -136,7 +137,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
       
       return true;
     } catch (error) {
-      console.error('Token refresh failed:', error);
+      reportError(error, 'AuthContext', 'warning', { operation: 'refreshToken' });
       return false;
     }
   };
@@ -170,7 +171,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
 
       router.push('/')
     } catch (error) {
-      console.error('Login failed:', error)
+      reportError(error, 'AuthContext', 'error', { operation: 'login' })
       throw error
     } finally {
       setIsLoading(false)
@@ -195,7 +196,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
 
       router.push('/')
     } catch (error) {
-      console.error('Registration failed:', error)
+      reportError(error, 'AuthContext', 'error', { operation: 'register' })
       throw error
     } finally {
       setIsLoading(false)
@@ -213,7 +214,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
         try {
           await logoutApi(refreshToken);
         } catch (error) {
-          console.error('Backend logout failed:', error);
+          reportError(error, 'AuthContext', 'warning', { operation: 'backendLogout' });
           // Continue with client-side logout even if backend fails
         }
       }

--- a/corporate-platform/corporate-platform-web/src/hooks/useAnalytics.ts
+++ b/corporate-platform/corporate-platform-web/src/hooks/useAnalytics.ts
@@ -19,6 +19,7 @@ import type {
   PerformanceTimeSeries,
   PerformanceRanking,
 } from '@/types/analytics.types';
+import { reportError } from '@/lib/telemetry/errorReporter';
 
 interface UseAnalyticsState<T> {
   data: T | null;
@@ -43,7 +44,7 @@ function useAnalytics<T>(
       setData(result);
     } catch (err: any) {
       setError(err.message || 'Failed to fetch analytics data');
-      console.error('Analytics fetch error:', err);
+      reportError(err, 'useAnalytics', 'error');
     } finally {
       setLoading(false);
     }

--- a/corporate-platform/corporate-platform-web/src/hooks/useCredits.ts
+++ b/corporate-platform/corporate-platform-web/src/hooks/useCredits.ts
@@ -17,6 +17,7 @@ import type {
   CreditQueryParams,
   CreditStats,
 } from '@/types/credit.types';
+import { reportError } from '@/lib/telemetry/errorReporter';
 
 interface UseCreditState<T> {
   data: T | null;
@@ -41,7 +42,7 @@ function useCredit<T>(
       setData(result);
     } catch (err: any) {
       setError(err.message || 'Failed to fetch credit data');
-      console.error('Credit fetch error:', err);
+      reportError(err, 'useCredits', 'error');
     } finally {
       setLoading(false);
     }

--- a/corporate-platform/corporate-platform-web/src/lib/api/http.ts
+++ b/corporate-platform/corporate-platform-web/src/lib/api/http.ts
@@ -1,5 +1,6 @@
 import { parseApiError, ParsedError } from '@/lib/utils/errorParser'
 import { withRetry, isRetryableError, RetryOptions } from '@/lib/utils/retry'
+import { reportError } from '@/lib/telemetry/errorReporter'
 
 export class ApiError extends Error {
   readonly status: number
@@ -70,6 +71,7 @@ export async function apiRequest<T>(
         `Unable to reach the API at ${baseUrl}. Check that the backend is running and CORS allows this origin.`,
         error,
       )
+      reportError(apiError, 'http', 'error', { path, method: init.method ?? 'GET' })
       // Check if this is a retryable network error
       if (isRetryableError(error, 0)) {
         throw error // Let retry logic handle it
@@ -83,7 +85,11 @@ export async function apiRequest<T>(
     if (!response.ok) {
       const parsed = parseApiError(parsedBody, response.status)
       const apiError = new ApiError(response.status, parsed.message, parsedBody)
-      
+      reportError(apiError, 'http', response.status >= 500 ? 'error' : 'warning', {
+        path,
+        method: init.method ?? 'GET',
+        status: response.status,
+      })
       // Check if this is a retryable error (5xx, 408, 429)
       const isRetryable = response.status >= 500 || response.status === 408 || response.status === 429
       if (isRetryable) {

--- a/corporate-platform/corporate-platform-web/src/lib/auth/token-storage.ts
+++ b/corporate-platform/corporate-platform-web/src/lib/auth/token-storage.ts
@@ -8,6 +8,8 @@
  * with server-side token management.
  */
 
+import { reportError } from '@/lib/telemetry/errorReporter';
+
 const ACCESS_TOKEN_KEY = 'cs_access_token';
 const REFRESH_TOKEN_KEY = 'cs_refresh_token';
 const USER_KEY = 'cs_user';
@@ -32,7 +34,7 @@ export function storeTokens(accessToken: string, refreshToken: string, expiresIn
     localStorage.setItem(REFRESH_TOKEN_KEY, refreshToken);
     localStorage.setItem(TOKEN_EXPIRY_KEY, expiresAt.toString());
   } catch (error) {
-    console.error('Failed to store tokens:', error);
+    reportError(error, 'token-storage', 'warning', { operation: 'storeTokens' });
   }
 }
 
@@ -61,7 +63,7 @@ export function getAccessToken(): string | null {
     
     return token;
   } catch (error) {
-    console.error('Failed to get access token:', error);
+    reportError(error, 'token-storage', 'warning', { operation: 'getAccessToken' });
     return null;
   }
 }
@@ -75,7 +77,7 @@ export function getRefreshToken(): string | null {
   try {
     return localStorage.getItem(REFRESH_TOKEN_KEY);
   } catch (error) {
-    console.error('Failed to get refresh token:', error);
+    reportError(error, 'token-storage', 'warning', { operation: 'getRefreshToken' });
     return null;
   }
 }
@@ -90,7 +92,7 @@ export function getTokenExpiry(): number | null {
     const expiry = localStorage.getItem(TOKEN_EXPIRY_KEY);
     return expiry ? parseInt(expiry, 10) : null;
   } catch (error) {
-    console.error('Failed to get token expiry:', error);
+    reportError(error, 'token-storage', 'warning', { operation: 'getTokenExpiry' });
     return null;
   }
 }
@@ -126,7 +128,7 @@ export function clearAuthData(): void {
     localStorage.removeItem(TOKEN_EXPIRY_KEY);
     localStorage.removeItem(USER_KEY);
   } catch (error) {
-    console.error('Failed to clear auth data:', error);
+    reportError(error, 'token-storage', 'warning', { operation: 'clearAuthData' });
   }
 }
 
@@ -139,7 +141,7 @@ export function storeUser(user: any): void {
   try {
     localStorage.setItem(USER_KEY, JSON.stringify(user));
   } catch (error) {
-    console.error('Failed to store user:', error);
+    reportError(error, 'token-storage', 'warning', { operation: 'storeUser' });
   }
 }
 
@@ -153,7 +155,7 @@ export function getUser(): any | null {
     const userStr = localStorage.getItem(USER_KEY);
     return userStr ? JSON.parse(userStr) : null;
   } catch (error) {
-    console.error('Failed to get user:', error);
+    reportError(error, 'token-storage', 'warning', { operation: 'getUser' });
     return null;
   }
 }

--- a/corporate-platform/corporate-platform-web/src/lib/telemetry/errorReporter.ts
+++ b/corporate-platform/corporate-platform-web/src/lib/telemetry/errorReporter.ts
@@ -1,0 +1,143 @@
+/**
+ * Centralized Error Reporting Service
+ *
+ * Provides structured error capture with:
+ * - Typed severity levels
+ * - Rate limiting (max N errors per window)
+ * - Environment-based filtering (dev vs production)
+ * - Forwarding to an observability platform endpoint
+ */
+
+export type ErrorSeverity = 'info' | 'warning' | 'error' | 'critical';
+
+export interface ErrorPayload {
+  error: string;
+  severity: ErrorSeverity;
+  context: string;
+  metadata?: Record<string, unknown>;
+  timestamp: string;
+  url: string;
+  userAgent: string;
+  requestId?: string;
+}
+
+// ── Rate limiter ─────────────────────────────────────────────────────────────
+
+const RATE_LIMIT_MAX = Number(process.env.NEXT_PUBLIC_ERROR_RATE_LIMIT_MAX) || 50;
+const RATE_LIMIT_WINDOW_MS =
+  Number(process.env.NEXT_PUBLIC_ERROR_RATE_LIMIT_WINDOW_MS) || 60_000;
+
+let windowStart = Date.now();
+let windowCount = 0;
+
+function isRateLimited(): boolean {
+  const now = Date.now();
+  if (now - windowStart > RATE_LIMIT_WINDOW_MS) {
+    windowStart = now;
+    windowCount = 0;
+  }
+  if (windowCount >= RATE_LIMIT_MAX) return true;
+  windowCount++;
+  return false;
+}
+
+// ── Helpers ──────────────────────────────────────────────────────────────────
+
+function buildPayload(
+  error: unknown,
+  severity: ErrorSeverity,
+  context: string,
+  metadata?: Record<string, unknown>,
+  requestId?: string,
+): ErrorPayload {
+  const message =
+    error instanceof Error
+      ? error.message
+      : typeof error === 'string'
+        ? error
+        : JSON.stringify(error);
+
+  return {
+    error: message,
+    severity,
+    context,
+    metadata: {
+      ...metadata,
+      ...(error instanceof Error && error.stack ? { stack: error.stack } : {}),
+    },
+    timestamp: new Date().toISOString(),
+    url: typeof window !== 'undefined' ? window.location.href : '',
+    userAgent: typeof navigator !== 'undefined' ? navigator.userAgent : '',
+    requestId,
+  };
+}
+
+// ── Platform forwarder ───────────────────────────────────────────────────────
+
+const ENDPOINT = process.env.NEXT_PUBLIC_ERROR_REPORTING_ENDPOINT;
+
+async function forward(payload: ErrorPayload): Promise<void> {
+  if (!ENDPOINT) return;
+  try {
+    await fetch(ENDPOINT, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(payload),
+      keepalive: true,
+    });
+  } catch {
+    // Silently ignore forwarding failures to avoid recursion
+  }
+}
+
+// ── Dev console output ───────────────────────────────────────────────────────
+
+const IS_DEV = process.env.NODE_ENV === 'development';
+const DEV_MIN_SEVERITY = (process.env.NEXT_PUBLIC_ERROR_DEV_MIN_SEVERITY ||
+  'warning') as ErrorSeverity;
+
+const SEVERITY_RANK: Record<ErrorSeverity, number> = {
+  info: 0,
+  warning: 1,
+  error: 2,
+  critical: 3,
+};
+
+function shouldLogToConsole(severity: ErrorSeverity): boolean {
+  return SEVERITY_RANK[severity] >= SEVERITY_RANK[DEV_MIN_SEVERITY];
+}
+
+// ── Public API ───────────────────────────────────────────────────────────────
+
+/**
+ * Report an error to the centralized telemetry sink.
+ *
+ * @param error    - The error object or message string
+ * @param context  - Component or service name (e.g. 'AuthContext', 'api-client')
+ * @param severity - 'info' | 'warning' | 'error' | 'critical' (default: 'error')
+ * @param metadata - Additional key/value debug context
+ * @param requestId - Correlation ID if available
+ */
+export function reportError(
+  error: unknown,
+  context: string,
+  severity: ErrorSeverity = 'error',
+  metadata?: Record<string, unknown>,
+  requestId?: string,
+): void {
+  if (isRateLimited()) return;
+
+  const payload = buildPayload(error, severity, context, metadata, requestId);
+
+  if (IS_DEV) {
+    if (shouldLogToConsole(severity)) {
+      // eslint-disable-next-line no-console
+      console.error(`[${severity.toUpperCase()}] ${context}:`, error, metadata ?? '');
+    }
+    // In development, skip remote forwarding unless explicitly configured
+    if (!ENDPOINT) return;
+  }
+
+  // Fire-and-forget
+  forward(payload);
+}

--- a/corporate-platform/corporate-platform-web/src/lib/utils/requestQueue.ts
+++ b/corporate-platform/corporate-platform-web/src/lib/utils/requestQueue.ts
@@ -3,6 +3,8 @@
  * Queues mutation requests when offline and retries them when connection is restored
  */
 
+import { reportError } from '@/lib/telemetry/errorReporter';
+
 export interface QueuedRequest {
   id: string;
   url: string;
@@ -45,7 +47,7 @@ class RequestQueueManager {
         this.queue = JSON.parse(stored);
       }
     } catch (error) {
-      console.error('Failed to load request queue from storage:', error);
+      reportError(error, 'requestQueue', 'warning', { operation: 'loadFromStorage' });
     }
   }
 
@@ -58,7 +60,7 @@ class RequestQueueManager {
     try {
       localStorage.setItem(this.storageKey, JSON.stringify(this.queue));
     } catch (error) {
-      console.error('Failed to save request queue to storage:', error);
+      reportError(error, 'requestQueue', 'warning', { operation: 'saveToStorage' });
     }
   }
 

--- a/corporate-platform/corporate-platform-web/src/services/api-client.ts
+++ b/corporate-platform/corporate-platform-web/src/services/api-client.ts
@@ -2,6 +2,7 @@ import { getAccessToken } from '@/lib/auth/token-storage';
 import { parseApiError, ParsedError, ErrorCode } from '@/lib/utils/errorParser';
 import { withRetry, isRetryableError, RetryOptions, generateIdempotencyKey } from '@/lib/utils/retry';
 import { requestQueue } from '@/lib/utils/requestQueue';
+import { reportError } from '@/lib/telemetry/errorReporter';
 
 /**
  * Base API Client for handling HTTP requests
@@ -173,7 +174,7 @@ class ApiClient {
           };
         }
         
-        console.error(`API Error [${endpoint}]:`, parsedError.message);
+        reportError(error, 'api-client', 'error', { endpoint, message: parsedError.message });
 
         return {
           success: false,
@@ -196,7 +197,7 @@ class ApiClient {
         });
       } catch (error) {
         const parsedError = parseApiError(error);
-        console.error(`API Error [${endpoint}] after retries:`, parsedError.message);
+        reportError(error, 'api-client', 'error', { endpoint, message: parsedError.message, retried: true });
         return {
           success: false,
           error: parsedError.message,

--- a/corporate-platform/corporate-platform-web/src/services/compliance.service.ts
+++ b/corporate-platform/corporate-platform-web/src/services/compliance.service.ts
@@ -6,6 +6,7 @@ import {
   ComplianceReport,
   CheckComplianceRequest,
 } from '@/types';
+import { reportError } from '@/lib/telemetry/errorReporter';
 
 /**
  * Compliance API Service
@@ -70,13 +71,13 @@ class ComplianceService {
       });
 
       if (!response.ok) {
-        console.error(`Failed to export report: ${response.statusText}`);
+        reportError(`Failed to export report: ${response.statusText}`, 'compliance.service', 'error', { entityId });
         return null;
       }
 
       return await response.blob();
     } catch (error) {
-      console.error('Error exporting compliance report:', error);
+      reportError(error, 'compliance.service', 'error', { entityId });
       return null;
     }
   }


### PR DESCRIPTION
## Summary

Replaces all scattered `console.error` calls with a centralized telemetry sink that forwards structured error payloads to an observability platform.

## Changes

- **New:** `src/lib/telemetry/errorReporter.ts` — centralized error reporter with:
  - Structured `ErrorPayload` (error, severity, context, metadata, timestamp, url, userAgent, requestId)
  - Severity levels: `info | warning | error | critical`
  - Rate limiting: 50 errors/60s window (configurable)
  - Environment filtering: dev logs at/above `NEXT_PUBLIC_ERROR_DEV_MIN_SEVERITY`, skips remote forwarding unless endpoint is configured
  - Fire-and-forget forwarding to any observability endpoint (Sentry, DataDog, custom)
- **Updated:** `http.ts` — network errors and non-ok HTTP responses auto-reported
- **Updated:** 23 files — all 36 `console.error` calls replaced with `reportError`
- **Updated:** `.env.example` — 4 new error reporting config vars documented

## Testing

- `tsc --noEmit` — 0 type errors
- `vitest run` — 222/222 tests passing
- Zero `console.error` remaining outside the reporter itself
- Zero merge conflicts

Closes #403