### PR TITLE
fix(collaboration): optimistic task updates with concurrency coverage

### DIFF
--- a/project-portal/project-portal-web/src/components/collaboration/TaskCard.tsx
+++ b/project-portal/project-portal-web/src/components/collaboration/TaskCard.tsx
@@ -1,7 +1,8 @@
 'use client';
 
-import { Calendar, User, GripVertical } from 'lucide-react';
+import { Calendar, User, GripVertical, Loader2 } from 'lucide-react';
 import type { Task } from '@/lib/store/collaboration/collaboration.types';
+import { useStore } from '@/lib/store/store';
 
 const priorityColors: Record<string, string> = {
   low: 'bg-gray-100 text-gray-700',
@@ -17,15 +18,23 @@ interface TaskCardProps {
 
 export default function TaskCard({ task, onClick }: TaskCardProps) {
   const priorityClass = priorityColors[task.priority] ?? priorityColors.medium;
+  const isUpdating = useStore((s) => s.updatingTaskIds?.includes(task.id));
 
   return (
     <button
       type="button"
       onClick={onClick}
-      className="w-full text-left p-4 bg-white border border-gray-200 rounded-xl shadow-sm hover:shadow-md hover:border-emerald-200 transition-all group"
+      disabled={isUpdating}
+      className={`w-full text-left p-4 bg-white border border-gray-200 rounded-xl shadow-sm hover:shadow-md transition-all group ${
+        isUpdating ? 'opacity-70 cursor-not-allowed' : 'hover:border-emerald-200'
+      }`}
     >
       <div className="flex items-start gap-2">
-        <GripVertical className="w-4 h-4 text-gray-300 flex-shrink-0 mt-0.5 opacity-0 group-hover:opacity-100" />
+        {isUpdating ? (
+          <Loader2 className="w-4 h-4 text-emerald-500 animate-spin flex-shrink-0 mt-0.5" />
+        ) : (
+          <GripVertical className="w-4 h-4 text-gray-300 flex-shrink-0 mt-0.5 opacity-0 group-hover:opacity-100" />
+        )}
         <div className="min-w-0 flex-1">
           <h4 className="font-medium text-gray-900 truncate">{task.title}</h4>
           {task.description && (

--- a/project-portal/project-portal-web/src/components/collaboration/TaskDetailModal.tsx
+++ b/project-portal/project-portal-web/src/components/collaboration/TaskDetailModal.tsx
@@ -1,9 +1,8 @@
 'use client';
 
-import { X, Loader2, Calendar, User } from 'lucide-react';
+import { X, Calendar, User } from 'lucide-react';
 import { useStore } from '@/lib/store/store';
-import { showToast } from '@/components/ui/Toast';
-import { TaskStatuses, TaskPriorities } from '@/lib/store/collaboration/collaboration.types';
+import { TaskStatuses } from '@/lib/store/collaboration/collaboration.types';
 import type { Task } from '@/lib/store/collaboration/collaboration.types';
 
 interface TaskDetailModalProps {
@@ -14,14 +13,12 @@ interface TaskDetailModalProps {
 
 export default function TaskDetailModal({ task, isOpen, onClose }: TaskDetailModalProps) {
   const updateTask = useStore((s) => s.updateTask);
-  const loading = useStore((s) => s.collaborationLoading.updateTask);
+  const loading = useStore((s) => task ? s.updatingTaskIds?.includes(task.id) : false);
 
   if (!isOpen || !task) return null;
 
   const handleStatusChange = async (newStatus: string) => {
-    const updated = await updateTask(task.id, { status: newStatus });
-    if (updated) showToast('success', 'Status updated.');
-    else showToast('error', 'Failed to update.');
+    await updateTask(task.id, { status: newStatus });
   };
 
   return (

--- a/project-portal/project-portal-web/src/lib/store/collaboration/collaboration.slice.test.ts
+++ b/project-portal/project-portal-web/src/lib/store/collaboration/collaboration.slice.test.ts
@@ -2,6 +2,12 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 import type { CollaborationSlice, ProjectInvitation, ActivityLog } from './collaboration.types';
 import { createCollaborationSlice } from './collaborationSlice';
 import * as api from './collaboration.api';
+import { showSuccessToast, showErrorToast } from '@/lib/utils/toast';
+
+vi.mock('@/lib/utils/toast', () => ({
+  showSuccessToast: vi.fn(),
+  showErrorToast: vi.fn(),
+}));
 
 // Mock the API module
 vi.mock('./collaboration.api', () => ({
@@ -51,6 +57,7 @@ describe('CollaborationSlice', () => {
       expect(slice.comments).toEqual([]);
       expect(slice.tasks).toEqual([]);
       expect(slice.resources).toEqual([]);
+      expect(slice.updatingTaskIds).toEqual([]);
       expect(slice.collaborationLoading).toEqual({
         members: false,
         invitations: false,
@@ -277,29 +284,82 @@ describe('CollaborationSlice', () => {
   });
 
   describe('updateTask', () => {
-    it('should update task successfully', async () => {
-      const mockTask = { id: '1', project_id: 'p1', created_by: 'user1', title: 'Updated task', status: 'done', description: '', priority: 'medium', time_logged: 0, created_at: '2023-01-01T00:00:00Z', updated_at: '2023-01-01T00:00:00Z' };
-      mockApi.updateTaskApi.mockResolvedValue(mockTask);
+    it('should update task successfully and apply optimistic update', async () => {
+      const initialTask = { id: '1', project_id: 'p1', created_by: 'user1', title: 'Initial task', status: 'todo', description: '', priority: 'medium', time_logged: 0, created_at: '2023-01-01T00:00:00Z', updated_at: '2023-01-01T00:00:00Z' };
+      slice.tasks = [initialTask];
+      slice.updatingTaskIds = [];
 
-      const result = await slice.updateTask('1', { status: 'done' });
+      const mockTask = { ...initialTask, status: 'done', title: 'Updated task' };
+      let resolveApi: (val: any) => void;
+      const apiPromise = new Promise((resolve) => { resolveApi = resolve; });
+      mockApi.updateTaskApi.mockReturnValue(apiPromise as any);
 
-      expect(mockApi.updateTaskApi).toHaveBeenCalledWith('1', { status: 'done' });
+      const updatePromise = slice.updateTask('1', { status: 'done', title: 'Updated task' });
+
+      // Assert optimistic update
+      expect(slice.tasks[0].status).toBe('done');
+      expect(slice.tasks[0].title).toBe('Updated task');
+      expect(slice.updatingTaskIds).toContain('1');
+      expect(mockApi.updateTaskApi).toHaveBeenCalledWith('1', { status: 'done', title: 'Updated task' });
+
+      // Resolve api
+      resolveApi!(mockTask);
+      const result = await updatePromise;
+
       expect(result).toEqual(mockTask);
+      expect(slice.updatingTaskIds).not.toContain('1');
+      expect(showSuccessToast).toHaveBeenCalledWith('Task updated successfully');
     });
 
-    it('should handle update task error', async () => {
+    it('should handle concurrent optimistic updates independently', async () => {
+      const taskOne = { id: '1', project_id: 'p1', created_by: 'user1', title: 'Task one', status: 'todo', description: '', priority: 'medium', time_logged: 0, created_at: '2023-01-01T00:00:00Z', updated_at: '2023-01-01T00:00:00Z' };
+      const taskTwo = { id: '2', project_id: 'p1', created_by: 'user1', title: 'Task two', status: 'in_progress', description: '', priority: 'high', time_logged: 0, created_at: '2023-01-01T00:00:00Z', updated_at: '2023-01-01T00:00:00Z' };
+      slice.tasks = [taskOne, taskTwo];
+      slice.updatingTaskIds = [];
+
+      let resolveFirst: (val: any) => void;
+      let resolveSecond: (val: any) => void;
+      const firstPromise = new Promise((resolve) => { resolveFirst = resolve; });
+      const secondPromise = new Promise((resolve) => { resolveSecond = resolve; });
+      mockApi.updateTaskApi
+        .mockReturnValueOnce(firstPromise as any)
+        .mockReturnValueOnce(secondPromise as any);
+
+      const firstUpdate = slice.updateTask('1', { status: 'done', priority: 'urgent' });
+      const secondUpdate = slice.updateTask('2', { assigned_to: 'user2' });
+
+      expect(slice.tasks.find((t) => t.id === '1')?.status).toBe('done');
+      expect(slice.tasks.find((t) => t.id === '1')?.priority).toBe('urgent');
+      expect(slice.tasks.find((t) => t.id === '2')?.assigned_to).toBe('user2');
+      expect(slice.updatingTaskIds).toEqual(expect.arrayContaining(['1', '2']));
+
+      resolveSecond!({ ...taskTwo, assigned_to: 'user2' });
+      await secondUpdate;
+      expect(slice.updatingTaskIds).toContain('1');
+      expect(slice.updatingTaskIds).not.toContain('2');
+
+      resolveFirst!({ ...taskOne, status: 'done', priority: 'urgent' });
+      await firstUpdate;
+      expect(slice.updatingTaskIds).toEqual([]);
+      expect(showSuccessToast).toHaveBeenCalledTimes(2);
+    });
+
+    it('should handle update task error and rollback', async () => {
+      const initialTask = { id: '1', project_id: 'p1', created_by: 'user1', title: 'Initial task', status: 'todo', description: '', priority: 'medium', time_logged: 0, created_at: '2023-01-01T00:00:00Z', updated_at: '2023-01-01T00:00:00Z' };
+      slice.tasks = [initialTask];
+      slice.updatingTaskIds = [];
+
       const error = new Error('Failed to update task');
       mockApi.updateTaskApi.mockRejectedValue(error);
 
       const result = await slice.updateTask('1', { status: 'done' });
 
-      expect(mockSet).toHaveBeenCalledWith(
-        expect.objectContaining({
-          collaborationLoading: expect.objectContaining({ updateTask: false }),
-          collaborationErrors: expect.objectContaining({ updateTask: error.message }),
-        })
-      );
+      // Expect rollback
+      expect(slice.tasks[0].status).toBe('todo');
+      expect(slice.updatingTaskIds).not.toContain('1');
       expect(result).toBeNull();
+      expect(showErrorToast).toHaveBeenCalledWith('Failed to update task. Changes reverted.');
+      expect(slice.collaborationErrors.updateTask).toBe(error.message);
     });
   });
 

--- a/project-portal/project-portal-web/src/lib/store/collaboration/collaboration.types.ts
+++ b/project-portal/project-portal-web/src/lib/store/collaboration/collaboration.types.ts
@@ -202,6 +202,7 @@ export interface CollaborationSlice {
   comments: Comment[];
   tasks: Task[];
   resources: SharedResource[];
+  updatingTaskIds: string[];
 
   // Loading & errors (prefixed to avoid clashing with projects slice)
   collaborationLoading: CollaborationLoadingState;

--- a/project-portal/project-portal-web/src/lib/store/collaboration/collaborationSlice.ts
+++ b/project-portal/project-portal-web/src/lib/store/collaboration/collaborationSlice.ts
@@ -34,7 +34,7 @@ import {
   declineInvitationApi,
 } from './collaboration.api';
 import { getErrorMessage } from '@/lib/utils/errorMessage';
-
+import { showSuccessToast, showErrorToast } from '@/lib/utils/toast';
 const initialLoading: CollaborationLoadingState = {
   members: false,
   invitations: false,
@@ -83,6 +83,7 @@ export const createCollaborationSlice: StateCreator<CollaborationSlice> = (set, 
   comments: [],
   tasks: [],
   resources: [],
+  updatingTaskIds: [],
   collaborationLoading: initialLoading,
   collaborationErrors: initialErrors,
 
@@ -241,19 +242,37 @@ export const createCollaborationSlice: StateCreator<CollaborationSlice> = (set, 
   },
 
   updateTask: async (taskId: string, data: UpdateTaskRequest): Promise<Task | null> => {
-    set((s) => ({ collaborationLoading: { ...s.collaborationLoading, updateTask: true }, collaborationErrors: { ...s.collaborationErrors, updateTask: null } }));
+    const currentTasks = get().tasks;
+    const previousTask = currentTasks.find((t) => t.id === taskId);
+    
+    if (!previousTask) return null;
+
+    const optimisticTask = { ...previousTask, ...data } as Task;
+
+    set((s) => ({
+      tasks: s.tasks.map((t) => (t.id === taskId ? optimisticTask : t)),
+      updatingTaskIds: [...s.updatingTaskIds, taskId],
+      collaborationLoading: { ...s.collaborationLoading, updateTask: true },
+      collaborationErrors: { ...s.collaborationErrors, updateTask: null },
+    }));
+
     try {
       const updated = await updateTaskApi(taskId, data);
       set((s) => ({
         tasks: s.tasks.map((t) => (t.id === taskId ? updated : t)),
+        updatingTaskIds: s.updatingTaskIds.filter((id) => id !== taskId),
         collaborationLoading: { ...s.collaborationLoading, updateTask: false },
       }));
+      showSuccessToast('Task updated successfully');
       return updated;
     } catch (error) {
-      set({
+      set((s) => ({
+        tasks: s.tasks.map((t) => (t.id === taskId ? previousTask : t)),
+        updatingTaskIds: s.updatingTaskIds.filter((id) => id !== taskId),
         collaborationLoading: { ...get().collaborationLoading, updateTask: false },
         collaborationErrors: { ...get().collaborationErrors, updateTask: getErrorMessage(error) },
-      });
+      }));
+      showErrorToast('Failed to update task. Changes reverted.');
       return null;
     }
   },
@@ -362,6 +381,7 @@ export const createCollaborationSlice: StateCreator<CollaborationSlice> = (set, 
       comments: [],
       tasks: [],
       resources: [],
+      updatingTaskIds: [],
       collaborationLoading: initialLoading,
       collaborationErrors: initialErrors,
     }),

--- a/project-portal/project-portal-web/src/lib/store/collaboration/team.slice.test.ts
+++ b/project-portal/project-portal-web/src/lib/store/collaboration/team.slice.test.ts
@@ -2,6 +2,12 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 import type { CollaborationSlice } from './collaboration.types';
 import { createCollaborationSlice } from './collaborationSlice';
 import * as api from './collaboration.api';
+import { showSuccessToast, showErrorToast } from '@/lib/utils/toast';
+
+vi.mock('@/lib/utils/toast', () => ({
+  showSuccessToast: vi.fn(),
+  showErrorToast: vi.fn(),
+}));
 
 // Mock the API module
 vi.mock('./collaboration.api', () => ({
@@ -356,28 +362,50 @@ describe('TeamSlice', () => {
     });
 
     it('should update team task status', async () => {
-      const mockUpdatedTask = {
+      const initialTask = {
         id: 'task-1',
         project_id: 'team-project-1',
         created_by: 'manager-123',
-        title: 'Updated task title',
-        description: 'Updated task description',
-        status: 'done' as const,
+        title: 'Initial task title',
+        description: 'Initial task description',
+        status: 'todo' as const,
         priority: 'medium' as const,
         time_logged: 0,
         created_at: '2023-01-01T00:00:00Z',
+        updated_at: '2023-01-01T00:00:00Z',
+      };
+      slice.tasks = [initialTask];
+      slice.updatingTaskIds = [];
+
+      const mockUpdatedTask = {
+        ...initialTask,
+        title: 'Updated task title',
+        description: 'Updated task description',
+        status: 'done' as const,
         updated_at: '2023-01-03T00:00:00Z',
       };
-      mockApi.updateTaskApi.mockResolvedValue(mockUpdatedTask);
 
-      const result = await slice.updateTask('task-1', {
+      let resolveApi: (val: any) => void;
+      const apiPromise = new Promise((resolve) => { resolveApi = resolve; });
+      mockApi.updateTaskApi.mockReturnValue(apiPromise as any);
+
+      const updatePromise = slice.updateTask('task-1', {
         status: 'done',
       });
 
+      // Assert optimistic update
+      expect(slice.tasks[0].status).toBe('done');
+      expect(slice.updatingTaskIds).toContain('task-1');
       expect(mockApi.updateTaskApi).toHaveBeenCalledWith('task-1', {
         status: 'done',
       });
+
+      resolveApi!(mockUpdatedTask);
+      const result = await updatePromise;
+
       expect(result).toEqual(mockUpdatedTask);
+      expect(slice.updatingTaskIds).not.toContain('task-1');
+      expect(showSuccessToast).toHaveBeenCalledWith('Task updated successfully');
     });
   });
 
@@ -630,6 +658,7 @@ describe('TeamSlice', () => {
       expect(slice.comments).toEqual([]);
       expect(slice.tasks).toEqual([]);
       expect(slice.resources).toEqual([]);
+      expect(slice.updatingTaskIds).toEqual([]);
       expect(slice.collaborationLoading).toEqual({
         members: false,
         invitations: false,


### PR DESCRIPTION
closes #426 

# Summary
Adds optimistic task update behavior in the collaboration store.
Updates task UI to reflect in-flight updates with a spinner and disabled interaction.
Adds tests for optimistic update, rollback, and concurrent update handling.
Removes a couple of unused imports in the task detail modal.


# Reason
Task status changes should feel immediate instead of waiting on the server round-trip.
The UI now gives fast feedback while still recovering safely if the API call fails.