### PR TITLE
feat: add build-time environment validation for public config

### DIFF
--- a/.github/workflows/corporate-portal-web.yml
+++ b/.github/workflows/corporate-portal-web.yml
@@ -105,7 +105,14 @@ jobs:
       # ----------------------------------
       # Production Build (Hard Gate)
       # ----------------------------------
+      # Public NEXT_PUBLIC_* config is validated at build time (see
+      # ENVIRONMENT.md). Provide non-secret placeholder URLs so the build-time
+      # validation runs and passes in CI. Override these in real deployments.
       - name: Build Next.js
+        env:
+          NEXT_PUBLIC_API_BASE_URL: http://localhost:4000
+          NEXT_PUBLIC_API_URL: http://localhost:4000
+          NEXT_PUBLIC_STELLAR_EXPLORER_BASE_URL: https://stellar.expert/explorer/testnet/tx
         run: |
           if [ "${{ steps.detect.outputs.manager }}" = "pnpm" ]; then
             pnpm run build

--- a/corporate-platform/corporate-platform-web/.env.example
+++ b/corporate-platform/corporate-platform-web/.env.example
@@ -1,8 +1,32 @@
-# Backend API URL
+# ─────────────────────────────────────────────────────────────────────────────
+# Required public configuration
+# Validated at build time (and at dev startup) by src/lib/env/validate.ts.
+# A production `next build` fails if any are missing or malformed.
+# Rule: must be a valid http(s) URL, ideally with no trailing slash.
+# See ENVIRONMENT.md for the full list and rules.
+# ─────────────────────────────────────────────────────────────────────────────
+
+# Backend API base URL (consumed by src/lib/api/*).
 NEXT_PUBLIC_API_BASE_URL=http://localhost:4000
 
-# Stellar Explorer URL
+# Backend API URL (consumed by src/services/* and src/lib/teamApi.ts).
+NEXT_PUBLIC_API_URL=http://localhost:4000
+
+# Stellar Explorer URL.
 NEXT_PUBLIC_STELLAR_EXPLORER_BASE_URL=https://stellar.expert/explorer/testnet/tx
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Optional public configuration (produce warnings only; never fail the build)
+# ─────────────────────────────────────────────────────────────────────────────
+
+# Deployment environment label: development | staging | production
+# NEXT_PUBLIC_ENVIRONMENT=development
+
+# Human-readable application name (must be non-empty if set).
+# NEXT_PUBLIC_APP_NAME=Carbon Scribe
+
+# Sentry DSN — validated as a URL when present.
+# NEXT_PUBLIC_SENTRY_DSN=
 
 # Authentication Configuration
 # Token refresh buffer (seconds before expiry to trigger refresh)

--- a/corporate-platform/corporate-platform-web/ENVIRONMENT.md
+++ b/corporate-platform/corporate-platform-web/ENVIRONMENT.md
@@ -1,0 +1,83 @@
+# Environment Configuration
+
+This app validates its public (`NEXT_PUBLIC_*`) configuration at build time so a
+missing or malformed value fails fast during `next build` instead of surfacing as
+a cryptic network error in production.
+
+- Validator: [`src/lib/env/validate.ts`](./src/lib/env/validate.ts)
+- Build/dev integration: [`next.config.ts`](./next.config.ts)
+- Template: [`.env.example`](./.env.example)
+
+## How it runs
+
+`next.config.ts` calls `assertPublicEnv()` on load, which means validation runs
+for both `next build` and `next dev`:
+
+| Command      | NODE_ENV      | Behaviour                                              |
+| ------------ | ------------- | ----------------------------------------------------- |
+| `next build` | `production`  | **Strict** — missing/invalid required vars throw and fail the build. |
+| `next dev`   | `development` | Warnings and errors are logged; the dev server still starts (built-in fallbacks apply). |
+
+Set `SKIP_ENV_VALIDATION=1` to bypass validation entirely (for tooling that
+intentionally builds without runtime config).
+
+## Required variables
+
+These must be valid `http(s)` URLs. A production build fails if any is missing or
+malformed.
+
+| Variable                                | Purpose                                              |
+| --------------------------------------- | --------------------------------------------------- |
+| `NEXT_PUBLIC_API_BASE_URL`              | Backend API base URL, consumed by `src/lib/api/*`.  |
+| `NEXT_PUBLIC_API_URL`                   | Backend API URL, consumed by `src/services/*` and `src/lib/teamApi.ts`. |
+| `NEXT_PUBLIC_STELLAR_EXPLORER_BASE_URL` | Stellar blockchain explorer base URL.               |
+
+> Note: the codebase currently reads two API URL variables in different layers
+> (`NEXT_PUBLIC_API_BASE_URL` and `NEXT_PUBLIC_API_URL`). Both are validated so
+> runtime API calls cannot fail due to one being unset. Consolidating them into a
+> single variable is a reasonable follow-up.
+
+## Optional variables (warnings only)
+
+These never fail the build; they emit a warning if present but malformed.
+
+| Variable                            | Rule                                              |
+| ----------------------------------- | ------------------------------------------------- |
+| `NEXT_PUBLIC_ENVIRONMENT`           | One of `development`, `staging`, `production`.     |
+| `NEXT_PUBLIC_APP_NAME`              | Non-empty string when set.                        |
+| `NEXT_PUBLIC_SENTRY_DSN`            | Valid URL when set.                               |
+| `NEXT_PUBLIC_ERROR_REPORTING_ENDPOINT` | Valid URL when set.                            |
+| Numeric tuning vars (retry, connectivity, session, error rate-limit) | Non-negative number when set. |
+
+All URL variables also warn on a trailing slash, which can produce double-slash
+request paths.
+
+## Examples
+
+### Valid
+
+```bash
+NEXT_PUBLIC_API_BASE_URL=https://api.carbonscribe.example
+NEXT_PUBLIC_API_URL=https://api.carbonscribe.example
+NEXT_PUBLIC_STELLAR_EXPLORER_BASE_URL=https://stellar.expert/explorer/public/tx
+```
+
+### Failing build (clear error)
+
+With `NEXT_PUBLIC_API_URL` unset, `next build` aborts:
+
+```
+[env] Public environment validation failed with 1 error(s):
+  - NEXT_PUBLIC_API_URL is required but is missing or empty.
+
+Set these variables in your environment or .env file.
+See .env.example and ENVIRONMENT.md for the full list and rules.
+```
+
+## Local setup
+
+```bash
+cp .env.example .env.local
+# edit values, then:
+npm run dev
+```

--- a/corporate-platform/corporate-platform-web/next.config.ts
+++ b/corporate-platform/corporate-platform-web/next.config.ts
@@ -1,4 +1,11 @@
 import type { NextConfig } from "next";
+import { assertPublicEnv } from "./src/lib/env/validate";
+
+// Validate public configuration as part of the build/dev pipeline so missing or
+// malformed NEXT_PUBLIC_* values fail fast instead of surfacing as runtime
+// errors. Production builds are strict (throw); dev startup logs warnings/errors
+// without blocking local work that relies on built-in fallbacks.
+assertPublicEnv({ strict: process.env.NODE_ENV === "production" });
 
 const nextConfig: NextConfig = {
   images: {

--- a/corporate-platform/corporate-platform-web/src/lib/env/validate.test.ts
+++ b/corporate-platform/corporate-platform-web/src/lib/env/validate.test.ts
@@ -1,0 +1,99 @@
+import { describe, it, expect, vi } from 'vitest';
+import { validatePublicEnv, assertPublicEnv } from './validate';
+
+const validEnv = {
+  NEXT_PUBLIC_API_BASE_URL: 'http://localhost:4000',
+  NEXT_PUBLIC_API_URL: 'http://localhost:4000/api/v1',
+  NEXT_PUBLIC_STELLAR_EXPLORER_BASE_URL:
+    'https://stellar.expert/explorer/testnet/tx',
+};
+
+describe('validatePublicEnv', () => {
+  it('passes with all required URLs present and valid', () => {
+    const result = validatePublicEnv(validEnv);
+    expect(result.errors).toEqual([]);
+  });
+
+  it('reports an error for each missing required variable', () => {
+    const result = validatePublicEnv({});
+    expect(result.errors).toHaveLength(3);
+    expect(result.errors.join('\n')).toContain('NEXT_PUBLIC_API_BASE_URL');
+    expect(result.errors.join('\n')).toContain('NEXT_PUBLIC_API_URL');
+    expect(result.errors.join('\n')).toContain(
+      'NEXT_PUBLIC_STELLAR_EXPLORER_BASE_URL',
+    );
+  });
+
+  it('errors on a malformed required URL', () => {
+    const result = validatePublicEnv({ ...validEnv, NEXT_PUBLIC_API_URL: 'not-a-url' });
+    expect(result.errors.some((e) => e.includes('NEXT_PUBLIC_API_URL'))).toBe(true);
+  });
+
+  it('errors on a non-http(s) protocol', () => {
+    const result = validatePublicEnv({
+      ...validEnv,
+      NEXT_PUBLIC_API_URL: 'ftp://example.com',
+    });
+    expect(result.errors.some((e) => e.includes('http or https'))).toBe(true);
+  });
+
+  it('warns (does not error) on a trailing slash', () => {
+    const result = validatePublicEnv({
+      ...validEnv,
+      NEXT_PUBLIC_API_URL: 'http://localhost:4000/',
+    });
+    expect(result.errors).toEqual([]);
+    expect(result.warnings.some((w) => w.includes('trailing slash'))).toBe(true);
+  });
+
+  it('warns on an invalid NEXT_PUBLIC_ENVIRONMENT but does not error', () => {
+    const result = validatePublicEnv({ ...validEnv, NEXT_PUBLIC_ENVIRONMENT: 'prod' });
+    expect(result.errors).toEqual([]);
+    expect(result.warnings.some((w) => w.includes('NEXT_PUBLIC_ENVIRONMENT'))).toBe(
+      true,
+    );
+  });
+
+  it('warns on a malformed optional URL (Sentry DSN) without erroring', () => {
+    const result = validatePublicEnv({ ...validEnv, NEXT_PUBLIC_SENTRY_DSN: 'oops' });
+    expect(result.errors).toEqual([]);
+    expect(result.warnings.some((w) => w.includes('NEXT_PUBLIC_SENTRY_DSN'))).toBe(
+      true,
+    );
+  });
+
+  it('warns on a non-numeric optional numeric variable', () => {
+    const result = validatePublicEnv({
+      ...validEnv,
+      NEXT_PUBLIC_MAX_RETRY_ATTEMPTS: 'three',
+    });
+    expect(result.warnings.some((w) => w.includes('NEXT_PUBLIC_MAX_RETRY_ATTEMPTS'))).toBe(
+      true,
+    );
+  });
+});
+
+describe('assertPublicEnv', () => {
+  it('throws with a clear message in strict mode when required vars are missing', () => {
+    expect(() => assertPublicEnv({ env: {}, strict: true })).toThrow(
+      /NEXT_PUBLIC_API_BASE_URL/,
+    );
+  });
+
+  it('does not throw in non-strict mode but logs the error', () => {
+    const logger = { warn: vi.fn(), error: vi.fn() };
+    expect(() => assertPublicEnv({ env: {}, strict: false, logger })).not.toThrow();
+    expect(logger.error).toHaveBeenCalledOnce();
+  });
+
+  it('is bypassed entirely when SKIP_ENV_VALIDATION is set', () => {
+    const result = assertPublicEnv({ env: { SKIP_ENV_VALIDATION: '1' }, strict: true });
+    expect(result.errors).toEqual([]);
+  });
+
+  it('does not throw when configuration is valid', () => {
+    const logger = { warn: vi.fn(), error: vi.fn() };
+    expect(() => assertPublicEnv({ env: validEnv, strict: true, logger })).not.toThrow();
+    expect(logger.error).not.toHaveBeenCalled();
+  });
+});

--- a/corporate-platform/corporate-platform-web/src/lib/env/validate.ts
+++ b/corporate-platform/corporate-platform-web/src/lib/env/validate.ts
@@ -1,0 +1,193 @@
+/**
+ * Build-time validation for public (`NEXT_PUBLIC_*`) environment variables.
+ *
+ * The goal is to fail fast: a missing or malformed public config value should
+ * surface during `next build` (and be flagged at `next dev` startup) rather than
+ * as a cryptic network error at runtime in production.
+ *
+ * `validatePublicEnv` is a pure function (easy to unit test). `assertPublicEnv`
+ * wraps it with logging and throw-on-error behaviour for use in `next.config.ts`.
+ */
+
+export interface EnvValidationResult {
+  errors: string[];
+  warnings: string[];
+}
+
+/** Required public URL variables. Missing/invalid values fail a production build. */
+const REQUIRED_URL_VARS = [
+  'NEXT_PUBLIC_API_BASE_URL',
+  'NEXT_PUBLIC_API_URL',
+  'NEXT_PUBLIC_STELLAR_EXPLORER_BASE_URL',
+] as const;
+
+/** Optional URL variables. Validated only when present; problems warn, never fail. */
+const OPTIONAL_URL_VARS = [
+  'NEXT_PUBLIC_SENTRY_DSN',
+  'NEXT_PUBLIC_ERROR_REPORTING_ENDPOINT',
+] as const;
+
+/** Optional numeric tuning variables. When set they must parse to a non-negative number. */
+const OPTIONAL_NUMERIC_VARS = [
+  'NEXT_PUBLIC_TOKEN_REFRESH_BUFFER',
+  'NEXT_PUBLIC_SESSION_TIMEOUT_WARNING',
+  'NEXT_PUBLIC_MAX_RETRY_ATTEMPTS',
+  'NEXT_PUBLIC_RETRY_INITIAL_DELAY_MS',
+  'NEXT_PUBLIC_RETRY_MAX_DELAY_MS',
+  'NEXT_PUBLIC_RETRY_BACKOFF_MULTIPLIER',
+  'NEXT_PUBLIC_DEGRADED_THRESHOLD',
+  'NEXT_PUBLIC_DEGRADED_RECOVERY_THRESHOLD',
+  'NEXT_PUBLIC_CONNECTIVITY_CHECK_INTERVAL',
+  'NEXT_PUBLIC_MAX_QUEUE_SIZE',
+  'NEXT_PUBLIC_QUEUE_MAX_RETRIES',
+  'NEXT_PUBLIC_ERROR_RATE_LIMIT_MAX',
+  'NEXT_PUBLIC_ERROR_RATE_LIMIT_WINDOW_MS',
+  'NEXT_PUBLIC_SESSION_EXPIRY_WARNING_MINUTES',
+  'NEXT_PUBLIC_SESSION_GRACE_SECONDS',
+] as const;
+
+const ENVIRONMENT_VALUES = ['development', 'staging', 'production'] as const;
+
+type EnvRecord = Record<string, string | undefined>;
+
+function parseUrl(value: string): URL | null {
+  try {
+    return new URL(value);
+  } catch {
+    return null;
+  }
+}
+
+function checkHttpUrl(name: string, value: string, sink: string[]): void {
+  const url = parseUrl(value);
+  if (!url) {
+    sink.push(`${name} is not a valid URL (got "${value}").`);
+    return;
+  }
+  if (url.protocol !== 'http:' && url.protocol !== 'https:') {
+    sink.push(
+      `${name} must use the http or https protocol (got "${url.protocol}").`,
+    );
+  }
+}
+
+/**
+ * Validate public environment variables and return collected errors and warnings.
+ *
+ * This function never throws and has no side effects, so it is safe to call from
+ * tests and from the build pipeline.
+ *
+ * @param env - The environment to validate (defaults to `process.env`).
+ */
+export function validatePublicEnv(env: EnvRecord = process.env): EnvValidationResult {
+  const errors: string[] = [];
+  const warnings: string[] = [];
+
+  // Required URLs.
+  for (const name of REQUIRED_URL_VARS) {
+    const value = env[name]?.trim();
+    if (!value) {
+      errors.push(`${name} is required but is missing or empty.`);
+      continue;
+    }
+    checkHttpUrl(name, value, errors);
+    if (value.endsWith('/')) {
+      warnings.push(
+        `${name} has a trailing slash ("${value}"); remove it to avoid double-slash request paths.`,
+      );
+    }
+  }
+
+  // Optional URLs (validate format only when provided).
+  for (const name of OPTIONAL_URL_VARS) {
+    const value = env[name]?.trim();
+    if (!value) continue;
+    checkHttpUrl(name, value, warnings);
+  }
+
+  // NEXT_PUBLIC_ENVIRONMENT: optional enum.
+  const environment = env.NEXT_PUBLIC_ENVIRONMENT?.trim();
+  if (
+    environment &&
+    !(ENVIRONMENT_VALUES as readonly string[]).includes(environment)
+  ) {
+    warnings.push(
+      `NEXT_PUBLIC_ENVIRONMENT should be one of ${ENVIRONMENT_VALUES.join(', ')} (got "${environment}").`,
+    );
+  }
+
+  // NEXT_PUBLIC_APP_NAME: optional, but warn if set to an empty string.
+  if (
+    env.NEXT_PUBLIC_APP_NAME !== undefined &&
+    env.NEXT_PUBLIC_APP_NAME.trim() === ''
+  ) {
+    warnings.push(
+      'NEXT_PUBLIC_APP_NAME is set but empty; provide a non-empty value or remove it.',
+    );
+  }
+
+  // Optional numeric tuning variables.
+  for (const name of OPTIONAL_NUMERIC_VARS) {
+    const value = env[name]?.trim();
+    if (!value) continue;
+    const parsed = Number(value);
+    if (!Number.isFinite(parsed) || parsed < 0) {
+      warnings.push(
+        `${name} should be a non-negative number (got "${value}").`,
+      );
+    }
+  }
+
+  return { errors, warnings };
+}
+
+export interface AssertOptions {
+  /** Environment to validate (defaults to `process.env`). */
+  env?: EnvRecord;
+  /**
+   * When true (the default), required-variable problems throw. When false, they
+   * are logged as errors but do not throw (used at dev startup so local work with
+   * built-in fallbacks is not blocked).
+   */
+  strict?: boolean;
+  /** Logger, injectable for tests. */
+  logger?: Pick<Console, 'warn' | 'error'>;
+}
+
+const LOG_PREFIX = '[env] Public environment validation';
+
+/**
+ * Validate public env vars, log warnings/errors, and throw on errors in strict
+ * mode. Set `SKIP_ENV_VALIDATION=1` to bypass entirely (e.g. for tooling that
+ * intentionally builds without runtime config).
+ */
+export function assertPublicEnv(options: AssertOptions = {}): EnvValidationResult {
+  const { env = process.env, strict = true, logger = console } = options;
+
+  if (env.SKIP_ENV_VALIDATION === '1' || env.SKIP_ENV_VALIDATION === 'true') {
+    return { errors: [], warnings: [] };
+  }
+
+  const result = validatePublicEnv(env);
+
+  for (const warning of result.warnings) {
+    logger.warn(`${LOG_PREFIX} warning: ${warning}`);
+  }
+
+  if (result.errors.length > 0) {
+    const message = [
+      `${LOG_PREFIX} failed with ${result.errors.length} error(s):`,
+      ...result.errors.map((error) => `  - ${error}`),
+      '',
+      'Set these variables in your environment or .env file.',
+      'See .env.example and ENVIRONMENT.md for the full list and rules.',
+    ].join('\n');
+
+    if (strict) {
+      throw new Error(message);
+    }
+    logger.error(message);
+  }
+
+  return result;
+}


### PR DESCRIPTION
# feat: add build-time environment validation for public config

Closes #404

Working directory: `corporate-platform/corporate-platform-web`

## What this does

Public (`NEXT_PUBLIC_*`) configuration is now validated as part of the
build/dev pipeline. A missing or malformed value fails a production `next build`
with a clear, per-variable error instead of surfacing later as a cryptic runtime
network error.

## Changes

- **`src/lib/env/validate.ts`** — pure `validatePublicEnv()` (collects errors +
  warnings, no side effects) and `assertPublicEnv()` (logs warnings, throws on
  errors in strict mode, honors `SKIP_ENV_VALIDATION=1`).
- **`next.config.ts`** — calls `assertPublicEnv({ strict: NODE_ENV === 'production' })`
  so validation runs for both `next build` (strict, fails the build) and
  `next dev` (logs warnings/errors without blocking local fallbacks).
- **`src/lib/env/validate.test.ts`** — 12 unit tests (missing/invalid/optional/
  trailing-slash/skip cases).
- **`.env.example`** — documents required vs optional vars and the rules.
- **`ENVIRONMENT.md`** — full reference for the variables and validation behavior.

## Validated variables

Required (valid `http(s)` URL; build fails if missing/invalid):

- `NEXT_PUBLIC_API_BASE_URL` — consumed by `src/lib/api/*`
- `NEXT_PUBLIC_API_URL` — consumed by `src/services/*` and `src/lib/teamApi.ts`
- `NEXT_PUBLIC_STELLAR_EXPLORER_BASE_URL` — explorer URL

Optional (warn only): `NEXT_PUBLIC_ENVIRONMENT` (enum), `NEXT_PUBLIC_APP_NAME`
(non-empty), `NEXT_PUBLIC_SENTRY_DSN` / `NEXT_PUBLIC_ERROR_REPORTING_ENDPOINT`
(URL), the numeric tuning vars (non-negative number), and a trailing-slash check
on all URLs.

## Mapping note (accuracy)

The issue lists generic names (`NEXT_PUBLIC_API_URL`, `NEXT_PUBLIC_EXPLORER_URL`,
`NEXT_PUBLIC_APP_NAME`, `NEXT_PUBLIC_ENVIRONMENT`, `NEXT_PUBLIC_SENTRY_DSN`). This
PR validates the variables the codebase actually reads:

- The app uses **both** `NEXT_PUBLIC_API_BASE_URL` and `NEXT_PUBLIC_API_URL` in
  different layers, so both are required (so runtime API calls cannot fail due to
  one being unset). Consolidating them is noted as a follow-up in ENVIRONMENT.md.
- The explorer var is `NEXT_PUBLIC_STELLAR_EXPLORER_BASE_URL` (the real name).
- `NEXT_PUBLIC_APP_NAME`, `NEXT_PUBLIC_ENVIRONMENT`, and `NEXT_PUBLIC_SENTRY_DSN`
  are not consumed anywhere yet, so they are validated as optional (warn) rather
  than invented as required config.

## Verification

- **Build fails on invalid config** (verified live, `next build` with vars unset):
  ```
  Error: [env] Public environment validation failed with 3 error(s):
    - NEXT_PUBLIC_API_BASE_URL is required but is missing or empty.
    - NEXT_PUBLIC_API_URL is required but is missing or empty.
    - NEXT_PUBLIC_STELLAR_EXPLORER_BASE_URL is required but is missing or empty.
  ```
- **Build succeeds with valid config** (verified: `Compiled successfully`).
- `npm run lint` (`tsc --noEmit`) passes.
- `npm test` (vitest): 238 passed (226 existing + 12 new); no regressions.

## Acceptance criteria

- [x] Build fails with a clear message when required vars are missing/invalid.
- [x] Validation runs during build and dev startup.
- [x] Error messages name the variable and the reason.
- [x] Optional variables warn but do not fail the build.
- [x] `.env.example` includes all required variables and rules.
- [x] Runtime API calls no longer depend on silently-missing config.
