### PR TITLE
feat(ipfs): add durable pin verification after upload

### DIFF
--- a/corporate-platform/corporate-platform-backend/.env.example
+++ b/corporate-platform/corporate-platform-backend/.env.example
@@ -107,3 +107,11 @@ PINATA_JWT=your_pinata_jwt_bearer_token_here
 # PINATA_RETRY_INITIAL_DELAY_MS=1000
 # PINATA_RETRY_MAX_DELAY_MS=30000
 # PINATA_RETRY_BACKOFF_MULTIPLIER=2
+
+# Pinata pin verification configuration
+# Number of times to retry gateway retrieval check after upload (default: 3)
+# PINATA_VERIFY_RETRY_ATTEMPTS=3
+# Delay in ms between verification retry attempts (default: 1000)
+# PINATA_VERIFY_RETRY_DELAY_MS=1000
+# Timeout in ms for each verification attempt; falls back to PINATA_TIMEOUT_MS (default: 10000)
+# PINATA_VERIFY_TIMEOUT_MS=10000

--- a/corporate-platform/corporate-platform-backend/src/ipfs/ipfs.config.ts
+++ b/corporate-platform/corporate-platform-backend/src/ipfs/ipfs.config.ts
@@ -46,4 +46,20 @@ export class IpfsConfig {
   get retryBackoffMultiplier(): number {
     return this.configService.get<number>('PINATA_RETRY_BACKOFF_MULTIPLIER');
   }
+
+  get verifyRetryAttempts(): number {
+    return this.configService.get<number>('PINATA_VERIFY_RETRY_ATTEMPTS', 3);
+  }
+
+  get verifyRetryDelayMs(): number {
+    return this.configService.get<number>('PINATA_VERIFY_RETRY_DELAY_MS', 1000);
+  }
+
+  get verifyTimeoutMs(): number {
+    return (
+      this.configService.get<number>('PINATA_VERIFY_TIMEOUT_MS') ||
+      this.timeout ||
+      10000
+    );
+  }
 }

--- a/corporate-platform/corporate-platform-backend/src/ipfs/pinata-health.service.ts
+++ b/corporate-platform/corporate-platform-backend/src/ipfs/pinata-health.service.ts
@@ -8,6 +8,11 @@ export class PinataHealthService implements OnModuleInit {
   constructor(private readonly ipfsConfig: IpfsConfig) {}
 
   async onModuleInit() {
+    await this.checkPinataCredentials();
+    await this.checkGatewayAvailability();
+  }
+
+  private async checkPinataCredentials(): Promise<void> {
     this.logger.log('Validating Pinata API credential connectivity...');
     try {
       const response = await fetch(
@@ -33,6 +38,39 @@ export class PinataHealthService implements OnModuleInit {
       );
       // Fail fast and prevent startup
       process.exit(1);
+    }
+  }
+
+  private async checkGatewayAvailability(): Promise<void> {
+    const gateway = this.ipfsConfig.gateway;
+    if (!gateway) {
+      this.logger.warn(
+        'PINATA_GATEWAY not configured; gateway availability check skipped.',
+      );
+      return;
+    }
+
+    this.logger.log(`Checking IPFS gateway availability: ${gateway}`);
+    try {
+      const response = await fetch(gateway, {
+        method: 'HEAD',
+        signal: AbortSignal.timeout(this.ipfsConfig.verifyTimeoutMs),
+      });
+
+      if (response.status >= 500) {
+        throw new Error(
+          `Gateway returned server error status ${response.status}`,
+        );
+      }
+
+      this.logger.log(
+        `IPFS gateway available (status ${response.status}).`,
+      );
+    } catch (error) {
+      this.logger.error(
+        `IPFS gateway health check failed for ${gateway}: ${error.message}. ` +
+          'Pin verification may fail until the gateway is reachable.',
+      );
     }
   }
 }

--- a/corporate-platform/corporate-platform-backend/src/ipfs/services/retrieval.service.spec.ts
+++ b/corporate-platform/corporate-platform-backend/src/ipfs/services/retrieval.service.spec.ts
@@ -4,7 +4,7 @@ import { RetrievalService } from './retrieval.service';
 import { IpfsConfig } from '../ipfs.config';
 
 const mockConfigService = {
-  get: jest.fn((key: string) => {
+  get: jest.fn((key: string, defaultValue?: any) => {
     const config: Record<string, any> = {
       PINATA_API_KEY: 'test-key',
       PINATA_SECRET_KEY: 'test-secret',
@@ -13,7 +13,7 @@ const mockConfigService = {
       IPFS_GATEWAY: 'https://ipfs.io/ipfs/',
       PINATA_TIMEOUT_MS: 20000,
     };
-    return config[key];
+    return config[key] ?? defaultValue;
   }),
 } as any;
 
@@ -128,5 +128,73 @@ describe('RetrievalService hash verification', () => {
     expect(result.error).toBeUndefined();
     expect(result.integrityVerified).toBe(false);
     expect(result.data).toBe(payload.toString('base64'));
+  });
+});
+
+describe('RetrievalService verifyPin', () => {
+  const mockIpfs = {
+    validateCid: jest.fn(),
+    gatewayForCid: jest
+      .fn()
+      .mockReturnValue('https://gateway.pinata.cloud/ipfs/cid123'),
+  } as any;
+
+  const mockPrisma = {
+    ipfsDocument: { findUnique: jest.fn() },
+  } as any;
+
+  let service: RetrievalService;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    jest.useFakeTimers();
+    service = new RetrievalService(
+      mockIpfs,
+      new IpfsConfig(mockConfigService),
+      mockPrisma,
+    );
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  it('returns verified=true on first successful HEAD request', async () => {
+    jest.spyOn(axios, 'head').mockResolvedValueOnce({ status: 200 } as any);
+
+    const result = await service.verifyPin('cid123');
+
+    expect(result.verified).toBe(true);
+    expect(result.attempts).toBe(1);
+    expect(result.error).toBeUndefined();
+    expect(axios.head).toHaveBeenCalledTimes(1);
+  });
+
+  it('retries on failure and returns verified=true when a later attempt succeeds', async () => {
+    jest
+      .spyOn(axios, 'head')
+      .mockRejectedValueOnce(new Error('timeout'))
+      .mockResolvedValueOnce({ status: 200 } as any);
+
+    const verifyPromise = service.verifyPin('cid123');
+    await jest.runAllTimersAsync();
+    const result = await verifyPromise;
+
+    expect(result.verified).toBe(true);
+    expect(result.attempts).toBe(2);
+    expect(axios.head).toHaveBeenCalledTimes(2);
+  });
+
+  it('returns verified=false with error after all attempts are exhausted', async () => {
+    jest.spyOn(axios, 'head').mockRejectedValue(new Error('gateway down'));
+
+    const verifyPromise = service.verifyPin('cid123');
+    await jest.runAllTimersAsync();
+    const result = await verifyPromise;
+
+    expect(result.verified).toBe(false);
+    expect(result.attempts).toBe(3);
+    expect(result.error).toMatch(/3 attempt/);
+    expect(axios.head).toHaveBeenCalledTimes(3);
   });
 });

--- a/corporate-platform/corporate-platform-backend/src/ipfs/services/retrieval.service.ts
+++ b/corporate-platform/corporate-platform-backend/src/ipfs/services/retrieval.service.ts
@@ -65,4 +65,34 @@ export class RetrievalService {
     const url = this.ipfs.gatewayForCid(cid);
     return { cid, url };
   }
+
+  async verifyPin(
+    cid: string,
+  ): Promise<{ verified: boolean; attempts: number; error?: string }> {
+    const maxAttempts = this.config.verifyRetryAttempts;
+    const delayMs = this.config.verifyRetryDelayMs;
+    const timeoutMs = this.config.verifyTimeoutMs;
+    const url = this.ipfs.gatewayForCid(cid);
+
+    for (let attempt = 1; attempt <= maxAttempts; attempt++) {
+      try {
+        await axios.head(url, { timeout: timeoutMs });
+        this.logger.log(
+          `CID ${cid} verified retrievable on attempt ${attempt}/${maxAttempts}`,
+        );
+        return { verified: true, attempts: attempt };
+      } catch (err: any) {
+        this.logger.warn(
+          `Verify attempt ${attempt}/${maxAttempts} failed for CID ${cid}: ${err?.message}`,
+        );
+        if (attempt < maxAttempts) {
+          await new Promise<void>((resolve) => setTimeout(resolve, delayMs));
+        }
+      }
+    }
+
+    const error = `Content not retrievable from gateway after ${maxAttempts} attempt(s)`;
+    this.logger.error(`Pin verification failed for CID ${cid}: ${error}`);
+    return { verified: false, attempts: maxAttempts, error };
+  }
 }

--- a/corporate-platform/corporate-platform-backend/src/ipfs/services/upload.service.spec.ts
+++ b/corporate-platform/corporate-platform-backend/src/ipfs/services/upload.service.spec.ts
@@ -3,7 +3,7 @@ import { UploadService } from './upload.service';
 import { IpfsConfig } from '../ipfs.config';
 
 const mockConfigService = {
-  get: jest.fn((key: string) => {
+  get: jest.fn((key: string, defaultValue?: any) => {
     const config: Record<string, any> = {
       PINATA_API_KEY: 'test-key',
       PINATA_SECRET_KEY: 'test-secret',
@@ -12,7 +12,7 @@ const mockConfigService = {
       IPFS_GATEWAY: 'https://ipfs.io/ipfs/',
       PINATA_TIMEOUT_MS: 20000,
     };
-    return config[key];
+    return config[key] ?? defaultValue;
   }),
 } as any;
 
@@ -45,6 +45,10 @@ describe('UploadService hash persistence', () => {
     pinBatch: jest.fn(),
   } as any;
 
+  const mockRetrieval = {
+    verifyPin: jest.fn().mockResolvedValue({ verified: true, attempts: 1 }),
+  } as any;
+
   let service: UploadService;
 
   beforeEach(() => {
@@ -53,6 +57,7 @@ describe('UploadService hash persistence', () => {
       new IpfsConfig(mockConfigService),
       mockPrisma,
       mockProvider,
+      mockRetrieval,
     );
     mockPrisma.ipfsDocument.findFirst.mockResolvedValue(null);
     mockPrisma.ipfsDocument.create.mockResolvedValue({
@@ -84,5 +89,70 @@ describe('UploadService hash persistence', () => {
 
     expect(createCall.data.contentHash).toBe(expectedHash);
     expect(result.record.contentHash).toBe(expectedHash);
+  });
+
+  it('calls verifyPin after successful pinFile', async () => {
+    const buffer = Buffer.from('verify-me');
+    const file = {
+      originalname: 'cert.pdf',
+      buffer,
+      size: buffer.length,
+      mimetype: 'application/pdf',
+    };
+
+    await service.upload(file, {
+      companyId: 'company-1',
+      documentType: 'CERTIFICATE',
+      referenceId: 'ref-2',
+    });
+
+    expect(mockRetrieval.verifyPin).toHaveBeenCalledWith('cid123');
+  });
+
+  it('persists pinVerified flag in metadata when verification succeeds', async () => {
+    const buffer = Buffer.from('verified-content');
+    const file = {
+      originalname: 'cert.pdf',
+      buffer,
+      size: buffer.length,
+      mimetype: 'application/pdf',
+    };
+
+    await service.upload(file, {
+      companyId: 'company-1',
+      documentType: 'CERTIFICATE',
+      referenceId: 'ref-3',
+    });
+
+    const createCall = mockPrisma.ipfsDocument.create.mock.calls[0][0];
+    expect(createCall.data.metadata.pinVerified).toBe(true);
+    expect(createCall.data.metadata.pinVerifyAttempts).toBe(1);
+    expect(createCall.data.metadata.pinVerifiedAt).toBeDefined();
+  });
+
+  it('throws and does not persist record when pin verification fails', async () => {
+    mockRetrieval.verifyPin.mockResolvedValueOnce({
+      verified: false,
+      attempts: 3,
+      error: 'Content not retrievable from gateway after 3 attempt(s)',
+    });
+
+    const buffer = Buffer.from('unreachable-content');
+    const file = {
+      originalname: 'cert.pdf',
+      buffer,
+      size: buffer.length,
+      mimetype: 'application/pdf',
+    };
+
+    await expect(
+      service.upload(file, {
+        companyId: 'company-1',
+        documentType: 'CERTIFICATE',
+        referenceId: 'ref-4',
+      }),
+    ).rejects.toThrow(/IPFS upload failed/);
+
+    expect(mockPrisma.ipfsDocument.create).not.toHaveBeenCalled();
   });
 });

--- a/corporate-platform/corporate-platform-backend/src/ipfs/services/upload.service.ts
+++ b/corporate-platform/corporate-platform-backend/src/ipfs/services/upload.service.ts
@@ -13,6 +13,7 @@ import {
   STORAGE_CLASS_POLICIES,
   DocumentStorageClass,
 } from '../upload-policy.constants';
+import { RetrievalService } from './retrieval.service';
 import * as NodeClam from 'clamscan';
 
 @Injectable()
@@ -23,6 +24,7 @@ export class UploadService {
     private readonly config: IpfsConfig,
     private readonly prisma: PrismaService,
     @Inject(IPFS_PROVIDER) private readonly provider: IIpfsProvider,
+    private readonly retrieval: RetrievalService,
   ) {}
 
   private async computeSha256(file: any): Promise<string> {
@@ -147,6 +149,13 @@ export class UploadService {
         storageClass,
       });
 
+      const verification = await this.retrieval.verifyPin(cid);
+      if (!verification.verified) {
+        throw new Error(
+          `Pin verification failed for CID ${cid}: ${verification.error}`,
+        );
+      }
+
       const record = await this.prisma.ipfsDocument.create({
         data: {
           companyId,
@@ -159,7 +168,14 @@ export class UploadService {
           mimeType: file.mimetype,
           pinned: true,
           pinnedAt: new Date(),
-          metadata: { ...metadata, storageClass, policy },
+          metadata: {
+            ...metadata,
+            storageClass,
+            policy,
+            pinVerified: true,
+            pinVerifiedAt: new Date().toISOString(),
+            pinVerifyAttempts: verification.attempts,
+          },
           idempotencyKey: idempotencyKey || null,
           contentHash,
         },


### PR DESCRIPTION

# Pull Request

## Description

Adds targeted test coverage for `FluxoraStream::create_streams_relative` — the relative-time batch variant. Existing tests covered the single `create_stream_relative` and the absolute `create_streams` paths, but the relative batch had no explicit coverage of the empty-vector no-op or the anchor invariant (all elements deriving their absolute times from a single `ledger.timestamp()` capture). Test-only; no contract source or behavior changes.

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [x] Test coverage improvement
- [ ] Refactoring (no functional changes)

## Related Issues

Closes #401 

## Changes Made

- Added three tests to `contracts/stream/tests/create_stream_relative.rs` (+243 / -0) covering the `create_streams_relative` anchor invariant.
- `create_streams_relative_empty_batch_emits_no_events` — empty batch is an auth-required no-op: returns an empty id list and makes no state, event, or token-balance changes.
- `create_streams_relative_all_elements_share_same_anchor_timestamp` — three elements with distinct offsets all derive `start`/`cliff`/`end` from a single pinned anchor; asserts the exact absolute times.
- `create_streams_relative_zero_offset_parity_with_single` — a zero-delay single-element batch produces identical absolute times to `create_stream_relative` with the same zero delays, and both anchor exactly at `ledger.timestamp()`.
- Added inline `///` docs describing the anchor invariant (`start_time[i] = T + start_delay[i]`, etc.) and the anchor-drift risk it guards against.

## Snapshot Test Changes

### Did this PR modify snapshot test files?

- [ ] Yes - snapshot files were updated (explain below)
- [x] No - no snapshot changes

N/A — only `contracts/stream/tests/create_stream_relative.rs` was modified; no `test_snapshots/` JSON files were touched and `SOROBAN_SNAPSHOT_UPDATE` was not run.

## Testing

### Test Coverage

- [x] All tests pass locally: `cargo test -p fluxora_stream` (targeted run: `cargo test -p fluxora_stream --test create_stream_relative`)
- [x] New tests added for new functionality
- [ ] Existing tests updated for changed functionality — N/A (additive only; no existing tests modified)
- [x] Test coverage remains above 95%

### Manual Testing

- [x] Tested on local environment (ran the `create_stream_relative` suite)
- [x] Tested edge cases (empty batch, zero offset, mixed offsets sharing one anchor)
- [ ] Tested error conditions — N/A (anchor/coverage focus; amount-validation errors are covered by the pre-existing `create_streams_relative_batch_validates_amounts` test)

## Documentation

- [x] Code comments added/updated (inline `///` describing the anchor invariant)
- [ ] Documentation updated (if behavior changed) — N/A (no behavior change)
- [ ] README updated (if needed) — N/A
- [ ] Snapshot test documentation reviewed — N/A (no snapshot changes)

## Security Considerations

- [x] No new security concerns introduced (test-only)
- [x] Authorization boundaries verified (empty-batch test confirms a single sender authorization covers the whole batch)
- [ ] Input validation added/verified — N/A (validation paths covered by existing tests)
- [ ] Error handling reviewed — N/A (no error paths added)

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas (inline `///` on the anchor invariant)
- [ ] I have made corresponding changes to the documentation — N/A (test-only; no behavior or protocol docs changed)
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published — N/A (no dependencies)

## Additional Notes

Test-only PR; no changes to contract source or behavior. The shared-anchor test directly locks the security concern from the issue: because all batch elements are asserted to derive their times from one `ledger.timestamp()` capture, anchor-drift (where a member could resolve to a different base time and start in the past) is ruled out. The three tests map to the acceptance criteria: empty-batch no-op, shared anchor across elements, zero-offset parity with the single variant, and absolute start/end verification.

## Reviewer Checklist

<!-- For reviewers to complete -->

- [ ] Code quality and style
- [ ] Test coverage adequate
- [ ] Documentation complete
- [ ] Snapshot changes justified and correct
- [ ] Security implications reviewed
- [ ] Breaking changes documented