### PR TITLE
feat(web): add fetch cancellation on route transitions

### DIFF
--- a/corporate-platform/corporate-platform-web/src/app/layout.tsx
+++ b/corporate-platform/corporate-platform-web/src/app/layout.tsx
@@ -1,4 +1,5 @@
 import type { Metadata } from 'next'
+import { Suspense } from 'react'
 import { Inter } from 'next/font/google'
 import './globals.css'
 import { ThemeProvider } from '@/components/theme/ThemeProvider'
@@ -28,16 +29,17 @@ export default function RootLayout({
           enableSystem
           disableTransitionOnChange
         >
-          <RouteCancellationProvider>
-            <AuthProvider>
-              <CorporateProvider>
-                <PlatformShell>{children}</PlatformShell>
-              </CorporateProvider>
-            </AuthProvider>
-          </RouteCancellationProvider>
+          <Suspense fallback={null}>
+            <RouteCancellationProvider>
+              <AuthProvider>
+                <CorporateProvider>
+                  <PlatformShell>{children}</PlatformShell>
+                </CorporateProvider>
+              </AuthProvider>
+            </RouteCancellationProvider>
+          </Suspense>
         </ThemeProvider>
       </body>
     </html>
   )
 }
-

--- a/corporate-platform/corporate-platform-web/src/app/layout.tsx
+++ b/corporate-platform/corporate-platform-web/src/app/layout.tsx
@@ -5,6 +5,7 @@ import { ThemeProvider } from '@/components/theme/ThemeProvider'
 import { CorporateProvider } from '@/contexts/CorporateContext'
 import { AuthProvider } from '@/contexts/AuthContext'
 import PlatformShell from '@/components/layout/PlatformShell'
+import { RouteCancellationProvider } from '@/components/common/RouteCancellationProvider'
 
 const inter = Inter({ subsets: ['latin'] })
 
@@ -27,11 +28,13 @@ export default function RootLayout({
           enableSystem
           disableTransitionOnChange
         >
-          <AuthProvider>
-            <CorporateProvider>
-              <PlatformShell>{children}</PlatformShell>
-            </CorporateProvider>
-          </AuthProvider>
+          <RouteCancellationProvider>
+            <AuthProvider>
+              <CorporateProvider>
+                <PlatformShell>{children}</PlatformShell>
+              </CorporateProvider>
+            </AuthProvider>
+          </RouteCancellationProvider>
         </ThemeProvider>
       </body>
     </html>

--- a/corporate-platform/corporate-platform-web/src/components/common/RouteCancellationProvider.tsx
+++ b/corporate-platform/corporate-platform-web/src/components/common/RouteCancellationProvider.tsx
@@ -1,0 +1,8 @@
+'use client';
+
+import { useRouteChangeCancellation } from '@/hooks/useRouteChangeCancellation';
+
+export function RouteCancellationProvider({ children }: { children: React.ReactNode }) {
+  useRouteChangeCancellation();
+  return <>{children}</>;
+}

--- a/corporate-platform/corporate-platform-web/src/hooks/useRetirement.ts
+++ b/corporate-platform/corporate-platform-web/src/hooks/useRetirement.ts
@@ -1,7 +1,8 @@
 'use client';
 
-import { useState, useCallback, useEffect } from 'react';
+import { useState, useCallback, useEffect, useRef } from 'react';
 import { retirementService } from '@/services/retirement.service';
+import type { ApiFetchOptions } from '@/services/api-client';
 import type {
   RetireCreditsPayload,
   RetirementRecord,
@@ -23,9 +24,9 @@ export interface UseRetirementState {
 }
 
 export interface UseRetirementActions {
-  retire: (payload: RetireCreditsPayload) => Promise<RetirementRecord | null>;
-  fetchHistory: (query?: RetirementHistoryQuery) => Promise<void>;
-  fetchStats: () => Promise<void>;
+  retire: (payload: RetireCreditsPayload, options?: ApiFetchOptions) => Promise<RetirementRecord | null>;
+  fetchHistory: (query?: RetirementHistoryQuery, options?: ApiFetchOptions) => Promise<void>;
+  fetchStats: (options?: ApiFetchOptions) => Promise<void>;
   clearRetireError: () => void;
   clearLastRetirement: () => void;
 }
@@ -54,41 +55,52 @@ export function useRetirement(
     useState<RetirementRecord | null>(null);
 
   const fetchHistory = useCallback(
-    async (query: RetirementHistoryQuery = initialQuery) => {
+    async (query: RetirementHistoryQuery = initialQuery, options?: ApiFetchOptions) => {
       setHistoryLoading(true);
       setHistoryError(null);
-      const res = await retirementService.getHistory(query);
-      if (res.success && res.data) {
-        setHistory(res.data);
-      } else {
-        // Use parentheses to clarify operator precedence
-        const errorMsg = (res.parsedError?.message || res.error) ?? 'Failed to fetch retirement history';
-        setHistoryError(errorMsg);
+      try {
+        const res = await retirementService.getHistory(query, options);
+        if (res.isCancelled) return; // Skip state update if cancelled
+        if (res.success && res.data) {
+          setHistory(res.data);
+        } else {
+          const errorMsg = (res.parsedError?.message || res.error) ?? 'Failed to fetch retirement history';
+          setHistoryError(errorMsg);
+        }
+      } finally {
+        setHistoryLoading(false);
       }
-      setHistoryLoading(false);
     },
     // intentionally omit initialQuery so callers can pass ad-hoc queries
     // eslint-disable-next-line react-hooks/exhaustive-deps
     [],
   );
 
-  const fetchStats = useCallback(async () => {
+  const fetchStats = useCallback(async (options?: ApiFetchOptions) => {
     setStatsLoading(true);
     setStatsError(null);
-    const res = await retirementService.getStats();
-    if (res.success && res.data) {
-      setStats(res.data);
-    } else {
-      setStatsError(res.parsedError?.message ?? res.error ?? 'Failed to fetch retirement stats');
+    try {
+      const res = await retirementService.getStats(options);
+      if (res.isCancelled) return; // Skip state update if cancelled
+      if (res.success && res.data) {
+        setStats(res.data);
+      } else {
+        setStatsError(res.parsedError?.message ?? res.error ?? 'Failed to fetch retirement stats');
+      }
+    } finally {
+      setStatsLoading(false);
     }
-    setStatsLoading(false);
   }, []);
 
   const retire = useCallback(
-    async (payload: RetireCreditsPayload): Promise<RetirementRecord | null> => {
+    async (payload: RetireCreditsPayload, options?: ApiFetchOptions): Promise<RetirementRecord | null> => {
       setRetiring(true);
       setRetireError(null);
-      const res = await retirementService.retire(payload);
+      const res = await retirementService.retire(payload, options);
+      if (res.isCancelled) {
+        setRetiring(false);
+        return null;
+      }
       setRetiring(false);
       if (res.success && res.data) {
         setLastRetirement(res.data);
@@ -104,10 +116,16 @@ export function useRetirement(
   const clearLastRetirement = useCallback(() => setLastRetirement(null), []);
 
   useEffect(() => {
+    const abortController = new AbortController();
+    
     if (autoFetch) {
-      fetchHistory(initialQuery);
-      fetchStats();
+      fetchHistory(initialQuery, { signal: abortController.signal });
+      fetchStats({ signal: abortController.signal });
     }
+    
+    return () => {
+      abortController.abort('useRetirement unmounted');
+    };
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [autoFetch]);
 

--- a/corporate-platform/corporate-platform-web/src/hooks/useRouteChangeCancellation.ts
+++ b/corporate-platform/corporate-platform-web/src/hooks/useRouteChangeCancellation.ts
@@ -1,0 +1,24 @@
+'use client';
+
+import { useEffect, useRef } from 'react';
+import { usePathname, useSearchParams } from 'next/navigation';
+import { requestManager } from '@/lib/api/requestManager';
+
+/**
+ * Hook to automatically cancel in-flight API requests when the user navigates 
+ * between routes. This prevents stale data from updating unmounted components
+ * and reduces unnecessary network traffic.
+ */
+export function useRouteChangeCancellation() {
+  const pathname = usePathname();
+  const searchParams = useSearchParams();
+  const previousPathname = useRef(pathname);
+
+  useEffect(() => {
+    // Only cancel requests if the actual pathname changed (not just query params)
+    if (previousPathname.current !== pathname) {
+      requestManager.cancelAllRequests();
+      previousPathname.current = pathname;
+    }
+  }, [pathname, searchParams]);
+}

--- a/corporate-platform/corporate-platform-web/src/lib/api/http.ts
+++ b/corporate-platform/corporate-platform-web/src/lib/api/http.ts
@@ -1,6 +1,7 @@
 import { parseApiError, ParsedError } from '@/lib/utils/errorParser'
 import { withRetry, isRetryableError, RetryOptions } from '@/lib/utils/retry'
 import { reportError } from '@/lib/telemetry/errorReporter'
+import { requestManager } from './requestManager'
 
 export class ApiError extends Error {
   readonly status: number
@@ -22,6 +23,10 @@ interface RequestOptions {
   fetchImpl?: typeof fetch
   retry?: RetryOptions
   idempotencyKey?: string
+  signal?: AbortSignal
+  cancelOnRouteChange?: boolean
+  deduplicate?: boolean
+  timeout?: number
 }
 
 const DEFAULT_API_BASE_URL = process.env.NEXT_PUBLIC_API_BASE_URL ?? 'http://localhost:4000'
@@ -43,6 +48,8 @@ export async function apiRequest<T>(
   const fetchImpl = options.fetchImpl ?? fetch
   const baseUrl = options.baseUrl ?? DEFAULT_API_BASE_URL
   const headers = new Headers(init.headers)
+  const method = init.method ?? 'GET'
+  const isQuery = method === 'GET'
 
   if (!headers.has('Content-Type') && init.body) {
     headers.set('Content-Type', 'application/json')
@@ -57,6 +64,30 @@ export async function apiRequest<T>(
     headers.set('Idempotency-Key', options.idempotencyKey)
   }
 
+  const cancelOnRouteChange = options.cancelOnRouteChange ?? isQuery
+  const deduplicate = options.deduplicate ?? isQuery
+  const timeoutMs = options.timeout ?? 30000
+
+  const controller = new AbortController()
+  const timeoutId = setTimeout(() => {
+    controller.abort('Request timeout')
+  }, timeoutMs)
+
+  if (options.signal) {
+    options.signal.addEventListener('abort', () => {
+      controller.abort(options.signal?.reason || 'Caller aborted')
+    })
+    if (options.signal.aborted) {
+      controller.abort(options.signal.reason)
+    }
+  }
+
+  const requestKey = requestManager.generateKey(method, path, init.body)
+
+  if (cancelOnRouteChange) {
+    requestManager.registerRequest(requestKey, controller, deduplicate)
+  }
+
   const executeRequest = async (): Promise<T> => {
     let response: Response
 
@@ -64,14 +95,19 @@ export async function apiRequest<T>(
       response = await fetchImpl(buildUrl(baseUrl, path), {
         ...init,
         headers,
+        signal: controller.signal,
       })
-    } catch (error) {
+    } catch (error: any) {
+      if (error.name === 'AbortError') {
+        console.log(`[http.ts] Request cancelled: ${path}`)
+        throw error
+      }
       const apiError = new ApiError(
         0,
         `Unable to reach the API at ${baseUrl}. Check that the backend is running and CORS allows this origin.`,
         error,
       )
-      reportError(apiError, 'http', 'error', { path, method: init.method ?? 'GET' })
+      reportError(apiError, 'http', 'error', { path, method })
       // Check if this is a retryable network error
       if (isRetryableError(error, 0)) {
         throw error // Let retry logic handle it
@@ -102,18 +138,24 @@ export async function apiRequest<T>(
     return parsedBody as T
   }
 
-  // Apply retry logic if retry options are provided
-  if (options.retry) {
-    return withRetry(executeRequest, {
-      ...options.retry,
-      onRetry: (attempt, error) => {
-        console.log(`Retrying request (attempt ${attempt})...`)
-        options.retry?.onRetry?.(attempt, error)
-      },
-    })
-  }
+  try {
+    if (options.retry) {
+      return await withRetry(executeRequest, {
+        ...options.retry,
+        onRetry: (attempt, error) => {
+          console.log(`Retrying request (attempt ${attempt})...`)
+          options.retry?.onRetry?.(attempt, error)
+        },
+      })
+    }
 
-  return executeRequest()
+    return await executeRequest()
+  } finally {
+    clearTimeout(timeoutId)
+    if (cancelOnRouteChange) {
+      requestManager.unregisterRequest(requestKey)
+    }
+  }
 }
 
 function safeJsonParse(value: string): unknown {

--- a/corporate-platform/corporate-platform-web/src/lib/api/requestManager.ts
+++ b/corporate-platform/corporate-platform-web/src/lib/api/requestManager.ts
@@ -1,0 +1,47 @@
+/**
+ * RequestManager handles deduplication and cancellation of in-flight API requests.
+ */
+export class RequestManager {
+  private inFlightRequests: Map<string, AbortController> = new Map();
+
+  /**
+   * Generates a unique key for the request to handle deduplication.
+   */
+  public generateKey(method: string, url: string, body?: any): string {
+    const stringifiedBody = typeof body === 'string' ? body : JSON.stringify(body || '');
+    return `${method.toUpperCase()}:${url}${stringifiedBody ? ':' + stringifiedBody : ''}`;
+  }
+
+  /**
+   * Registers a request, optionally cancelling duplicate in-flight requests.
+   */
+  public registerRequest(key: string, abortController: AbortController, deduplicate: boolean = false) {
+    if (deduplicate && this.inFlightRequests.has(key)) {
+      console.log(`[RequestManager] Cancelling duplicate request: ${key}`);
+      this.inFlightRequests.get(key)?.abort('Duplicate request cancelled');
+    }
+    this.inFlightRequests.set(key, abortController);
+  }
+
+  /**
+   * Unregisters a completed or failed request.
+   */
+  public unregisterRequest(key: string) {
+    this.inFlightRequests.delete(key);
+  }
+
+  /**
+   * Cancels all currently in-flight requests. Used primarily during route transitions.
+   */
+  public cancelAllRequests() {
+    if (this.inFlightRequests.size > 0) {
+      console.log(`[RequestManager] Cancelling ${this.inFlightRequests.size} in-flight request(s) due to route transition.`);
+      for (const [key, controller] of this.inFlightRequests.entries()) {
+        controller.abort('Route transition cancelled');
+      }
+      this.inFlightRequests.clear();
+    }
+  }
+}
+
+export const requestManager = new RequestManager();

--- a/corporate-platform/corporate-platform-web/src/services/api-client.ts
+++ b/corporate-platform/corporate-platform-web/src/services/api-client.ts
@@ -3,6 +3,7 @@ import { parseApiError, ParsedError, ErrorCode } from '@/lib/utils/errorParser';
 import { withRetry, isRetryableError, RetryOptions, generateIdempotencyKey } from '@/lib/utils/retry';
 import { requestQueue } from '@/lib/utils/requestQueue';
 import { reportError } from '@/lib/telemetry/errorReporter';
+import { requestManager } from '@/lib/api/requestManager';
 
 /**
  * Base API Client for handling HTTP requests
@@ -15,6 +16,7 @@ export interface ApiResponse<T> {
   success: boolean;
   data?: T;
   error?: string;
+  isCancelled?: boolean;
   timestamp?: string;
   statusCode?: number;
   parsedError?: ParsedError;
@@ -25,6 +27,9 @@ export interface ApiFetchOptions extends RequestInit {
   retry?: RetryOptions;
   idempotencyKey?: string;
   queueOffline?: boolean; // Whether to queue request when offline
+  signal?: AbortSignal;
+  cancelOnRouteChange?: boolean;
+  deduplicate?: boolean;
 }
 
 class ApiClient {
@@ -108,6 +113,12 @@ class ApiClient {
       };
     }
 
+    const method = options?.method ?? 'GET';
+    const isQuery = method === 'GET';
+    const cancelOnRouteChange = options?.cancelOnRouteChange ?? isQuery;
+    const deduplicate = options?.deduplicate ?? isQuery;
+    const requestKey = requestManager.generateKey(method, url, options?.body);
+
     const executeRequest = async (): Promise<ApiResponse<T>> => {
       try {
         const controller = new AbortController();
@@ -120,14 +131,21 @@ class ApiClient {
         if (externalSignal) {
           if (externalSignal.aborted) {
             clearTimeout(timeoutId);
-            controller.abort();
+            controller.abort(externalSignal.reason);
           } else {
             externalSignal.addEventListener(
               'abort',
-              () => { clearTimeout(timeoutId); controller.abort(); },
+              () => {
+                clearTimeout(timeoutId);
+                controller.abort(externalSignal.reason || 'Caller aborted');
+              },
               { once: true },
             );
           }
+        }
+
+        if (cancelOnRouteChange) {
+          requestManager.registerRequest(requestKey, controller, deduplicate);
         }
 
         const response = await fetch(url, {
@@ -137,6 +155,9 @@ class ApiClient {
         });
 
         clearTimeout(timeoutId);
+        if (cancelOnRouteChange) {
+          requestManager.unregisterRequest(requestKey);
+        }
 
         const data = await response.json();
 
@@ -159,7 +180,21 @@ class ApiClient {
         }
 
         return data as ApiResponse<T>;
-      } catch (error) {
+      } catch (error: any) {
+        if (error.name === 'AbortError') {
+          console.log(`[ApiClient] Request to ${endpoint} cancelled`);
+          if (cancelOnRouteChange) {
+            requestManager.unregisterRequest(requestKey);
+          }
+          return {
+            success: false,
+            isCancelled: true,
+            error: 'Request cancelled',
+            statusCode: 0,
+            timestamp: new Date().toISOString(),
+          };
+        }
+        
         const parsedError = parseApiError(error);
         
         // Check if this is a retryable network error

--- a/corporate-platform/corporate-platform-web/src/services/portfolio.service.ts
+++ b/corporate-platform/corporate-platform-web/src/services/portfolio.service.ts
@@ -1,4 +1,4 @@
-import { apiClient, ApiResponse } from './api-client';
+import { apiClient, ApiResponse, ApiFetchOptions } from './api-client';
 
 // Types for Portfolio API responses (can be refined based on backend interfaces)
 export interface PortfolioSummaryMetrics {
@@ -68,35 +68,35 @@ export interface PortfolioAnalytics {
 }
 
 export const portfolioService = {
-  async getSummary(): Promise<ApiResponse<PortfolioSummaryMetrics>> {
-    return apiClient.get<PortfolioSummaryMetrics>('/portfolio/summary');
+  async getSummary(options?: ApiFetchOptions): Promise<ApiResponse<PortfolioSummaryMetrics>> {
+    return apiClient.get<PortfolioSummaryMetrics>('/portfolio/summary', options);
   },
-  async getPerformance(): Promise<ApiResponse<PortfolioPerformance>> {
-    return apiClient.get<PortfolioPerformance>('/portfolio/performance');
+  async getPerformance(options?: ApiFetchOptions): Promise<ApiResponse<PortfolioPerformance>> {
+    return apiClient.get<PortfolioPerformance>('/portfolio/performance', options);
   },
-  async getComposition(): Promise<ApiResponse<PortfolioComposition>> {
-    return apiClient.get<PortfolioComposition>('/portfolio/composition');
+  async getComposition(options?: ApiFetchOptions): Promise<ApiResponse<PortfolioComposition>> {
+    return apiClient.get<PortfolioComposition>('/portfolio/composition', options);
   },
-  async getTimeline(params?: { startDate?: string; endDate?: string; aggregation?: string }): Promise<ApiResponse<PortfolioTimeline>> {
+  async getTimeline(params?: { startDate?: string; endDate?: string; aggregation?: string }, options?: ApiFetchOptions): Promise<ApiResponse<PortfolioTimeline>> {
     const query = params
       ? '?' + new URLSearchParams(params as Record<string, string>).toString()
       : '';
-    return apiClient.get<PortfolioTimeline>(`/portfolio/timeline${query}`);
+    return apiClient.get<PortfolioTimeline>(`/portfolio/timeline${query}`, options);
   },
-  async getRisk(): Promise<ApiResponse<PortfolioRisk>> {
-    return apiClient.get<PortfolioRisk>('/portfolio/risk');
+  async getRisk(options?: ApiFetchOptions): Promise<ApiResponse<PortfolioRisk>> {
+    return apiClient.get<PortfolioRisk>('/portfolio/risk', options);
   },
-  async getHoldings(params?: { page?: number; pageSize?: number }): Promise<ApiResponse<PortfolioHoldingsResponse>> {
+  async getHoldings(params?: { page?: number; pageSize?: number }, options?: ApiFetchOptions): Promise<ApiResponse<PortfolioHoldingsResponse>> {
     const query = params
       ? '?' + new URLSearchParams(params as Record<string, string>).toString()
       : '';
-    return apiClient.get<PortfolioHoldingsResponse>(`/portfolio/holdings${query}`);
+    return apiClient.get<PortfolioHoldingsResponse>(`/portfolio/holdings${query}`, options);
   },
-  async getAnalytics(): Promise<ApiResponse<PortfolioAnalytics>> {
-    return apiClient.get<PortfolioAnalytics>('/portfolio/analytics');
+  async getAnalytics(options?: ApiFetchOptions): Promise<ApiResponse<PortfolioAnalytics>> {
+    return apiClient.get<PortfolioAnalytics>('/portfolio/analytics', options);
   },
-  async getHoldingById(id: string): Promise<ApiResponse<PortfolioHolding>> {
-    return apiClient.get<PortfolioHolding>(`/portfolio/${id}`);
+  async getHoldingById(id: string, options?: ApiFetchOptions): Promise<ApiResponse<PortfolioHolding>> {
+    return apiClient.get<PortfolioHolding>(`/portfolio/${id}`, options);
   },
 };
 

--- a/corporate-platform/corporate-platform-web/src/services/retirement.service.ts
+++ b/corporate-platform/corporate-platform-web/src/services/retirement.service.ts
@@ -1,5 +1,5 @@
 import { getAccessToken } from '@/lib/auth/token-storage';
-import { ApiResponse, apiClient } from './api-client';
+import { ApiResponse, apiClient, ApiFetchOptions } from './api-client';
 import type {
   RetireCreditsPayload,
   RetirementRecord,
@@ -29,11 +29,11 @@ class RetirementService {
    */
   async retire(
     payload: RetireCreditsPayload,
+    options?: ApiFetchOptions,
   ): Promise<ApiResponse<RetirementRecord>> {
-    const response = await apiClient.post<RetirementRecord>(
-      '/retirements',
-      payload,
-    );
+    const response = options
+      ? await apiClient.post<RetirementRecord>('/retirements', payload, options)
+      : await apiClient.post<RetirementRecord>('/retirements', payload);
     return this.normalizeResponse(response);
   }
 
@@ -43,6 +43,7 @@ class RetirementService {
    */
   async getHistory(
     query: RetirementHistoryQuery = {},
+    options?: ApiFetchOptions,
   ): Promise<ApiResponse<RetirementHistoryResponse>> {
     const params = new URLSearchParams();
     if (query.startDate) params.set('startDate', query.startDate);
@@ -53,9 +54,9 @@ class RetirementService {
     if (query.limit) params.set('limit', String(query.limit));
 
     const qs = params.toString();
-    const response = await apiClient.get<RetirementHistoryResponse>(
-      `/retirements${qs ? `?${qs}` : ''}`,
-    );
+    const response = options
+      ? await apiClient.get<RetirementHistoryResponse>(`/retirements${qs ? `?${qs}` : ''}`, options)
+      : await apiClient.get<RetirementHistoryResponse>(`/retirements${qs ? `?${qs}` : ''}`);
     return this.normalizeResponse(response);
   }
 
@@ -63,10 +64,10 @@ class RetirementService {
    * GET /api/v1/retirements/:id
    * Fetch details for a specific retirement record.
    */
-  async getById(id: string): Promise<ApiResponse<RetirementRecord>> {
-    const response = await apiClient.get<RetirementRecord>(
-      `/retirements/${encodeURIComponent(id)}`,
-    );
+  async getById(id: string, options?: ApiFetchOptions): Promise<ApiResponse<RetirementRecord>> {
+    const response = options
+      ? await apiClient.get<RetirementRecord>(`/retirements/${encodeURIComponent(id)}`, options)
+      : await apiClient.get<RetirementRecord>(`/retirements/${encodeURIComponent(id)}`);
     return this.normalizeResponse(response);
   }
 
@@ -74,8 +75,10 @@ class RetirementService {
    * GET /api/v1/retirements/stats
    * Fetch aggregate retirement stats for the authenticated company.
    */
-  async getStats(): Promise<ApiResponse<RetirementStats>> {
-    const response = await apiClient.get<RetirementStats>('/retirements/stats');
+  async getStats(options?: ApiFetchOptions): Promise<ApiResponse<RetirementStats>> {
+    const response = options
+      ? await apiClient.get<RetirementStats>('/retirements/stats', options)
+      : await apiClient.get<RetirementStats>('/retirements/stats');
     return this.normalizeResponse(response);
   }
 
@@ -86,14 +89,15 @@ class RetirementService {
   async validate(
     creditId: string,
     amount: number,
+    options?: ApiFetchOptions,
   ): Promise<ApiResponse<RetirementValidationResult>> {
     const params = new URLSearchParams({
       creditId,
       amount: String(amount),
     });
-    const response = await apiClient.get<RetirementValidationResult>(
-      `/retirements/validate?${params.toString()}`,
-    );
+    const response = options
+      ? await apiClient.get<RetirementValidationResult>(`/retirements/validate?${params.toString()}`, options)
+      : await apiClient.get<RetirementValidationResult>(`/retirements/validate?${params.toString()}`);
     return this.normalizeResponse(response);
   }
 
@@ -116,6 +120,7 @@ class RetirementService {
     address: string,
     page = 1,
     limit = 20,
+    options?: ApiFetchOptions,
   ): Promise<
     ApiResponse<{ data: EntityCertificate[]; meta: RetirementHistoryMeta }>
   > {
@@ -123,12 +128,15 @@ class RetirementService {
       page: String(page),
       limit: String(limit),
     });
-    const response = await apiClient.get<{
-      data: EntityCertificate[];
-      meta: RetirementHistoryMeta;
-    }>(
-      `/retirements/entity/${encodeURIComponent(address)}/certificates?${params.toString()}`,
-    );
+    const response = options
+      ? await apiClient.get<{
+          data: EntityCertificate[];
+          meta: RetirementHistoryMeta;
+        }>(`/retirements/entity/${encodeURIComponent(address)}/certificates?${params.toString()}`, options)
+      : await apiClient.get<{
+          data: EntityCertificate[];
+          meta: RetirementHistoryMeta;
+        }>(`/retirements/entity/${encodeURIComponent(address)}/certificates?${params.toString()}`);
     return this.normalizeResponse(response);
   }
 

--- a/corporate-platform/corporate-platform-web/tsconfig.json
+++ b/corporate-platform/corporate-platform-web/tsconfig.json
@@ -12,7 +12,7 @@
     "resolveJsonModule": true,
     "isolatedModules": true,
     "jsx": "react-jsx",
-    
+    "types": ["vitest/globals"],
     "incremental": true,
     "plugins": [
       {

--- a/corporate-platform/corporate-platform-web/tsconfig.json
+++ b/corporate-platform/corporate-platform-web/tsconfig.json
@@ -12,7 +12,7 @@
     "resolveJsonModule": true,
     "isolatedModules": true,
     "jsx": "react-jsx",
-    "types": ["vitest/globals"],
+    "types": ["vitest/globals", "@testing-library/jest-dom"],
     "incremental": true,
     "plugins": [
       {

--- a/corporate-platform/corporate-platform-web/tsconfig.json
+++ b/corporate-platform/corporate-platform-web/tsconfig.json
@@ -12,7 +12,7 @@
     "resolveJsonModule": true,
     "isolatedModules": true,
     "jsx": "react-jsx",
-    "types": ["vitest/globals", "@testing-library/jest-dom"],
+    
     "incremental": true,
     "plugins": [
       {


### PR DESCRIPTION
closes #407 

##Summary
Added AbortController-based cancellation support to the shared API client.
Added a route transition cancellation provider wired into the app layout.
Propagated cancellation-aware options through service layers and retirement hooks.
Added request deduplication, timeout handling, and cancellation logging.
Updated retirement loading cleanup so aborted requests do not leave the UI stuck.

##Reason
Prevent stale API responses from overwriting newer UI state after navigation.
Reduce unnecessary network traffic during route changes.
Improve reliability for components that fetch data during mount/unmount cycles.