### PR TITLE
fix(retirement-tracker): handle typed already initialized error

### DIFF
--- a/stellar-core/carbon-asset-factory/Cargo.lock
+++ b/stellar-core/carbon-asset-factory/Cargo.lock
@@ -584,9 +584,9 @@ checksum = "2bfcf67fea2815c2fc3b90873fae90957be12ff417335dfadc7f52927feb03b2"
 
 [[package]]
 name = "ethnum"
-version = "1.5.2"
+version = "1.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca81e6b4777c89fd810c25a4be2b1bd93ea034fbe58e6a75216a34c6b82c539b"
+checksum = "40404c3f5f511ec4da6fe866ddf6a717c309fdbb69fbbad7b0f3edab8f2e835f"
 
 [[package]]
 name = "ff"

--- a/stellar-core/carbon-asset-factory/contracts/retirement_tracker/src/errors.rs
+++ b/stellar-core/carbon-asset-factory/contracts/retirement_tracker/src/errors.rs
@@ -1,0 +1,24 @@
+use soroban_sdk::contracterror;
+
+/// Errors defined for the Retirement Tracker contract.
+#[contracterror]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, PartialOrd, Ord)]
+#[repr(u32)]
+pub enum ContractError {
+    /// The caller is not authorized to perform this operation.
+    NotAuthorized = 1,
+    /// The specified token is not owned by the caller.
+    TokenNotOwned = 2,
+    /// The token has already been retired.
+    TokenAlreadyRetired = 3,
+    /// The provided token ID is invalid.
+    InvalidTokenId = 4,
+    /// The token burn operation failed.
+    BurnFailed = 5,
+    /// The contract must be initialized.
+    ContractNotInitialized = 6,
+    /// The event nonce has overflowed.
+    EventNonceOverflow = 7,
+    /// The contract has already been initialized.
+    AlreadyInitialized = 8,
+}

--- a/stellar-core/carbon-asset-factory/contracts/retirement_tracker/src/lib.rs
+++ b/stellar-core/carbon-asset-factory/contracts/retirement_tracker/src/lib.rs
@@ -1,6 +1,6 @@
 #![no_std]
 use soroban_sdk::{
-    contract, contracterror, contractevent, contractimpl, contracttype, Address, BytesN, Env,
+    contract, contractevent, contractimpl, contracttype, Address, BytesN, Env,
     IntoVal, String, Symbol, Vec,
 };
 

--- a/stellar-core/carbon-asset-factory/contracts/retirement_tracker/src/lib.rs
+++ b/stellar-core/carbon-asset-factory/contracts/retirement_tracker/src/lib.rs
@@ -35,17 +35,8 @@ pub enum DataKey {
 // Contract Errors
 // ========================================================================
 
-#[derive(Clone, Copy)]
-#[contracterror]
-pub enum ContractError {
-    NotAuthorized = 1,
-    TokenNotOwned = 2,
-    TokenAlreadyRetired = 3,
-    InvalidTokenId = 4,
-    BurnFailed = 5,
-    ContractNotInitialized = 6,
-    EventNonceOverflow = 7,
-}
+pub mod errors;
+pub use errors::ContractError;
 
 // ========================================================================
 // Events
@@ -67,6 +58,17 @@ pub struct ContractUpdatedEvent {
     pub updated_by: Address,
 }
 
+#[contractevent]
+pub struct InitializationEvent {
+    pub admin: Address,
+    pub carbon_asset_contract: Address,
+}
+
+#[contractevent]
+pub struct ReinitializationBlockedEvent {
+    pub attempted_admin: Address,
+}
+
 // ========================================================================
 // Contract Implementation
 // ========================================================================
@@ -81,12 +83,20 @@ impl RetirementTracker {
     /// # Arguments
     /// * `admin` - CarbonScribe admin address
     /// * `carbon_asset_contract` - Address of the CarbonAsset contract
-    pub fn initialize(env: Env, admin: Address, carbon_asset_contract: Address) {
+    pub fn initialize(
+        env: Env,
+        admin: Address,
+        carbon_asset_contract: Address,
+    ) -> Result<(), ContractError> {
         admin.require_auth();
 
         // Check if already initialized
         if env.storage().instance().has(&DataKey::Admin) {
-            panic!("Contract already initialized");
+            ReinitializationBlockedEvent {
+                attempted_admin: admin,
+            }
+            .publish(&env);
+            return Err(ContractError::AlreadyInitialized);
         }
 
         env.storage().instance().set(&DataKey::Admin, &admin);
@@ -94,6 +104,19 @@ impl RetirementTracker {
             .instance()
             .set(&DataKey::CarbonAssetContract, &carbon_asset_contract);
         env.storage().instance().set(&DataKey::EventNonce, &0u64);
+
+        InitializationEvent {
+            admin,
+            carbon_asset_contract,
+        }
+        .publish(&env);
+
+        Ok(())
+    }
+
+    /// Check if the contract has been initialized.
+    pub fn is_initialized(env: Env) -> bool {
+        env.storage().instance().has(&DataKey::Admin)
     }
 
     /// Retire a single carbon credit token
@@ -500,5 +523,25 @@ mod test {
         assert_eq!(records.get(1).unwrap().tx_hash, Some(second_hash));
         assert_eq!(records.get(1).unwrap().event_nonce, 2);
         assert_eq!(client.get_event_nonce(), 2);
+    }
+
+    #[test]
+    fn test_initialize_twice_fails() {
+        let env = Env::default();
+        env.mock_all_auths();
+
+        let admin = Address::generate(&env);
+        let asset_contract = Address::generate(&env);
+        let tracker_contract = env.register(RetirementTracker, ());
+        let client = RetirementTrackerClient::new(&env, &tracker_contract);
+
+        // First initialization succeeds
+        assert!(!client.is_initialized());
+        client.initialize(&admin, &asset_contract);
+        assert!(client.is_initialized());
+
+        // Second initialization fails
+        let result = client.try_initialize(&admin, &asset_contract);
+        assert!(result.is_err());
     }
 }


### PR DESCRIPTION
Closes #473

# PR Description

I modified the retirement tracker contract to return a typed error when initialization is attempted on an already initialized contract. Previously, the contract panicked with a string message "Contract already initialized". In Soroban, panics halt execution and cannot be caught gracefully by invoking SDKs or frontend integrations.

To solve this, I changed the initialize function signature to return Result<(), ContractError>. I moved the ContractError enum to a dedicated errors.rs module for better organization and added the AlreadyInitialized variant representing error code 8.

The flow now starts with calling admin.require_auth(). If the contract is already initialized, I publish a ReinitializationBlockedEvent containing the attempted admin address and return Err(ContractError::AlreadyInitialized). If the contract is not initialized yet, I initialize the storage keys, publish an InitializationEvent, and return Ok(()).

I also added the is_initialized view function so that callers can check the state before attempting initialization. I covered the re-initialization failure path by adding the test_initialize_twice_fails test case.

# Changes Made
* Created errors.rs to define the ContractError enum with the contracterror attribute and repr(u32) representation.
* Added the AlreadyInitialized variant with error code 8 to the ContractError enum.
* Modified lib.rs to use the new errors module and remove the inline enum.
* Updated the initialize function in lib.rs to return Result<(), ContractError>.
* Added InitializationEvent and ReinitializationBlockedEvent definitions and published them in the initialize function.
* Implemented the is_initialized view function in lib.rs.
* Added the test_initialize_twice_fails test case to cover double initialization errors.