### PR TITLE
refactor(store): unify reports store into main zustand store (#424)

### DIFF
--- a/project-portal/project-portal-web/src/app/(portal)/analytics/page.tsx
+++ b/project-portal/project-portal-web/src/app/(portal)/analytics/page.tsx
@@ -1,6 +1,6 @@
-'use client';
+"use client";
 
-import { useEffect, useState } from 'react';
+import { useEffect, useState } from "react";
 import {
   BarChart3,
   TrendingUp,
@@ -15,10 +15,10 @@ import {
   Droplets,
   Loader2,
   AlertCircle,
-} from 'lucide-react';
-import { useReportsStore } from '@/store/store';
-import { toast } from 'sonner';
-import * as api from '@/store/reports.api';
+} from "lucide-react";
+import { useStore } from "@/lib/store/store";
+import { toast } from "sonner";
+import * as api from "@/lib/store/reports/reports.api";
 
 export default function AnalyticsPage() {
   const {
@@ -26,11 +26,13 @@ export default function AnalyticsPage() {
     dashboardSummaryLoading,
     dashboardSummaryError,
     fetchDashboardSummary,
-  } = useReportsStore();
+  } = useStore();
 
-  const [timeRange, setTimeRange] = useState('year');
-  const [selectedMetric, setSelectedMetric] = useState('carbon_sequestered');
-  const [timeSeriesData, setTimeSeriesData] = useState<Array<{ time: string; value: number; label?: string }>>([]);
+  const [timeRange, setTimeRange] = useState("year");
+  const [selectedMetric, setSelectedMetric] = useState("carbon_sequestered");
+  const [timeSeriesData, setTimeSeriesData] = useState<
+    Array<{ time: string; value: number; label?: string }>
+  >([]);
   const [timeSeriesLoading, setTimeSeriesLoading] = useState(false);
 
   useEffect(() => {
@@ -41,19 +43,32 @@ export default function AnalyticsPage() {
     const now = new Date();
     const end = now.toISOString();
     const start = new Date(
-      timeRange === 'week' ? now.getTime() - 7 * 86400000 :
-      timeRange === 'month' ? now.getTime() - 30 * 86400000 :
-      timeRange === 'quarter' ? now.getTime() - 90 * 86400000 :
-      now.getTime() - 365 * 86400000
+      timeRange === "week"
+        ? now.getTime() - 7 * 86400000
+        : timeRange === "month"
+          ? now.getTime() - 30 * 86400000
+          : timeRange === "quarter"
+            ? now.getTime() - 90 * 86400000
+            : now.getTime() - 365 * 86400000,
     ).toISOString();
 
     const interval =
-      timeRange === 'week' ? 'day' :
-      timeRange === 'month' ? 'day' :
-      timeRange === 'quarter' ? 'week' : 'month';
+      timeRange === "week"
+        ? "day"
+        : timeRange === "month"
+          ? "day"
+          : timeRange === "quarter"
+            ? "week"
+            : "month";
 
     setTimeSeriesLoading(true);
-    api.apiGetTimeSeriesData({ metric: selectedMetric, start_time: start, end_time: end, interval })
+    api
+      .apiGetTimeSeriesData({
+        metric: selectedMetric,
+        start_time: start,
+        end_time: end,
+        interval,
+      })
       .then((res) => setTimeSeriesData(res.data ?? []))
       .catch(() => setTimeSeriesData([]))
       .finally(() => setTimeSeriesLoading(false));
@@ -61,11 +76,11 @@ export default function AnalyticsPage() {
 
   const handleRefresh = () => {
     fetchDashboardSummary(true);
-    toast.success('Data refreshed');
+    toast.success("Data refreshed");
   };
 
   const handleExport = async () => {
-    toast.info('Export started — check Execution History in Reports');
+    toast.info("Export started — check Execution History in Reports");
   };
 
   const summary = dashboardSummary;
@@ -74,36 +89,39 @@ export default function AnalyticsPage() {
 
   const kpiCards = [
     {
-      title: 'Total Carbon Credits',
-      value: summary ? `${summary.total_credits.toLocaleString()} tCO₂` : '—',
-      change: summary?.performance_metrics?.['carbon_credits']?.change_percent,
+      title: "Total Carbon Credits",
+      value: summary ? `${summary.total_credits.toLocaleString()} tCO₂` : "—",
+      change: summary?.performance_metrics?.["carbon_credits"]?.change_percent,
       icon: TreePine,
-      color: 'from-emerald-500 to-green-500',
+      color: "from-emerald-500 to-green-500",
     },
     {
-      title: 'Total Revenue',
-      value: summary ? `$${summary.total_revenue.toLocaleString()}` : '—',
-      change: summary?.performance_metrics?.['revenue']?.change_percent,
+      title: "Total Revenue",
+      value: summary ? `$${summary.total_revenue.toLocaleString()}` : "—",
+      change: summary?.performance_metrics?.["revenue"]?.change_percent,
       icon: Coins,
-      color: 'from-amber-500 to-orange-500',
+      color: "from-amber-500 to-orange-500",
     },
     {
-      title: 'Active Projects',
-      value: summary ? String(summary.total_projects) : '—',
-      change: summary?.performance_metrics?.['projects']?.change_percent,
+      title: "Active Projects",
+      value: summary ? String(summary.total_projects) : "—",
+      change: summary?.performance_metrics?.["projects"]?.change_percent,
       icon: Users,
-      color: 'from-blue-500 to-cyan-500',
+      color: "from-blue-500 to-cyan-500",
     },
     {
-      title: 'Monitoring Areas',
-      value: summary ? String(summary.active_monitoring_areas) : '—',
-      change: summary?.performance_metrics?.['monitoring']?.change_percent,
+      title: "Monitoring Areas",
+      value: summary ? String(summary.active_monitoring_areas) : "—",
+      change: summary?.performance_metrics?.["monitoring"]?.change_percent,
       icon: Droplets,
-      color: 'from-cyan-500 to-teal-500',
+      color: "from-cyan-500 to-teal-500",
     },
   ];
 
-  const maxValue = timeSeriesData.length > 0 ? Math.max(...timeSeriesData.map((d) => d.value)) : 1;
+  const maxValue =
+    timeSeriesData.length > 0
+      ? Math.max(...timeSeriesData.map((d) => d.value))
+      : 1;
 
   return (
     <div className="space-y-6 animate-fadeIn">
@@ -116,7 +134,9 @@ export default function AnalyticsPage() {
             </div>
             <div>
               <h1 className="text-3xl font-bold">Analytics Dashboard</h1>
-              <p className="text-cyan-100 mt-1">Live insights from your carbon projects</p>
+              <p className="text-cyan-100 mt-1">
+                Live insights from your carbon projects
+              </p>
             </div>
           </div>
           <div className="flex items-center gap-3">
@@ -125,8 +145,10 @@ export default function AnalyticsPage() {
               disabled={loading}
               className="px-4 py-2 bg-white/20 rounded-lg font-medium hover:bg-white/30 transition-colors disabled:opacity-50 flex items-center"
             >
-              <RefreshCw className={`w-5 h-5 mr-2 ${loading ? 'animate-spin' : ''}`} />
-              {loading ? 'Refreshing…' : 'Refresh'}
+              <RefreshCw
+                className={`w-5 h-5 mr-2 ${loading ? "animate-spin" : ""}`}
+              />
+              {loading ? "Refreshing…" : "Refresh"}
             </button>
             <button
               onClick={handleExport}
@@ -179,10 +201,18 @@ export default function AnalyticsPage() {
       </div>
 
       {/* KPI Cards */}
-      <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-6" aria-busy={loading} aria-label="KPI metrics">
+      <div
+        className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-6"
+        aria-busy={loading}
+        aria-label="KPI metrics"
+      >
         {loading
           ? Array.from({ length: 4 }).map((_, i) => (
-              <div key={i} className="bg-white rounded-2xl p-6 shadow-sm border border-gray-100 animate-pulse" aria-hidden="true">
+              <div
+                key={i}
+                className="bg-white rounded-2xl p-6 shadow-sm border border-gray-100 animate-pulse"
+                aria-hidden="true"
+              >
                 <div className="flex items-center justify-between mb-4">
                   <div className="w-12 h-12 bg-gray-200 rounded-lg" />
                   <div className="w-16 h-5 bg-gray-200 rounded" />
@@ -195,19 +225,35 @@ export default function AnalyticsPage() {
               const Icon = kpi.icon;
               const pct = kpi.change;
               return (
-                <div key={kpi.title} className="bg-white rounded-2xl p-6 shadow-sm border border-gray-100 hover:shadow-md transition-shadow">
+                <div
+                  key={kpi.title}
+                  className="bg-white rounded-2xl p-6 shadow-sm border border-gray-100 hover:shadow-md transition-shadow"
+                >
                   <div className="flex items-center justify-between mb-4">
-                    <div className={`p-3 rounded-lg bg-linear-to-r ${kpi.color}`}>
+                    <div
+                      className={`p-3 rounded-lg bg-linear-to-r ${kpi.color}`}
+                    >
                       <Icon className="w-6 h-6 text-white" />
                     </div>
                     {pct !== undefined && (
-                      <div className={`flex items-center ${pct >= 0 ? 'text-emerald-600' : 'text-red-600'}`}>
-                        {pct >= 0 ? <TrendingUp className="w-4 h-4 mr-1" /> : <TrendingDown className="w-4 h-4 mr-1" />}
-                        <span className="font-medium">{pct >= 0 ? '+' : ''}{pct.toFixed(1)}%</span>
+                      <div
+                        className={`flex items-center ${pct >= 0 ? "text-emerald-600" : "text-red-600"}`}
+                      >
+                        {pct >= 0 ? (
+                          <TrendingUp className="w-4 h-4 mr-1" />
+                        ) : (
+                          <TrendingDown className="w-4 h-4 mr-1" />
+                        )}
+                        <span className="font-medium">
+                          {pct >= 0 ? "+" : ""}
+                          {pct.toFixed(1)}%
+                        </span>
                       </div>
                     )}
                   </div>
-                  <div className="text-2xl font-bold text-gray-900 mb-1">{kpi.value}</div>
+                  <div className="text-2xl font-bold text-gray-900 mb-1">
+                    {kpi.value}
+                  </div>
                   <div className="text-sm text-gray-600">{kpi.title}</div>
                 </div>
               );
@@ -215,14 +261,27 @@ export default function AnalyticsPage() {
       </div>
 
       {/* Time Series Chart */}
-      <div className="bg-white rounded-2xl p-6 shadow-sm border border-gray-100" aria-busy={timeSeriesLoading}>
+      <div
+        className="bg-white rounded-2xl p-6 shadow-sm border border-gray-100"
+        aria-busy={timeSeriesLoading}
+      >
         <div className="flex items-center justify-between mb-6">
-          <h3 className="text-xl font-bold text-gray-900">Performance Over Time</h3>
-          {timeSeriesLoading && <Loader2 className="w-5 h-5 animate-spin text-emerald-600" aria-label="Loading chart data" />}
+          <h3 className="text-xl font-bold text-gray-900">
+            Performance Over Time
+          </h3>
+          {timeSeriesLoading && (
+            <Loader2
+              className="w-5 h-5 animate-spin text-emerald-600"
+              aria-label="Loading chart data"
+            />
+          )}
         </div>
 
         {timeSeriesLoading ? (
-          <div className="h-48 flex items-end gap-1 animate-pulse" aria-hidden="true">
+          <div
+            className="h-48 flex items-end gap-1 animate-pulse"
+            aria-hidden="true"
+          >
             {Array.from({ length: 12 }).map((_, i) => (
               <div
                 key={i}
@@ -239,15 +298,24 @@ export default function AnalyticsPage() {
           <div className="h-48 flex items-end gap-1">
             {timeSeriesData.map((point, i) => {
               const height = maxValue > 0 ? (point.value / maxValue) * 100 : 0;
-              const label = new Date(point.time).toLocaleDateString(undefined, { month: 'short', day: 'numeric' });
+              const label = new Date(point.time).toLocaleDateString(undefined, {
+                month: "short",
+                day: "numeric",
+              });
               return (
-                <div key={i} className="flex flex-col items-center flex-1 min-w-0" title={`${label}: ${point.value}`}>
+                <div
+                  key={i}
+                  className="flex flex-col items-center flex-1 min-w-0"
+                  title={`${label}: ${point.value}`}
+                >
                   <div
                     className="w-full rounded-t-sm bg-emerald-500 transition-all duration-500"
                     style={{ height: `${height}%` }}
                   />
                   {timeSeriesData.length <= 14 && (
-                    <div className="text-xs text-gray-500 mt-1 truncate w-full text-center">{label}</div>
+                    <div className="text-xs text-gray-500 mt-1 truncate w-full text-center">
+                      {label}
+                    </div>
                   )}
                 </div>
               );
@@ -259,10 +327,15 @@ export default function AnalyticsPage() {
       {/* Recent Activity */}
       {summary?.recent_activity && summary.recent_activity.length > 0 && (
         <div className="bg-white rounded-2xl p-6 shadow-sm border border-gray-100">
-          <h3 className="text-xl font-bold text-gray-900 mb-4">Recent Activity</h3>
+          <h3 className="text-xl font-bold text-gray-900 mb-4">
+            Recent Activity
+          </h3>
           <div className="space-y-3">
             {summary.recent_activity.slice(0, 8).map((item) => (
-              <div key={item.id} className="flex items-start gap-3 py-2 border-b border-gray-100 last:border-0">
+              <div
+                key={item.id}
+                className="flex items-start gap-3 py-2 border-b border-gray-100 last:border-0"
+              >
                 <div className="w-2 h-2 mt-2 rounded-full bg-emerald-500 shrink-0" />
                 <div className="flex-1 min-w-0">
                   <p className="text-sm text-gray-900">{item.description}</p>
@@ -277,31 +350,39 @@ export default function AnalyticsPage() {
       )}
 
       {/* Performance Metrics */}
-      {summary?.performance_metrics && Object.keys(summary.performance_metrics).length > 0 && (
-        <div className="bg-linear-to-br from-emerald-500 to-teal-600 rounded-2xl p-6 text-white">
-          <h3 className="text-xl font-bold mb-6">Performance Metrics</h3>
-          <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
-            {Object.entries(summary.performance_metrics).map(([key, metric]) => (
-              <div key={key} className="space-y-1">
-                <div className="flex justify-between items-center">
-                  <span className="font-medium capitalize">{key.replace(/_/g, ' ')}</span>
-                  <div className="flex items-center gap-1">
-                    <span className="font-bold text-lg">{metric.value.toLocaleString()}</span>
-                    {metric.trend === 'up' ? (
-                      <TrendingUp className="w-4 h-4 text-emerald-200" />
-                    ) : metric.trend === 'down' ? (
-                      <TrendingDown className="w-4 h-4 text-amber-200" />
-                    ) : null}
+      {summary?.performance_metrics &&
+        Object.keys(summary.performance_metrics).length > 0 && (
+          <div className="bg-linear-to-br from-emerald-500 to-teal-600 rounded-2xl p-6 text-white">
+            <h3 className="text-xl font-bold mb-6">Performance Metrics</h3>
+            <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+              {Object.entries(summary.performance_metrics).map(
+                ([key, metric]) => (
+                  <div key={key} className="space-y-1">
+                    <div className="flex justify-between items-center">
+                      <span className="font-medium capitalize">
+                        {key.replace(/_/g, " ")}
+                      </span>
+                      <div className="flex items-center gap-1">
+                        <span className="font-bold text-lg">
+                          {metric.value.toLocaleString()}
+                        </span>
+                        {metric.trend === "up" ? (
+                          <TrendingUp className="w-4 h-4 text-emerald-200" />
+                        ) : metric.trend === "down" ? (
+                          <TrendingDown className="w-4 h-4 text-amber-200" />
+                        ) : null}
+                      </div>
+                    </div>
+                    <div className="text-sm text-emerald-200">
+                      {metric.change_percent >= 0 ? "+" : ""}
+                      {metric.change_percent.toFixed(1)}% · {metric.period}
+                    </div>
                   </div>
-                </div>
-                <div className="text-sm text-emerald-200">
-                  {metric.change_percent >= 0 ? '+' : ''}{metric.change_percent.toFixed(1)}% · {metric.period}
-                </div>
-              </div>
-            ))}
+                ),
+              )}
+            </div>
           </div>
-        </div>
-      )}
+        )}
     </div>
   );
 }

--- a/project-portal/project-portal-web/src/app/(portal)/reports/page.tsx
+++ b/project-portal/project-portal-web/src/app/(portal)/reports/page.tsx
@@ -1,6 +1,6 @@
-'use client';
+"use client";
 
-import { useState } from 'react';
+import { useState } from "react";
 import {
   FileText,
   Wrench,
@@ -9,74 +9,83 @@ import {
   BarChart2,
   Database,
   LayoutDashboard,
-} from 'lucide-react';
-import ReportsList from '@/components/reports/ReportsList';
-import ReportBuilder from '@/components/reports/ReportBuilder';
-import ExecutionHistory from '@/components/reports/ExecutionHistory';
-import DashboardGrid from '@/components/reports/DashboardGrid';
-import WidgetLibrary from '@/components/reports/WidgetLibrary';
-import WidgetConfigurator from '@/components/reports/WidgetConfigurator';
-import ScheduleForm from '@/components/reports/ScheduleForm';
-import BenchmarkComparison from '@/components/reports/BenchmarkComparison';
-import DatasetExplorer from '@/components/reports/DatasetExplorer';
-import { useReportsStore } from '@/store/store';
-import type { WidgetType } from '@/store/reports.types';
-import { toast } from 'sonner';
+} from "lucide-react";
+import ReportsList from "@/components/reports/ReportsList";
+import ReportBuilder from "@/components/reports/ReportBuilder";
+import ExecutionHistory from "@/components/reports/ExecutionHistory";
+import DashboardGrid from "@/components/reports/DashboardGrid";
+import WidgetLibrary from "@/components/reports/WidgetLibrary";
+import WidgetConfigurator from "@/components/reports/WidgetConfigurator";
+import ScheduleForm from "@/components/reports/ScheduleForm";
+import BenchmarkComparison from "@/components/reports/BenchmarkComparison";
+import DatasetExplorer from "@/components/reports/DatasetExplorer";
+import { useStore } from "@/lib/store/store";
+import type { WidgetType } from "@/lib/store/store";
+import { toast } from "sonner";
 
 const TABS = [
-  { id: 'reports', label: 'Reports', icon: FileText },
-  { id: 'builder', label: 'Report Builder', icon: Wrench },
-  { id: 'executions', label: 'Execution History', icon: History },
-  { id: 'dashboard', label: 'Dashboard', icon: LayoutDashboard },
-  { id: 'schedules', label: 'Schedules', icon: Calendar },
-  { id: 'benchmark', label: 'Benchmark', icon: BarChart2 },
-  { id: 'datasets', label: 'Dataset Explorer', icon: Database },
+  { id: "reports", label: "Reports", icon: FileText },
+  { id: "builder", label: "Report Builder", icon: Wrench },
+  { id: "executions", label: "Execution History", icon: History },
+  { id: "dashboard", label: "Dashboard", icon: LayoutDashboard },
+  { id: "schedules", label: "Schedules", icon: Calendar },
+  { id: "benchmark", label: "Benchmark", icon: BarChart2 },
+  { id: "datasets", label: "Dataset Explorer", icon: Database },
 ] as const;
 
-type TabId = (typeof TABS)[number]['id'];
+type TabId = (typeof TABS)[number]["id"];
 
 export default function ReportsPage() {
-  const [tab, setTab] = useState<TabId>('reports');
+  const [tab, setTab] = useState<TabId>("reports");
   const [selectedReportId, setSelectedReportId] = useState<string | null>(null);
-  const [configuringWidget, setConfiguringWidget] = useState<Partial<import('@/store/reports.types').DashboardWidget> | null>(null);
+  const [configuringWidget, setConfiguringWidget] = useState<Partial<
+    import("@/lib/store/store").DashboardWidget
+  > | null>(null);
   const [scheduleReportId, setScheduleReportId] = useState<string | null>(null);
 
-  const { createWidget } = useReportsStore();
+  const { createWidget } = useStore();
 
   const handleAddWidget = (type: WidgetType) => {
     setConfiguringWidget({
       widget_type: type,
       title: `New ${type}`,
-      size: 'medium',
+      size: "medium",
       position: 999,
       refresh_interval_seconds: 300,
-      config: { data_source: 'dashboard_summary' },
+      config: { data_source: "dashboard_summary" },
     });
   };
 
-  const handleSaveWidget = async (config: Partial<import('@/store/reports.types').DashboardWidget> & { config: import('@/store/reports.types').WidgetConfig }) => {
+  const handleSaveWidget = async (
+    config: Partial<import("@/lib/store/store").DashboardWidget> & {
+      config: import("@/lib/store/store").WidgetConfig;
+    },
+  ) => {
     try {
       await createWidget({
         widget_type: configuringWidget!.widget_type!,
-        title: config.title ?? 'Widget',
-        size: config.size ?? 'medium',
+        title: config.title ?? "Widget",
+        size: config.size ?? "medium",
         position: configuringWidget!.position ?? 0,
         refresh_interval_seconds: config.refresh_interval_seconds ?? 300,
         config: config.config,
       });
-      toast.success('Widget added');
+      toast.success("Widget added");
       setConfiguringWidget(null);
     } catch (e) {
-      toast.error(e instanceof Error ? e.message : 'Failed to add widget');
+      toast.error(e instanceof Error ? e.message : "Failed to add widget");
     }
   };
 
   return (
     <div className="space-y-6 animate-fadeIn">
       <div className="bg-linear-to-r from-cyan-500 to-blue-600 rounded-2xl p-6 md:p-8 text-white">
-        <h1 className="text-2xl md:text-3xl font-bold mb-2">Reports & Analytics</h1>
+        <h1 className="text-2xl md:text-3xl font-bold mb-2">
+          Reports & Analytics
+        </h1>
         <p className="text-cyan-100">
-          Create custom reports, run benchmarks, and manage your dashboard widgets.
+          Create custom reports, run benchmarks, and manage your dashboard
+          widgets.
         </p>
       </div>
 
@@ -89,8 +98,8 @@ export default function ReportsPage() {
               onClick={() => setTab(t.id)}
               className={`flex items-center gap-2 px-4 py-2 rounded-xl font-medium transition-colors ${
                 tab === t.id
-                  ? 'bg-emerald-100 text-emerald-800 border border-emerald-200'
-                  : 'bg-white text-gray-700 border border-gray-200 hover:bg-gray-50'
+                  ? "bg-emerald-100 text-emerald-800 border border-emerald-200"
+                  : "bg-white text-gray-700 border border-gray-200 hover:bg-gray-50"
               }`}
             >
               <Icon className="w-5 h-5" />
@@ -100,33 +109,33 @@ export default function ReportsPage() {
         })}
       </div>
 
-      {tab === 'reports' && (
+      {tab === "reports" && (
         <ReportsList
           onSelectReport={setSelectedReportId}
           onEditReport={(id) => {
             setSelectedReportId(id);
-            setTab('builder');
+            setTab("builder");
           }}
         />
       )}
 
-      {tab === 'builder' && (
+      {tab === "builder" && (
         <div className="bg-white rounded-2xl border border-gray-200 p-6">
           <ReportBuilder
             reportId={selectedReportId}
             onSave={(id) => setSelectedReportId(id)}
-            onExecute={() => setTab('executions')}
+            onExecute={() => setTab("executions")}
           />
         </div>
       )}
 
-      {tab === 'executions' && (
+      {tab === "executions" && (
         <div className="bg-white rounded-2xl border border-gray-200 p-6">
           <ExecutionHistory reportId={selectedReportId} />
         </div>
       )}
 
-      {tab === 'dashboard' && (
+      {tab === "dashboard" && (
         <div className="space-y-6">
           <div className="flex items-center justify-between">
             <h2 className="text-lg font-semibold text-gray-900">Widgets</h2>
@@ -146,7 +155,7 @@ export default function ReportsPage() {
         </div>
       )}
 
-      {tab === 'schedules' && (
+      {tab === "schedules" && (
         <div className="bg-white rounded-2xl border border-gray-200 p-6">
           {scheduleReportId ? (
             <div className="space-y-4">
@@ -163,7 +172,9 @@ export default function ReportsPage() {
             </div>
           ) : (
             <div className="space-y-4">
-              <p className="text-gray-600">Choose a report to schedule delivery (email, S3, or webhook):</p>
+              <p className="text-gray-600">
+                Choose a report to schedule delivery (email, S3, or webhook):
+              </p>
               <ReportsList
                 onScheduleReport={(id) => setScheduleReportId(id)}
                 showScheduleButton
@@ -173,13 +184,13 @@ export default function ReportsPage() {
         </div>
       )}
 
-      {tab === 'benchmark' && (
+      {tab === "benchmark" && (
         <div className="bg-white rounded-2xl border border-gray-200 p-6">
           <BenchmarkComparison />
         </div>
       )}
 
-      {tab === 'datasets' && (
+      {tab === "datasets" && (
         <div className="bg-white rounded-2xl border border-gray-200 p-6">
           <DatasetExplorer />
         </div>

--- a/project-portal/project-portal-web/src/components/monitoring/MonitoringAlerts.tsx
+++ b/project-portal/project-portal-web/src/components/monitoring/MonitoringAlerts.tsx
@@ -1,22 +1,50 @@
-'use client';
+"use client";
 
-import { useEffect } from 'react';
-import { AlertTriangle, CheckCircle, Clock, Zap, Wind } from 'lucide-react';
-import { useReportsStore } from '@/store/store';
-import { Loader2 } from 'lucide-react';
+import { useEffect } from "react";
+import { AlertTriangle, CheckCircle, Clock, Zap, Wind } from "lucide-react";
+import { useStore } from "@/lib/store/store";
+import { Loader2 } from "lucide-react";
 
 const FALLBACK_ALERTS = [
-  { id: '1', type: 'warning' as const, title: 'Soil Moisture Low', message: 'Zone A needs irrigation', time: '2 hours ago', icon: AlertTriangle },
-  { id: '2', type: 'success' as const, title: 'NDVI Improvement', message: 'Vegetation health +12%', time: '1 day ago', icon: CheckCircle },
-  { id: '3', type: 'info' as const, title: 'Drone Survey Ready', message: 'Schedule flight for mapping', time: '3 days ago', icon: Clock },
-  { id: '4', type: 'warning' as const, title: 'Wind Speed High', message: '30 km/h - check saplings', time: 'Just now', icon: Wind },
+  {
+    id: "1",
+    type: "warning" as const,
+    title: "Soil Moisture Low",
+    message: "Zone A needs irrigation",
+    time: "2 hours ago",
+    icon: AlertTriangle,
+  },
+  {
+    id: "2",
+    type: "success" as const,
+    title: "NDVI Improvement",
+    message: "Vegetation health +12%",
+    time: "1 day ago",
+    icon: CheckCircle,
+  },
+  {
+    id: "3",
+    type: "info" as const,
+    title: "Drone Survey Ready",
+    message: "Schedule flight for mapping",
+    time: "3 days ago",
+    icon: Clock,
+  },
+  {
+    id: "4",
+    type: "warning" as const,
+    title: "Wind Speed High",
+    message: "30 km/h - check saplings",
+    time: "Just now",
+    icon: Wind,
+  },
 ];
 
 const sensorData = [
-  { sensor: 'Soil Temp', value: '24.5°C', status: 'optimal', icon: '🌡️' },
-  { sensor: 'Humidity', value: '68%', status: 'good', icon: '💨' },
-  { sensor: 'pH Level', value: '6.8', status: 'optimal', icon: '⚡' },
-  { sensor: 'Rainfall', value: '12mm', status: 'good', icon: '💧' },
+  { sensor: "Soil Temp", value: "24.5°C", status: "optimal", icon: "🌡️" },
+  { sensor: "Humidity", value: "68%", status: "good", icon: "💨" },
+  { sensor: "pH Level", value: "6.8", status: "optimal", icon: "⚡" },
+  { sensor: "Rainfall", value: "12mm", status: "good", icon: "💧" },
 ];
 
 function formatTimeAgo(iso: string): string {
@@ -26,34 +54,41 @@ function formatTimeAgo(iso: string): string {
   const diffM = Math.floor(diffMs / 60000);
   const diffH = Math.floor(diffM / 60);
   const diffD = Math.floor(diffH / 24);
-  if (diffM < 60) return diffM <= 1 ? 'Just now' : `${diffM} min ago`;
+  if (diffM < 60) return diffM <= 1 ? "Just now" : `${diffM} min ago`;
   if (diffH < 24) return `${diffH} hours ago`;
   if (diffD < 7) return `${diffD} days ago`;
   return d.toLocaleDateString();
 }
 
 const MonitoringAlerts = () => {
-  const {
-    dashboardSummary,
-    dashboardSummaryLoading,
-    fetchDashboardSummary,
-  } = useReportsStore();
+  const { dashboardSummary, dashboardSummaryLoading, fetchDashboardSummary } =
+    useStore();
 
   useEffect(() => {
     fetchDashboardSummary();
   }, [fetchDashboardSummary]);
 
   const activity = dashboardSummary?.recent_activity ?? [];
-  const alerts = activity.length > 0
-    ? activity.slice(0, 4).map((a) => ({
-        id: a.id,
-        type: (a.type === 'alert' ? 'warning' : a.type === 'success' ? 'success' : 'info') as 'warning' | 'success' | 'info',
-        title: a.type,
-        message: a.description,
-        time: formatTimeAgo(a.timestamp),
-        icon: a.type === 'success' ? CheckCircle : a.type === 'alert' ? AlertTriangle : Clock,
-      }))
-    : FALLBACK_ALERTS;
+  const alerts =
+    activity.length > 0
+      ? activity.slice(0, 4).map((a) => ({
+          id: a.id,
+          type: (a.type === "alert"
+            ? "warning"
+            : a.type === "success"
+              ? "success"
+              : "info") as "warning" | "success" | "info",
+          title: a.type,
+          message: a.description,
+          time: formatTimeAgo(a.timestamp),
+          icon:
+            a.type === "success"
+              ? CheckCircle
+              : a.type === "alert"
+                ? AlertTriangle
+                : Clock,
+        }))
+      : FALLBACK_ALERTS;
 
   if (dashboardSummaryLoading && !dashboardSummary) {
     return (
@@ -66,7 +101,9 @@ const MonitoringAlerts = () => {
   return (
     <div className="bg-white rounded-2xl shadow-lg border border-gray-100 p-6">
       <div className="flex items-center justify-between mb-6">
-        <h2 className="text-xl font-bold text-gray-900">Live Monitoring & Alerts</h2>
+        <h2 className="text-xl font-bold text-gray-900">
+          Live Monitoring & Alerts
+        </h2>
         <div className="flex items-center text-emerald-600">
           <Zap className="w-5 h-5 mr-2" />
           <span className="font-medium">Real-time Updates</span>
@@ -83,25 +120,37 @@ const MonitoringAlerts = () => {
                 <div
                   key={alert.id}
                   className={`p-4 rounded-xl border-2 transition-all duration-200 hover:scale-102 cursor-pointer ${
-                    alert.type === 'warning' ? 'border-amber-200 bg-amber-50' :
-                    alert.type === 'success' ? 'border-emerald-200 bg-emerald-50' :
-                    'border-blue-200 bg-blue-50'
+                    alert.type === "warning"
+                      ? "border-amber-200 bg-amber-50"
+                      : alert.type === "success"
+                        ? "border-emerald-200 bg-emerald-50"
+                        : "border-blue-200 bg-blue-50"
                   }`}
                 >
                   <div className="flex items-start">
-                    <div className={`p-2 rounded-lg mr-3 ${
-                      alert.type === 'warning' ? 'bg-amber-100 text-amber-600' :
-                      alert.type === 'success' ? 'bg-emerald-100 text-emerald-600' :
-                      'bg-blue-100 text-blue-600'
-                    }`}>
+                    <div
+                      className={`p-2 rounded-lg mr-3 ${
+                        alert.type === "warning"
+                          ? "bg-amber-100 text-amber-600"
+                          : alert.type === "success"
+                            ? "bg-emerald-100 text-emerald-600"
+                            : "bg-blue-100 text-blue-600"
+                      }`}
+                    >
                       <Icon className="w-5 h-5" />
                     </div>
                     <div className="flex-1">
                       <div className="flex justify-between items-start">
-                        <h4 className="font-bold text-gray-900">{alert.title}</h4>
-                        <span className="text-xs text-gray-500">{alert.time}</span>
+                        <h4 className="font-bold text-gray-900">
+                          {alert.title}
+                        </h4>
+                        <span className="text-xs text-gray-500">
+                          {alert.time}
+                        </span>
                       </div>
-                      <p className="text-gray-600 text-sm mt-1">{alert.message}</p>
+                      <p className="text-gray-600 text-sm mt-1">
+                        {alert.message}
+                      </p>
                     </div>
                   </div>
                 </div>
@@ -114,17 +163,25 @@ const MonitoringAlerts = () => {
           <h3 className="font-bold text-gray-900 mb-4">Sensor Network</h3>
           <div className="grid grid-cols-2 gap-4">
             {sensorData.map((sensor, index) => (
-              <div key={index} className="bg-linear-to-br from-gray-50 to-white border border-gray-200 rounded-xl p-4 hover:shadow-md transition-shadow">
+              <div
+                key={index}
+                className="bg-linear-to-br from-gray-50 to-white border border-gray-200 rounded-xl p-4 hover:shadow-md transition-shadow"
+              >
                 <div className="flex items-center justify-between mb-3">
                   <div className="text-2xl">{sensor.icon}</div>
-                  <div className={`px-2 py-1 rounded-full text-xs font-medium ${
-                    sensor.status === 'optimal' ? 'bg-emerald-100 text-emerald-700' :
-                    'bg-blue-100 text-blue-700'
-                  }`}>
+                  <div
+                    className={`px-2 py-1 rounded-full text-xs font-medium ${
+                      sensor.status === "optimal"
+                        ? "bg-emerald-100 text-emerald-700"
+                        : "bg-blue-100 text-blue-700"
+                    }`}
+                  >
                     {sensor.status}
                   </div>
                 </div>
-                <div className="text-lg font-bold text-gray-900">{sensor.value}</div>
+                <div className="text-lg font-bold text-gray-900">
+                  {sensor.value}
+                </div>
                 <div className="text-sm text-gray-600">{sensor.sensor}</div>
               </div>
             ))}
@@ -133,8 +190,12 @@ const MonitoringAlerts = () => {
           <div className="mt-6 p-4 bg-linear-to-r from-cyan-50 to-blue-50 rounded-xl border border-cyan-200">
             <div className="flex items-center justify-between">
               <div>
-                <div className="font-medium text-gray-900">Satellite Connection</div>
-                <div className="text-sm text-gray-600">Sentinel-2 • Planet Labs</div>
+                <div className="font-medium text-gray-900">
+                  Satellite Connection
+                </div>
+                <div className="text-sm text-gray-600">
+                  Sentinel-2 • Planet Labs
+                </div>
               </div>
               <div className="flex items-center">
                 <div className="w-2 h-2 bg-emerald-500 rounded-full animate-pulse mr-2" />

--- a/project-portal/project-portal-web/src/components/reports/BenchmarkComparison.tsx
+++ b/project-portal/project-portal-web/src/components/reports/BenchmarkComparison.tsx
@@ -1,10 +1,16 @@
-'use client';
+"use client";
 
-import { useState } from 'react';
-import { toast } from 'sonner';
-import { useReportsStore } from '@/store/store';
-import { useFarmer } from '@/contexts/FarmerContext';
-import { TrendingUp, TrendingDown, Minus, Loader2, BarChart2 } from 'lucide-react';
+import { useState } from "react";
+import { toast } from "sonner";
+import { useStore } from "@/lib/store/store";
+import { useFarmer } from "@/contexts/FarmerContext";
+import {
+  TrendingUp,
+  TrendingDown,
+  Minus,
+  Loader2,
+  BarChart2,
+} from "lucide-react";
 
 export default function BenchmarkComparison() {
   const { projects } = useFarmer();
@@ -14,15 +20,15 @@ export default function BenchmarkComparison() {
     benchmarkError,
     fetchBenchmarkComparison,
     clearBenchmark,
-  } = useReportsStore();
-  const [projectId, setProjectId] = useState(projects[0]?.id?.toString() ?? '');
-  const [category, setCategory] = useState('carbon');
+  } = useStore();
+  const [projectId, setProjectId] = useState(projects[0]?.id?.toString() ?? "");
+  const [category, setCategory] = useState("carbon");
   const [year, setYear] = useState(new Date().getFullYear());
 
   const runComparison = async () => {
     const pid = projectId || projects[0]?.id;
     if (!pid) {
-      toast.error('Select a project');
+      toast.error("Select a project");
       return;
     }
     try {
@@ -31,9 +37,9 @@ export default function BenchmarkComparison() {
         category,
         year,
       });
-      toast.success('Benchmark comparison complete');
+      toast.success("Benchmark comparison complete");
     } catch (e) {
-      toast.error(e instanceof Error ? e.message : 'Comparison failed');
+      toast.error(e instanceof Error ? e.message : "Comparison failed");
     }
   };
 
@@ -41,19 +47,25 @@ export default function BenchmarkComparison() {
     <div className="space-y-6">
       <div className="flex flex-wrap items-end gap-4 p-4 bg-white rounded-xl border border-gray-200">
         <div>
-          <label className="block text-sm font-medium text-gray-700 mb-1">Project</label>
+          <label className="block text-sm font-medium text-gray-700 mb-1">
+            Project
+          </label>
           <select
             value={projectId}
             onChange={(e) => setProjectId(e.target.value)}
             className="border border-gray-300 rounded-lg px-3 py-2 min-w-[200px]"
           >
             {projects.map((p) => (
-              <option key={p.id} value={String(p.id)}>{p.name}</option>
+              <option key={p.id} value={String(p.id)}>
+                {p.name}
+              </option>
             ))}
           </select>
         </div>
         <div>
-          <label className="block text-sm font-medium text-gray-700 mb-1">Category</label>
+          <label className="block text-sm font-medium text-gray-700 mb-1">
+            Category
+          </label>
           <select
             value={category}
             onChange={(e) => setCategory(e.target.value)}
@@ -65,7 +77,9 @@ export default function BenchmarkComparison() {
           </select>
         </div>
         <div>
-          <label className="block text-sm font-medium text-gray-700 mb-1">Year</label>
+          <label className="block text-sm font-medium text-gray-700 mb-1">
+            Year
+          </label>
           <input
             type="number"
             value={year}
@@ -79,7 +93,11 @@ export default function BenchmarkComparison() {
           disabled={benchmarkLoading}
           className="px-4 py-2 bg-emerald-600 text-white rounded-lg font-medium hover:bg-emerald-700 disabled:opacity-50 flex items-center"
         >
-          {benchmarkLoading ? <Loader2 className="w-5 h-5 animate-spin mr-2" /> : <BarChart2 className="w-5 h-5 mr-2" />}
+          {benchmarkLoading ? (
+            <Loader2 className="w-5 h-5 animate-spin mr-2" />
+          ) : (
+            <BarChart2 className="w-5 h-5 mr-2" />
+          )}
           Compare
         </button>
         {benchmarkResult && (
@@ -102,22 +120,33 @@ export default function BenchmarkComparison() {
       {benchmarkResult && (
         <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
           <div className="bg-white rounded-xl border border-gray-200 p-6">
-            <h3 className="font-semibold text-gray-900 mb-4">Percentile rankings</h3>
+            <h3 className="font-semibold text-gray-900 mb-4">
+              Percentile rankings
+            </h3>
             <div className="space-y-3">
-              {Object.entries(benchmarkResult.percentile_rank ?? {}).map(([metric, pct]) => (
-                <div key={metric} className="flex items-center justify-between">
-                  <span className="text-gray-700 capitalize">{metric.replace(/_/g, ' ')}</span>
-                  <div className="flex items-center gap-2">
-                    <div className="w-24 h-2 bg-gray-200 rounded-full overflow-hidden">
-                      <div
-                        className="h-full bg-emerald-500 rounded-full"
-                        style={{ width: `${pct}%` }}
-                      />
+              {Object.entries(benchmarkResult.percentile_rank ?? {}).map(
+                ([metric, pct]) => (
+                  <div
+                    key={metric}
+                    className="flex items-center justify-between"
+                  >
+                    <span className="text-gray-700 capitalize">
+                      {metric.replace(/_/g, " ")}
+                    </span>
+                    <div className="flex items-center gap-2">
+                      <div className="w-24 h-2 bg-gray-200 rounded-full overflow-hidden">
+                        <div
+                          className="h-full bg-emerald-500 rounded-full"
+                          style={{ width: `${pct}%` }}
+                        />
+                      </div>
+                      <span className="font-medium text-gray-900">
+                        {pct.toFixed(0)}%
+                      </span>
                     </div>
-                    <span className="font-medium text-gray-900">{pct.toFixed(0)}%</span>
                   </div>
-                </div>
-              ))}
+                ),
+              )}
             </div>
           </div>
 
@@ -128,29 +157,45 @@ export default function BenchmarkComparison() {
                 <div
                   key={gap.metric}
                   className={`p-3 rounded-lg border ${
-                    gap.priority === 'high' ? 'border-amber-200 bg-amber-50' :
-                    gap.priority === 'medium' ? 'border-cyan-200 bg-cyan-50' :
-                    'border-gray-200 bg-gray-50'
+                    gap.priority === "high"
+                      ? "border-amber-200 bg-amber-50"
+                      : gap.priority === "medium"
+                        ? "border-cyan-200 bg-cyan-50"
+                        : "border-gray-200 bg-gray-50"
                   }`}
                 >
                   <div className="font-medium text-gray-900">{gap.metric}</div>
-                  <div className="text-sm text-gray-600 mt-1">{gap.recommendation}</div>
+                  <div className="text-sm text-gray-600 mt-1">
+                    {gap.recommendation}
+                  </div>
                 </div>
               ))}
             </div>
           </div>
 
           <div className="lg:col-span-2 bg-white rounded-xl border border-gray-200 p-6">
-            <h3 className="font-semibold text-gray-900 mb-4">Benchmark results</h3>
+            <h3 className="font-semibold text-gray-900 mb-4">
+              Benchmark results
+            </h3>
             <div className="overflow-x-auto">
               <table className="w-full text-sm">
                 <thead>
                   <tr className="border-b border-gray-200">
-                    <th className="text-left py-2 px-3 font-medium text-gray-700">Metric</th>
-                    <th className="text-left py-2 px-3 font-medium text-gray-700">Your value</th>
-                    <th className="text-left py-2 px-3 font-medium text-gray-700">Benchmark</th>
-                    <th className="text-left py-2 px-3 font-medium text-gray-700">Difference</th>
-                    <th className="text-left py-2 px-3 font-medium text-gray-700">Level</th>
+                    <th className="text-left py-2 px-3 font-medium text-gray-700">
+                      Metric
+                    </th>
+                    <th className="text-left py-2 px-3 font-medium text-gray-700">
+                      Your value
+                    </th>
+                    <th className="text-left py-2 px-3 font-medium text-gray-700">
+                      Benchmark
+                    </th>
+                    <th className="text-left py-2 px-3 font-medium text-gray-700">
+                      Difference
+                    </th>
+                    <th className="text-left py-2 px-3 font-medium text-gray-700">
+                      Level
+                    </th>
                   </tr>
                 </thead>
                 <tbody>
@@ -160,12 +205,20 @@ export default function BenchmarkComparison() {
                       <td className="py-2 px-3">{b.project_value}</td>
                       <td className="py-2 px-3">{b.benchmark_value}</td>
                       <td className="py-2 px-3">
-                        {b.difference >= 0 ? '+' : ''}{b.difference} ({b.difference_percent >= 0 ? '+' : ''}{b.difference_percent.toFixed(1)}%)
+                        {b.difference >= 0 ? "+" : ""}
+                        {b.difference} ({b.difference_percent >= 0 ? "+" : ""}
+                        {b.difference_percent.toFixed(1)}%)
                       </td>
                       <td className="py-2 px-3">
-                        {b.performance_level === 'above' && <TrendingUp className="w-4 h-4 text-emerald-600" />}
-                        {b.performance_level === 'below' && <TrendingDown className="w-4 h-4 text-red-600" />}
-                        {b.performance_level === 'at' && <Minus className="w-4 h-4 text-gray-500" />}
+                        {b.performance_level === "above" && (
+                          <TrendingUp className="w-4 h-4 text-emerald-600" />
+                        )}
+                        {b.performance_level === "below" && (
+                          <TrendingDown className="w-4 h-4 text-red-600" />
+                        )}
+                        {b.performance_level === "at" && (
+                          <Minus className="w-4 h-4 text-gray-500" />
+                        )}
                       </td>
                     </tr>
                   ))}

--- a/project-portal/project-portal-web/src/components/reports/DashboardGrid.tsx
+++ b/project-portal/project-portal-web/src/components/reports/DashboardGrid.tsx
@@ -1,13 +1,13 @@
-'use client';
+"use client";
 
-import { useEffect } from 'react';
-import { useReportsStore } from '@/store/store';
-import type { DashboardWidget as Widget } from '@/store/reports.types';
-import ChartWidget from './widgets/ChartWidget';
-import MetricWidget from './widgets/MetricWidget';
-import TableWidget from './widgets/TableWidget';
-import GaugeWidget from './widgets/GaugeWidget';
-import { Loader2 } from 'lucide-react';
+import { useEffect } from "react";
+import { useStore } from "@/lib/store/store";
+import type { DashboardWidget as Widget } from "@/lib/store/store";
+import ChartWidget from "./widgets/ChartWidget";
+import MetricWidget from "./widgets/MetricWidget";
+import TableWidget from "./widgets/TableWidget";
+import GaugeWidget from "./widgets/GaugeWidget";
+import { Loader2 } from "lucide-react";
 
 interface DashboardGridProps {
   section?: string;
@@ -15,13 +15,13 @@ interface DashboardGridProps {
 
 function WidgetRenderer({ widget }: { widget: Widget }) {
   switch (widget.widget_type) {
-    case 'chart':
+    case "chart":
       return <ChartWidget widget={widget} />;
-    case 'metric':
+    case "metric":
       return <MetricWidget widget={widget} />;
-    case 'table':
+    case "table":
       return <TableWidget widget={widget} />;
-    case 'gauge':
+    case "gauge":
       return <GaugeWidget widget={widget} />;
     default:
       return (
@@ -33,7 +33,7 @@ function WidgetRenderer({ widget }: { widget: Widget }) {
 }
 
 export default function DashboardGrid({ section }: DashboardGridProps) {
-  const { widgets, widgetsLoading, widgetsError, fetchWidgets } = useReportsStore();
+  const { widgets, widgetsLoading, widgetsError, fetchWidgets } = useStore();
 
   useEffect(() => {
     fetchWidgets(section);
@@ -61,15 +61,17 @@ export default function DashboardGrid({ section }: DashboardGridProps) {
     <div
       className="grid gap-4 w-full"
       style={{
-        gridTemplateColumns: 'repeat(auto-fill, minmax(280px, 1fr))',
+        gridTemplateColumns: "repeat(auto-fill, minmax(280px, 1fr))",
       }}
     >
       {sorted.map((widget) => (
         <div
           key={widget.id}
           className={`rounded-xl border border-gray-200 bg-white overflow-hidden ${
-            widget.size === 'large' || widget.size === 'full' ? 'md:col-span-2' : ''
-          } ${widget.size === 'full' ? 'md:col-span-3' : ''}`}
+            widget.size === "large" || widget.size === "full"
+              ? "md:col-span-2"
+              : ""
+          } ${widget.size === "full" ? "md:col-span-3" : ""}`}
         >
           <WidgetRenderer widget={widget} />
         </div>

--- a/project-portal/project-portal-web/src/components/reports/DatasetExplorer.tsx
+++ b/project-portal/project-portal-web/src/components/reports/DatasetExplorer.tsx
@@ -1,12 +1,13 @@
-'use client';
+"use client";
 
-import { useEffect } from 'react';
-import { useReportsStore } from '@/store/store';
-import { Database, Loader2, ChevronDown, ChevronRight } from 'lucide-react';
-import { useState } from 'react';
+import { useEffect } from "react";
+import { useStore } from "@/lib/store/store";
+import { Database, Loader2, ChevronDown, ChevronRight } from "lucide-react";
+import { useState } from "react";
 
 export default function DatasetExplorer() {
-  const { datasets, datasetsLoading, datasetsError, fetchDatasets } = useReportsStore();
+  const { datasets, datasetsLoading, datasetsError, fetchDatasets } =
+    useStore();
   const [expanded, setExpanded] = useState<string | null>(null);
 
   useEffect(() => {
@@ -45,7 +46,10 @@ export default function DatasetExplorer() {
         {datasets.map((ds) => {
           const isOpen = expanded === ds.name;
           return (
-            <div key={ds.name} className="border-b border-gray-100 last:border-b-0">
+            <div
+              key={ds.name}
+              className="border-b border-gray-100 last:border-b-0"
+            >
               <button
                 type="button"
                 onClick={() => setExpanded(isOpen ? null : ds.name)}
@@ -57,30 +61,50 @@ export default function DatasetExplorer() {
                   <ChevronRight className="w-5 h-5 text-gray-500" />
                 )}
                 <Database className="w-5 h-5 text-emerald-600" />
-                <span className="font-medium text-gray-900">{ds.display_name}</span>
+                <span className="font-medium text-gray-900">
+                  {ds.display_name}
+                </span>
                 <span className="text-sm text-gray-500">({ds.name})</span>
               </button>
               {isOpen && (
                 <div className="px-4 pb-4 pt-0">
                   {ds.description && (
-                    <p className="text-sm text-gray-600 mb-3">{ds.description}</p>
+                    <p className="text-sm text-gray-600 mb-3">
+                      {ds.description}
+                    </p>
                   )}
                   <table className="w-full text-sm border border-gray-200 rounded-lg overflow-hidden">
                     <thead>
                       <tr className="bg-gray-50 border-b border-gray-200">
-                        <th className="text-left py-2 px-3 font-medium text-gray-700">Field</th>
-                        <th className="text-left py-2 px-3 font-medium text-gray-700">Type</th>
-                        <th className="text-left py-2 px-3 font-medium text-gray-700">Aggregatable</th>
-                        <th className="text-left py-2 px-3 font-medium text-gray-700">Filterable</th>
+                        <th className="text-left py-2 px-3 font-medium text-gray-700">
+                          Field
+                        </th>
+                        <th className="text-left py-2 px-3 font-medium text-gray-700">
+                          Type
+                        </th>
+                        <th className="text-left py-2 px-3 font-medium text-gray-700">
+                          Aggregatable
+                        </th>
+                        <th className="text-left py-2 px-3 font-medium text-gray-700">
+                          Filterable
+                        </th>
                       </tr>
                     </thead>
                     <tbody>
                       {ds.fields.map((f) => (
                         <tr key={f.name} className="border-b border-gray-100">
-                          <td className="py-2 px-3 font-medium">{f.display_name}</td>
-                          <td className="py-2 px-3 text-gray-600">{f.data_type}</td>
-                          <td className="py-2 px-3">{f.is_aggregatable ? 'Yes' : 'No'}</td>
-                          <td className="py-2 px-3">{f.is_filterable ? 'Yes' : 'No'}</td>
+                          <td className="py-2 px-3 font-medium">
+                            {f.display_name}
+                          </td>
+                          <td className="py-2 px-3 text-gray-600">
+                            {f.data_type}
+                          </td>
+                          <td className="py-2 px-3">
+                            {f.is_aggregatable ? "Yes" : "No"}
+                          </td>
+                          <td className="py-2 px-3">
+                            {f.is_filterable ? "Yes" : "No"}
+                          </td>
                         </tr>
                       ))}
                     </tbody>

--- a/project-portal/project-portal-web/src/components/reports/ExecutionHistory.tsx
+++ b/project-portal/project-portal-web/src/components/reports/ExecutionHistory.tsx
@@ -1,23 +1,23 @@
-'use client';
+"use client";
 
-import { useEffect } from 'react';
-import { useReportsStore } from '@/store/store';
-import type { ReportExecution } from '@/store/reports.types';
-import { Loader2, CheckCircle, XCircle, Clock, Download } from 'lucide-react';
-import { toast } from 'sonner';
+import { useEffect } from "react";
+import { useStore } from "@/lib/store/store";
+import type { ReportExecution } from "@/lib/store/store";
+import { Loader2, CheckCircle, XCircle, Clock, Download } from "lucide-react";
+import { toast } from "sonner";
 
-const STATUS_ICONS: Record<ReportExecution['status'], typeof Clock> = {
+const STATUS_ICONS: Record<ReportExecution["status"], typeof Clock> = {
   pending: Clock,
   processing: Loader2,
   completed: CheckCircle,
   failed: XCircle,
 };
 
-const STATUS_COLORS: Record<ReportExecution['status'], string> = {
-  pending: 'text-gray-600 bg-gray-100',
-  processing: 'text-cyan-600 bg-cyan-100',
-  completed: 'text-emerald-600 bg-emerald-100',
-  failed: 'text-red-600 bg-red-100',
+const STATUS_COLORS: Record<ReportExecution["status"], string> = {
+  pending: "text-gray-600 bg-gray-100",
+  processing: "text-cyan-600 bg-cyan-100",
+  completed: "text-emerald-600 bg-emerald-100",
+  failed: "text-red-600 bg-red-100",
 };
 
 interface ExecutionHistoryProps {
@@ -25,26 +25,34 @@ interface ExecutionHistoryProps {
   pageSize?: number;
 }
 
-export default function ExecutionHistory({ reportId, pageSize = 20 }: ExecutionHistoryProps) {
+export default function ExecutionHistory({
+  reportId,
+  pageSize = 20,
+}: ExecutionHistoryProps) {
   const {
     executions,
     executionsLoading,
     executionsError,
     fetchExecutions,
     pollExecutionUntilDone,
-  } = useReportsStore();
+  } = useStore();
 
   useEffect(() => {
-    fetchExecutions({ report_id: reportId ?? undefined, page: 1, page_size: pageSize });
+    fetchExecutions({
+      report_id: reportId ?? undefined,
+      page: 1,
+      page_size: pageSize,
+    });
   }, [fetchExecutions, reportId, pageSize]);
 
   const refreshStatus = async (executionId: string) => {
     try {
       const final = await pollExecutionUntilDone(executionId);
-      if (final.status === 'completed') toast.success('Report ready');
-      if (final.status === 'failed') toast.error(final.error_message ?? 'Execution failed');
+      if (final.status === "completed") toast.success("Report ready");
+      if (final.status === "failed")
+        toast.error(final.error_message ?? "Execution failed");
     } catch (e) {
-      toast.error(e instanceof Error ? e.message : 'Failed to refresh status');
+      toast.error(e instanceof Error ? e.message : "Failed to refresh status");
     }
   };
 
@@ -78,10 +86,18 @@ export default function ExecutionHistory({ reportId, pageSize = 20 }: ExecutionH
       <table className="w-full text-sm">
         <thead>
           <tr className="border-b border-gray-200">
-            <th className="text-left py-3 px-4 font-medium text-gray-700">Status</th>
-            <th className="text-left py-3 px-4 font-medium text-gray-700">Triggered</th>
-            <th className="text-left py-3 px-4 font-medium text-gray-700">Records</th>
-            <th className="text-left py-3 px-4 font-medium text-gray-700">Actions</th>
+            <th className="text-left py-3 px-4 font-medium text-gray-700">
+              Status
+            </th>
+            <th className="text-left py-3 px-4 font-medium text-gray-700">
+              Triggered
+            </th>
+            <th className="text-left py-3 px-4 font-medium text-gray-700">
+              Records
+            </th>
+            <th className="text-left py-3 px-4 font-medium text-gray-700">
+              Actions
+            </th>
           </tr>
         </thead>
         <tbody>
@@ -89,10 +105,15 @@ export default function ExecutionHistory({ reportId, pageSize = 20 }: ExecutionH
             const Icon = STATUS_ICONS[exec.status];
             const color = STATUS_COLORS[exec.status];
             return (
-              <tr key={exec.id} className="border-b border-gray-100 hover:bg-gray-50">
+              <tr
+                key={exec.id}
+                className="border-b border-gray-100 hover:bg-gray-50"
+              >
                 <td className="py-3 px-4">
-                  <span className={`inline-flex items-center gap-1.5 px-2 py-1 rounded-full ${color}`}>
-                    {exec.status === 'processing' ? (
+                  <span
+                    className={`inline-flex items-center gap-1.5 px-2 py-1 rounded-full ${color}`}
+                  >
+                    {exec.status === "processing" ? (
                       <Loader2 className="w-4 h-4 animate-spin" />
                     ) : (
                       <Icon className="w-4 h-4" />
@@ -103,9 +124,12 @@ export default function ExecutionHistory({ reportId, pageSize = 20 }: ExecutionH
                 <td className="py-3 px-4 text-gray-700">
                   {new Date(exec.triggered_at).toLocaleString()}
                 </td>
-                <td className="py-3 px-4 text-gray-700">{exec.record_count ?? '—'}</td>
+                <td className="py-3 px-4 text-gray-700">
+                  {exec.record_count ?? "—"}
+                </td>
                 <td className="py-3 px-4">
-                  {(exec.status === 'pending' || exec.status === 'processing') && (
+                  {(exec.status === "pending" ||
+                    exec.status === "processing") && (
                     <button
                       type="button"
                       onClick={() => refreshStatus(exec.id)}
@@ -114,7 +138,7 @@ export default function ExecutionHistory({ reportId, pageSize = 20 }: ExecutionH
                       Refresh
                     </button>
                   )}
-                  {exec.status === 'completed' && exec.download_url && (
+                  {exec.status === "completed" && exec.download_url && (
                     <a
                       href={exec.download_url}
                       target="_blank"
@@ -125,8 +149,11 @@ export default function ExecutionHistory({ reportId, pageSize = 20 }: ExecutionH
                       Download
                     </a>
                   )}
-                  {exec.status === 'failed' && exec.error_message && (
-                    <span className="text-red-600 text-xs" title={exec.error_message}>
+                  {exec.status === "failed" && exec.error_message && (
+                    <span
+                      className="text-red-600 text-xs"
+                      title={exec.error_message}
+                    >
                       {exec.error_message.slice(0, 40)}…
                     </span>
                   )}

--- a/project-portal/project-portal-web/src/components/reports/FieldSelector.tsx
+++ b/project-portal/project-portal-web/src/components/reports/FieldSelector.tsx
@@ -1,9 +1,9 @@
-'use client';
+"use client";
 
-import type { FieldConfig, FieldMetadata } from '@/store/reports.types';
-import { Plus, X } from 'lucide-react';
+import type { FieldConfig, FieldMetadata } from "@/lib/store/store";
+import { Plus, X } from "lucide-react";
 
-type AggregateFunction = 'SUM' | 'AVG' | 'COUNT' | 'MIN' | 'MAX';
+type AggregateFunction = "SUM" | "AVG" | "COUNT" | "MIN" | "MAX";
 
 interface FieldSelectorProps {
   availableFields: FieldMetadata[];
@@ -15,11 +15,11 @@ interface FieldSelectorProps {
 }
 
 const AGG_OPTIONS: { value: AggregateFunction; label: string }[] = [
-  { value: 'SUM', label: 'Sum' },
-  { value: 'AVG', label: 'Avg' },
-  { value: 'COUNT', label: 'Count' },
-  { value: 'MIN', label: 'Min' },
-  { value: 'MAX', label: 'Max' },
+  { value: "SUM", label: "Sum" },
+  { value: "AVG", label: "Avg" },
+  { value: "COUNT", label: "Count" },
+  { value: "MIN", label: "Min" },
+  { value: "MAX", label: "Max" },
 ];
 
 export default function FieldSelector({
@@ -44,7 +44,9 @@ export default function FieldSelector({
       <div className="flex items-center justify-between">
         <h4 className="font-semibold text-gray-900">Fields</h4>
         {availableFields.length === 0 && (
-          <span className="text-sm text-gray-500">Load a dataset to see fields</span>
+          <span className="text-sm text-gray-500">
+            Load a dataset to see fields
+          </span>
         )}
       </div>
 
@@ -54,17 +56,27 @@ export default function FieldSelector({
             key={`${field.name}-${idx}`}
             className="flex items-center gap-2 p-2 bg-gray-50 rounded-lg border border-gray-200"
           >
-            <span className="flex-1 font-medium text-gray-800 truncate">{field.alias || field.name}</span>
-            {availableFields.find((f) => f.name === field.name)?.is_aggregatable && (
+            <span className="flex-1 font-medium text-gray-800 truncate">
+              {field.alias || field.name}
+            </span>
+            {availableFields.find((f) => f.name === field.name)
+              ?.is_aggregatable && (
               <select
-                value={field.aggregate ?? ''}
-                onChange={(e) => onUpdate(idx, { aggregate: (e.target.value || undefined) as AggregateFunction })}
+                value={field.aggregate ?? ""}
+                onChange={(e) =>
+                  onUpdate(idx, {
+                    aggregate: (e.target.value ||
+                      undefined) as AggregateFunction,
+                  })
+                }
                 className="text-sm border border-gray-300 rounded px-2 py-1"
                 disabled={disabled}
               >
                 <option value="">—</option>
                 {AGG_OPTIONS.map((o) => (
-                  <option key={o.value} value={o.value}>{o.label}</option>
+                  <option key={o.value} value={o.value}>
+                    {o.label}
+                  </option>
                 ))}
               </select>
             )}

--- a/project-portal/project-portal-web/src/components/reports/FilterBuilder.tsx
+++ b/project-portal/project-portal-web/src/components/reports/FilterBuilder.tsx
@@ -1,18 +1,18 @@
-'use client';
+"use client";
 
-import type { FilterConfig } from '@/store/reports.types';
-import { Plus, Trash2 } from 'lucide-react';
+import type { FilterConfig } from "@/lib/store/store";
+import { Plus, Trash2 } from "lucide-react";
 
 const OPERATORS = [
-  { value: 'eq', label: 'Equals' },
-  { value: 'ne', label: 'Not equals' },
-  { value: 'gt', label: 'Greater than' },
-  { value: 'gte', label: 'Greater or equal' },
-  { value: 'lt', label: 'Less than' },
-  { value: 'lte', label: 'Less or equal' },
-  { value: 'like', label: 'Contains' },
-  { value: 'in', label: 'In list' },
-  { value: 'between', label: 'Between' },
+  { value: "eq", label: "Equals" },
+  { value: "ne", label: "Not equals" },
+  { value: "gt", label: "Greater than" },
+  { value: "gte", label: "Greater or equal" },
+  { value: "lt", label: "Less than" },
+  { value: "lte", label: "Less or equal" },
+  { value: "like", label: "Contains" },
+  { value: "in", label: "In list" },
+  { value: "between", label: "Between" },
 ];
 
 interface FilterBuilderProps {
@@ -32,7 +32,12 @@ export default function FilterBuilder({
     const first = fieldOptions[0];
     onChange([
       ...filters,
-      { field: first?.name ?? '', operator: 'eq', value: '', logic: filters.length ? 'AND' : undefined },
+      {
+        field: first?.name ?? "",
+        operator: "eq",
+        value: "",
+        logic: filters.length ? "AND" : undefined,
+      },
     ]);
   };
 
@@ -45,7 +50,7 @@ export default function FilterBuilder({
   const removeFilter = (index: number) => {
     const next = filters.filter((_, i) => i !== index);
     next.forEach((f, i) => {
-      f.logic = i === 0 ? undefined : 'AND';
+      f.logic = i === 0 ? undefined : "AND";
     });
     onChange(next);
   };
@@ -66,16 +71,23 @@ export default function FilterBuilder({
       </div>
 
       {filters.length === 0 && (
-        <p className="text-sm text-gray-500">No filters. Add a condition to narrow results.</p>
+        <p className="text-sm text-gray-500">
+          No filters. Add a condition to narrow results.
+        </p>
       )}
 
       <div className="space-y-2">
         {filters.map((filter, idx) => (
-          <div key={idx} className="flex flex-wrap items-center gap-2 p-3 bg-gray-50 rounded-lg border border-gray-200">
+          <div
+            key={idx}
+            className="flex flex-wrap items-center gap-2 p-3 bg-gray-50 rounded-lg border border-gray-200"
+          >
             {idx > 0 && (
               <select
-                value={filter.logic ?? 'AND'}
-                onChange={(e) => updateFilter(idx, { logic: e.target.value as 'AND' | 'OR' })}
+                value={filter.logic ?? "AND"}
+                onChange={(e) =>
+                  updateFilter(idx, { logic: e.target.value as "AND" | "OR" })
+                }
                 className="text-sm font-medium text-gray-700 border border-gray-300 rounded px-2 py-1 w-16"
                 disabled={disabled}
               >
@@ -91,7 +103,9 @@ export default function FilterBuilder({
             >
               <option value="">Select field</option>
               {fieldOptions.map((f) => (
-                <option key={f.name} value={f.name}>{f.display_name}</option>
+                <option key={f.name} value={f.name}>
+                  {f.display_name}
+                </option>
               ))}
             </select>
             <select
@@ -101,12 +115,14 @@ export default function FilterBuilder({
               disabled={disabled}
             >
               {OPERATORS.map((o) => (
-                <option key={o.value} value={o.value}>{o.label}</option>
+                <option key={o.value} value={o.value}>
+                  {o.label}
+                </option>
               ))}
             </select>
             <input
               type="text"
-              value={typeof filter.value === 'string' ? filter.value : ''}
+              value={typeof filter.value === "string" ? filter.value : ""}
               onChange={(e) => updateFilter(idx, { value: e.target.value })}
               placeholder="Value"
               className="text-sm border border-gray-300 rounded px-2 py-1 min-w-[100px]"

--- a/project-portal/project-portal-web/src/components/reports/ReportBuilder.tsx
+++ b/project-portal/project-portal-web/src/components/reports/ReportBuilder.tsx
@@ -1,15 +1,15 @@
-'use client';
+"use client";
 
-import { useState, useEffect } from 'react';
-import { toast } from 'sonner';
-import { useReportsStore } from '@/store/store';
-import type { ReportConfig, CreateReportRequest } from '@/store/reports.types';
-import FieldSelector from './FieldSelector';
-import FilterBuilder from './FilterBuilder';
-import { Save, Play, Loader2 } from 'lucide-react';
+import { useState, useEffect } from "react";
+import { toast } from "sonner";
+import { useStore } from "@/lib/store/store";
+import type { ReportConfig, CreateReportRequest } from "@/lib/store/store";
+import FieldSelector from "./FieldSelector";
+import FilterBuilder from "./FilterBuilder";
+import { Save, Play, Loader2 } from "lucide-react";
 
 const DEFAULT_CONFIG: ReportConfig = {
-  dataset: '',
+  dataset: "",
   fields: [],
   filters: [],
   groupings: [],
@@ -23,7 +23,11 @@ interface ReportBuilderProps {
   onExecute?: (id: string) => void;
 }
 
-export default function ReportBuilder({ reportId, onSave, onExecute }: ReportBuilderProps) {
+export default function ReportBuilder({
+  reportId,
+  onSave,
+  onExecute,
+}: ReportBuilderProps) {
   const {
     datasets,
     datasetsLoading,
@@ -35,10 +39,10 @@ export default function ReportBuilder({ reportId, onSave, onExecute }: ReportBui
     executeReport,
     setCurrentReport,
     clearCurrentReport,
-  } = useReportsStore();
+  } = useStore();
 
-  const [name, setName] = useState('');
-  const [description, setDescription] = useState('');
+  const [name, setName] = useState("");
+  const [description, setDescription] = useState("");
   const [config, setConfig] = useState<ReportConfig>(DEFAULT_CONFIG);
   const [saving, setSaving] = useState(false);
   const [executing, setExecuting] = useState(false);
@@ -58,49 +62,58 @@ export default function ReportBuilder({ reportId, onSave, onExecute }: ReportBui
   useEffect(() => {
     if (currentReport) {
       setName(currentReport.name);
-      setDescription(currentReport.description ?? '');
+      setDescription(currentReport.description ?? "");
       setConfig(currentReport.config ?? DEFAULT_CONFIG);
     } else if (!reportId) {
-      setName('');
-      setDescription('');
+      setName("");
+      setDescription("");
       setConfig(DEFAULT_CONFIG);
     }
   }, [currentReport, reportId]);
 
-  const currentDataset = config.dataset ? datasets.find((d) => d.name === config.dataset) : null;
-  const fieldOptions = (currentDataset?.fields ?? []).map((f) => ({ name: f.name, display_name: f.display_name }));
+  const currentDataset = config.dataset
+    ? datasets.find((d) => d.name === config.dataset)
+    : null;
+  const fieldOptions = (currentDataset?.fields ?? []).map((f) => ({
+    name: f.name,
+    display_name: f.display_name,
+  }));
   const availableFieldsForSelector = currentDataset?.fields ?? [];
 
   const handleSave = async () => {
     if (!name.trim()) {
-      toast.error('Report name is required');
+      toast.error("Report name is required");
       return;
     }
     if (!config.dataset || config.fields.length === 0) {
-      toast.error('Select a dataset and at least one field');
+      toast.error("Select a dataset and at least one field");
       return;
     }
     setSaving(true);
     try {
       if (reportId && currentReport) {
-        await updateReport(reportId, { name: name.trim(), description: description.trim() || undefined, config });
-        toast.success('Report updated');
+        await updateReport(reportId, {
+          name: name.trim(),
+          description: description.trim() || undefined,
+          config,
+        });
+        toast.success("Report updated");
         onSave?.(reportId);
       } else {
         const body: CreateReportRequest = {
           name: name.trim(),
           description: description.trim() || undefined,
           config,
-          category: 'custom',
-          visibility: 'private',
+          category: "custom",
+          visibility: "private",
         };
         const report = await createReport(body);
         setCurrentReport(report);
-        toast.success('Report created');
+        toast.success("Report created");
         onSave?.(report.id);
       }
     } catch (e) {
-      toast.error(e instanceof Error ? e.message : 'Failed to save report');
+      toast.error(e instanceof Error ? e.message : "Failed to save report");
     } finally {
       setSaving(false);
     }
@@ -109,16 +122,16 @@ export default function ReportBuilder({ reportId, onSave, onExecute }: ReportBui
   const handleExecute = async () => {
     const id = reportId ?? currentReport?.id;
     if (!id) {
-      toast.error('Save the report first before executing');
+      toast.error("Save the report first before executing");
       return;
     }
     setExecuting(true);
     try {
-      await executeReport(id, { format: 'csv' });
-      toast.success('Report execution started');
+      await executeReport(id, { format: "csv" });
+      toast.success("Report execution started");
       onExecute?.(id);
     } catch (e) {
-      toast.error(e instanceof Error ? e.message : 'Failed to execute report');
+      toast.error(e instanceof Error ? e.message : "Failed to execute report");
     } finally {
       setExecuting(false);
     }
@@ -128,7 +141,9 @@ export default function ReportBuilder({ reportId, onSave, onExecute }: ReportBui
     <div className="space-y-6">
       <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
         <div>
-          <label className="block text-sm font-medium text-gray-700 mb-1">Report name</label>
+          <label className="block text-sm font-medium text-gray-700 mb-1">
+            Report name
+          </label>
           <input
             type="text"
             value={name}
@@ -138,22 +153,30 @@ export default function ReportBuilder({ reportId, onSave, onExecute }: ReportBui
           />
         </div>
         <div>
-          <label className="block text-sm font-medium text-gray-700 mb-1">Dataset</label>
+          <label className="block text-sm font-medium text-gray-700 mb-1">
+            Dataset
+          </label>
           <select
             value={config.dataset}
-            onChange={(e) => setConfig((c) => ({ ...c, dataset: e.target.value }))}
+            onChange={(e) =>
+              setConfig((c) => ({ ...c, dataset: e.target.value }))
+            }
             className="w-full border border-gray-300 rounded-lg px-3 py-2 focus:ring-2 focus:ring-emerald-500"
             disabled={datasetsLoading}
           >
             <option value="">Select dataset</option>
             {datasets.map((d) => (
-              <option key={d.name} value={d.name}>{d.display_name}</option>
+              <option key={d.name} value={d.name}>
+                {d.display_name}
+              </option>
             ))}
           </select>
         </div>
       </div>
       <div>
-        <label className="block text-sm font-medium text-gray-700 mb-1">Description (optional)</label>
+        <label className="block text-sm font-medium text-gray-700 mb-1">
+          Description (optional)
+        </label>
         <textarea
           value={description}
           onChange={(e) => setDescription(e.target.value)}
@@ -168,12 +191,21 @@ export default function ReportBuilder({ reportId, onSave, onExecute }: ReportBui
           <FieldSelector
             availableFields={availableFieldsForSelector}
             selectedFields={config.fields}
-            onAdd={(f) => setConfig((c) => ({ ...c, fields: [...c.fields, f] }))}
-            onRemove={(idx) => setConfig((c) => ({ ...c, fields: c.fields.filter((_, i) => i !== idx) }))}
+            onAdd={(f) =>
+              setConfig((c) => ({ ...c, fields: [...c.fields, f] }))
+            }
+            onRemove={(idx) =>
+              setConfig((c) => ({
+                ...c,
+                fields: c.fields.filter((_, i) => i !== idx),
+              }))
+            }
             onUpdate={(idx, updates) =>
               setConfig((c) => ({
                 ...c,
-                fields: c.fields.map((f, i) => (i === idx ? { ...f, ...updates } : f)),
+                fields: c.fields.map((f, i) =>
+                  i === idx ? { ...f, ...updates } : f,
+                ),
               }))
             }
             disabled={saving}
@@ -194,8 +226,8 @@ export default function ReportBuilder({ reportId, onSave, onExecute }: ReportBui
         <h4 className="font-semibold text-gray-900 mb-2">Preview</h4>
         <p className="text-sm text-gray-600">
           {config.fields.length === 0
-            ? 'Add fields and save to run the report.'
-            : `Fields: ${config.fields.map((f) => f.alias || f.name).join(', ')}. Filters: ${(config.filters?.length ?? 0)}.`}
+            ? "Add fields and save to run the report."
+            : `Fields: ${config.fields.map((f) => f.alias || f.name).join(", ")}. Filters: ${config.filters?.length ?? 0}.`}
         </p>
       </div>
 
@@ -205,15 +237,23 @@ export default function ReportBuilder({ reportId, onSave, onExecute }: ReportBui
           disabled={saving || datasetsLoading}
           className="inline-flex items-center px-4 py-2 bg-emerald-600 text-white rounded-lg font-medium hover:bg-emerald-700 disabled:opacity-50"
         >
-          {saving ? <Loader2 className="w-5 h-5 animate-spin mr-2" /> : <Save className="w-5 h-5 mr-2" />}
-          {reportId ? 'Update' : 'Save'} report
+          {saving ? (
+            <Loader2 className="w-5 h-5 animate-spin mr-2" />
+          ) : (
+            <Save className="w-5 h-5 mr-2" />
+          )}
+          {reportId ? "Update" : "Save"} report
         </button>
         <button
           onClick={handleExecute}
           disabled={executing || !(reportId ?? currentReport?.id)}
           className="inline-flex items-center px-4 py-2 bg-cyan-600 text-white rounded-lg font-medium hover:bg-cyan-700 disabled:opacity-50"
         >
-          {executing ? <Loader2 className="w-5 h-5 animate-spin mr-2" /> : <Play className="w-5 h-5 mr-2" />}
+          {executing ? (
+            <Loader2 className="w-5 h-5 animate-spin mr-2" />
+          ) : (
+            <Play className="w-5 h-5 mr-2" />
+          )}
           Run now
         </button>
       </div>

--- a/project-portal/project-portal-web/src/components/reports/ReportSharing.tsx
+++ b/project-portal/project-portal-web/src/components/reports/ReportSharing.tsx
@@ -1,10 +1,10 @@
-'use client';
+"use client";
 
-import { useState } from 'react';
-import type { ReportDefinition } from '@/store/reports.types';
-import { Share2, Lock, Users, Globe } from 'lucide-react';
+import { useState } from "react";
+import type { ReportDefinition } from "@/lib/store/store";
+import { Share2, Lock, Users, Globe } from "lucide-react";
 
-type ReportVisibility = 'private' | 'shared' | 'public';
+type ReportVisibility = "private" | "shared" | "public";
 
 interface ReportSharingProps {
   report: ReportDefinition;
@@ -13,20 +13,24 @@ interface ReportSharingProps {
 }
 
 const LABELS: Record<ReportVisibility, string> = {
-  private: 'Private',
-  shared: 'Shared',
-  public: 'Public',
+  private: "Private",
+  shared: "Shared",
+  public: "Public",
 };
 
-const ICONS: Record<ReportVisibility, typeof Lock> = {
+const ICONS: Record<string, typeof Lock> = {
   private: Lock,
   shared: Users,
   public: Globe,
 };
 
-export default function ReportSharing({ report, onVisibilityChange, disabled }: ReportSharingProps) {
+export default function ReportSharing({
+  report,
+  onVisibilityChange,
+  disabled,
+}: ReportSharingProps) {
   const [open, setOpen] = useState(false);
-  const visibility = report.visibility ?? 'private';
+  const visibility: ReportVisibility = report.visibility ?? "private";
   const Icon = ICONS[visibility];
 
   return (
@@ -42,9 +46,13 @@ export default function ReportSharing({ report, onVisibilityChange, disabled }: 
       </button>
       {open && (
         <>
-          <div className="fixed inset-0 z-10" aria-hidden onClick={() => setOpen(false)} />
+          <div
+            className="fixed inset-0 z-10"
+            aria-hidden
+            onClick={() => setOpen(false)}
+          />
           <div className="absolute right-0 mt-1 w-48 bg-white rounded-lg shadow-lg border border-gray-200 z-20 py-1">
-            {(['private', 'shared', 'public'] as const).map((v) => {
+            {(["private", "shared", "public"] as const).map((v) => {
               const I = ICONS[v];
               return (
                 <button
@@ -55,7 +63,9 @@ export default function ReportSharing({ report, onVisibilityChange, disabled }: 
                     setOpen(false);
                   }}
                   className={`w-full flex items-center gap-2 px-3 py-2 text-left text-sm ${
-                    visibility === v ? 'bg-emerald-50 text-emerald-700' : 'text-gray-700 hover:bg-gray-50'
+                    visibility === v
+                      ? "bg-emerald-50 text-emerald-700"
+                      : "text-gray-700 hover:bg-gray-50"
                   }`}
                 >
                   <I className="w-4 h-4" />

--- a/project-portal/project-portal-web/src/components/reports/ReportsList.tsx
+++ b/project-portal/project-portal-web/src/components/reports/ReportsList.tsx
@@ -1,11 +1,19 @@
-'use client';
+"use client";
 
-import { useEffect } from 'react';
-import { useReportsStore } from '@/store/store';
-import ReportSharing from './ReportSharing';
-import { FileText, Play, Copy, Trash2, Loader2, Edit, Calendar } from 'lucide-react';
-import { toast } from 'sonner';
-import EmptyState from '@/components/ui/EmptyState';
+import { useEffect } from "react";
+import { useStore } from "@/lib/store/store";
+import ReportSharing from "./ReportSharing";
+import {
+  FileText,
+  Play,
+  Copy,
+  Trash2,
+  Loader2,
+  Edit,
+  Calendar,
+} from "lucide-react";
+import { toast } from "sonner";
+import EmptyState from "@/components/ui/EmptyState";
 
 interface ReportsListProps {
   onSelectReport?: (id: string) => void;
@@ -31,7 +39,7 @@ export default function ReportsList({
     cloneReport,
     deleteReport,
     updateReport,
-  } = useReportsStore();
+  } = useStore();
 
   useEffect(() => {
     fetchReports({
@@ -45,20 +53,21 @@ export default function ReportsList({
   const handleClone = async (id: string, name: string) => {
     try {
       const cloned = await cloneReport(id, `${name} (copy)`);
-      toast.success('Report cloned');
+      toast.success("Report cloned");
       onSelectReport?.(cloned.id);
     } catch (e) {
-      toast.error(e instanceof Error ? e.message : 'Clone failed');
+      toast.error(e instanceof Error ? e.message : "Clone failed");
     }
   };
 
   const handleDelete = async (id: string) => {
-    if (typeof window !== 'undefined' && !window.confirm('Delete this report?')) return;
+    if (typeof window !== "undefined" && !window.confirm("Delete this report?"))
+      return;
     try {
       await deleteReport(id);
-      toast.success('Report deleted');
+      toast.success("Report deleted");
     } catch (e) {
-      toast.error(e instanceof Error ? e.message : 'Delete failed');
+      toast.error(e instanceof Error ? e.message : "Delete failed");
     }
   };
 
@@ -89,25 +98,33 @@ export default function ReportsList({
         >
           <div className="flex items-start justify-between gap-2">
             <div className="min-w-0 flex-1">
-              <h3 className="font-semibold text-gray-900 truncate">{report.name}</h3>
+              <h3 className="font-semibold text-gray-900 truncate">
+                {report.name}
+              </h3>
               {report.description && (
-                <p className="text-sm text-gray-600 mt-1 line-clamp-2">{report.description}</p>
+                <p className="text-sm text-gray-600 mt-1 line-clamp-2">
+                  {report.description}
+                </p>
               )}
               <div className="mt-2 flex items-center gap-2 text-xs text-gray-500">
-                <span>{report.category ?? 'custom'}</span>
+                <span>{report.category ?? "custom"}</span>
                 <span>•</span>
                 <span>v{report.version}</span>
               </div>
             </div>
             <ReportSharing
               report={report}
-              onVisibilityChange={(v) => updateReport(report.id, { visibility: v }).catch(() => {})}
+              onVisibilityChange={(v) =>
+                updateReport(report.id, { visibility: v }).catch(() => {})
+              }
             />
           </div>
           <div className="mt-4 flex flex-wrap gap-2">
             <button
               type="button"
-              onClick={() => onEditReport?.(report.id) ?? onSelectReport?.(report.id)}
+              onClick={() =>
+                onEditReport?.(report.id) ?? onSelectReport?.(report.id)
+              }
               className="inline-flex items-center px-3 py-1.5 text-sm bg-emerald-50 text-emerald-700 rounded-lg hover:bg-emerald-100"
             >
               <Edit className="w-4 h-4 mr-1" />

--- a/project-portal/project-portal-web/src/components/reports/ScheduleForm.tsx
+++ b/project-portal/project-portal-web/src/components/reports/ScheduleForm.tsx
@@ -1,16 +1,20 @@
-'use client';
+"use client";
 
-import { useState, useEffect } from 'react';
-import { toast } from 'sonner';
-import { useReportsStore } from '@/store/store';
-import type { CreateScheduleRequest, ExportFormat, DeliveryMethod } from '@/store/reports.types';
-import { Calendar, Mail, Server, Webhook } from 'lucide-react';
+import { useState, useEffect } from "react";
+import { toast } from "sonner";
+import { useStore } from "@/lib/store/store";
+import type {
+  CreateScheduleRequest,
+  ExportFormat,
+  DeliveryMethod,
+} from "@/lib/store/store";
+import { Calendar, Mail, Server, Webhook } from "lucide-react";
 
 const CRON_PRESETS = [
-  { label: 'Daily at 8:00', value: '0 8 * * *' },
-  { label: 'Weekly Monday 9:00', value: '0 9 * * 1' },
-  { label: 'Monthly 1st at 6:00', value: '0 6 1 * *' },
-  { label: 'Every 6 hours', value: '0 */6 * * *' },
+  { label: "Daily at 8:00", value: "0 8 * * *" },
+  { label: "Weekly Monday 9:00", value: "0 9 * * 1" },
+  { label: "Monthly 1st at 6:00", value: "0 6 1 * *" },
+  { label: "Every 6 hours", value: "0 */6 * * *" },
 ];
 
 interface ScheduleFormProps {
@@ -18,31 +22,37 @@ interface ScheduleFormProps {
   onSuccess?: () => void;
 }
 
-export default function ScheduleForm({ reportId, onSuccess }: ScheduleFormProps) {
-  const { createSchedule } = useReportsStore();
-  const [name, setName] = useState('');
-  const [cronExpression, setCronExpression] = useState('0 8 * * *');
-  const [timezone, setTimezone] = useState('UTC');
-  const [format, setFormat] = useState<ExportFormat>('csv');
-  const [deliveryMethod, setDeliveryMethod] = useState<DeliveryMethod>('email');
-  const [recipientEmails, setRecipientEmails] = useState('');
-  const [webhookUrl, setWebhookUrl] = useState('');
+export default function ScheduleForm({
+  reportId,
+  onSuccess,
+}: ScheduleFormProps) {
+  const { createSchedule } = useStore();
+  const [name, setName] = useState("");
+  const [cronExpression, setCronExpression] = useState("0 8 * * *");
+  const [timezone, setTimezone] = useState("UTC");
+  const [format, setFormat] = useState<ExportFormat>("csv");
+  const [deliveryMethod, setDeliveryMethod] = useState<DeliveryMethod>("email");
+  const [recipientEmails, setRecipientEmails] = useState("");
+  const [webhookUrl, setWebhookUrl] = useState("");
   const [saving, setSaving] = useState(false);
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
     if (!name.trim()) {
-      toast.error('Schedule name is required');
+      toast.error("Schedule name is required");
       return;
     }
     setSaving(true);
     try {
       const deliveryConfig =
-        deliveryMethod === 'email'
-          ? { subject: `Report: ${name}`, body: 'Please find the report attached.' }
-          : deliveryMethod === 'webhook'
-            ? { method: 'POST' as const }
-            : { bucket: 'reports', prefix: 'scheduled/', region: 'us-east-1' };
+        deliveryMethod === "email"
+          ? {
+              subject: `Report: ${name}`,
+              body: "Please find the report attached.",
+            }
+          : deliveryMethod === "webhook"
+            ? { method: "POST" as const }
+            : { bucket: "reports", prefix: "scheduled/", region: "us-east-1" };
 
       await createSchedule({
         report_definition_id: reportId,
@@ -53,13 +63,20 @@ export default function ScheduleForm({ reportId, onSuccess }: ScheduleFormProps)
         delivery_method: deliveryMethod,
         delivery_config: deliveryConfig,
         recipient_emails:
-          deliveryMethod === 'email' ? recipientEmails.split(',').map((e) => e.trim()).filter(Boolean) : undefined,
-        webhook_url: deliveryMethod === 'webhook' ? webhookUrl : undefined,
+          deliveryMethod === "email"
+            ? recipientEmails
+                .split(",")
+                .map((e) => e.trim())
+                .filter(Boolean)
+            : undefined,
+        webhook_url: deliveryMethod === "webhook" ? webhookUrl : undefined,
       });
-      toast.success('Schedule created');
+      toast.success("Schedule created");
       onSuccess?.();
     } catch (err) {
-      toast.error(err instanceof Error ? err.message : 'Failed to create schedule');
+      toast.error(
+        err instanceof Error ? err.message : "Failed to create schedule",
+      );
     } finally {
       setSaving(false);
     }
@@ -68,7 +85,9 @@ export default function ScheduleForm({ reportId, onSuccess }: ScheduleFormProps)
   return (
     <form onSubmit={handleSubmit} className="space-y-6 max-w-xl">
       <div>
-        <label className="block text-sm font-medium text-gray-700 mb-1">Schedule name</label>
+        <label className="block text-sm font-medium text-gray-700 mb-1">
+          Schedule name
+        </label>
         <input
           type="text"
           value={name}
@@ -79,14 +98,18 @@ export default function ScheduleForm({ reportId, onSuccess }: ScheduleFormProps)
       </div>
 
       <div>
-        <label className="block text-sm font-medium text-gray-700 mb-1">Cron expression</label>
+        <label className="block text-sm font-medium text-gray-700 mb-1">
+          Cron expression
+        </label>
         <select
           value={cronExpression}
           onChange={(e) => setCronExpression(e.target.value)}
           className="w-full border border-gray-300 rounded-lg px-3 py-2"
         >
           {CRON_PRESETS.map((p) => (
-            <option key={p.value} value={p.value}>{p.label}</option>
+            <option key={p.value} value={p.value}>
+              {p.label}
+            </option>
           ))}
         </select>
         <input
@@ -99,7 +122,9 @@ export default function ScheduleForm({ reportId, onSuccess }: ScheduleFormProps)
       </div>
 
       <div>
-        <label className="block text-sm font-medium text-gray-700 mb-1">Timezone</label>
+        <label className="block text-sm font-medium text-gray-700 mb-1">
+          Timezone
+        </label>
         <input
           type="text"
           value={timezone}
@@ -109,7 +134,9 @@ export default function ScheduleForm({ reportId, onSuccess }: ScheduleFormProps)
       </div>
 
       <div>
-        <label className="block text-sm font-medium text-gray-700 mb-1">Export format</label>
+        <label className="block text-sm font-medium text-gray-700 mb-1">
+          Export format
+        </label>
         <select
           value={format}
           onChange={(e) => setFormat(e.target.value as ExportFormat)}
@@ -123,14 +150,19 @@ export default function ScheduleForm({ reportId, onSuccess }: ScheduleFormProps)
       </div>
 
       <div>
-        <label className="block text-sm font-medium text-gray-700 mb-2">Delivery</label>
+        <label className="block text-sm font-medium text-gray-700 mb-2">
+          Delivery
+        </label>
         <div className="flex gap-4 mb-3">
           {[
-            { value: 'email' as const, icon: Mail, label: 'Email' },
-            { value: 's3' as const, icon: Server, label: 'S3' },
-            { value: 'webhook' as const, icon: Webhook, label: 'Webhook' },
+            { value: "email" as const, icon: Mail, label: "Email" },
+            { value: "s3" as const, icon: Server, label: "S3" },
+            { value: "webhook" as const, icon: Webhook, label: "Webhook" },
           ].map(({ value, icon: Icon, label }) => (
-            <label key={value} className="flex items-center gap-2 cursor-pointer">
+            <label
+              key={value}
+              className="flex items-center gap-2 cursor-pointer"
+            >
               <input
                 type="radio"
                 name="delivery"
@@ -143,7 +175,7 @@ export default function ScheduleForm({ reportId, onSuccess }: ScheduleFormProps)
             </label>
           ))}
         </div>
-        {deliveryMethod === 'email' && (
+        {deliveryMethod === "email" && (
           <input
             type="text"
             value={recipientEmails}
@@ -152,7 +184,7 @@ export default function ScheduleForm({ reportId, onSuccess }: ScheduleFormProps)
             placeholder="email1@example.com, email2@example.com"
           />
         )}
-        {deliveryMethod === 'webhook' && (
+        {deliveryMethod === "webhook" && (
           <input
             type="url"
             value={webhookUrl}
@@ -168,7 +200,7 @@ export default function ScheduleForm({ reportId, onSuccess }: ScheduleFormProps)
         disabled={saving}
         className="px-4 py-2 bg-emerald-600 text-white rounded-lg font-medium hover:bg-emerald-700 disabled:opacity-50"
       >
-        {saving ? 'Creating…' : 'Create schedule'}
+        {saving ? "Creating…" : "Create schedule"}
       </button>
     </form>
   );

--- a/project-portal/project-portal-web/src/components/reports/WidgetConfigurator.tsx
+++ b/project-portal/project-portal-web/src/components/reports/WidgetConfigurator.tsx
@@ -1,9 +1,14 @@
-'use client';
+"use client";
 
-import { useState } from 'react';
-import type { DashboardWidget, WidgetConfig, WidgetType, WidgetSize } from '@/store/reports.types';
+import { useState } from "react";
+import type {
+  DashboardWidget,
+  WidgetConfig,
+  WidgetType,
+  WidgetSize,
+} from "@/lib/store/store";
 
-const SIZES: WidgetSize[] = ['small', 'medium', 'large', 'full'];
+const SIZES: WidgetSize[] = ["small", "medium", "large", "full"];
 const REFRESH_OPTIONS = [60, 300, 600, 3600];
 
 interface WidgetConfiguratorProps {
@@ -12,18 +17,26 @@ interface WidgetConfiguratorProps {
   onCancel: () => void;
 }
 
-export default function WidgetConfigurator({ widget, onSave, onCancel }: WidgetConfiguratorProps) {
-  const [title, setTitle] = useState(widget?.title ?? '');
-  const [size, setSize] = useState<WidgetSize>(widget?.size ?? 'medium');
+export default function WidgetConfigurator({
+  widget,
+  onSave,
+  onCancel,
+}: WidgetConfiguratorProps) {
+  const [title, setTitle] = useState(widget?.title ?? "");
+  const [size, setSize] = useState<WidgetSize>(widget?.size ?? "medium");
   const [refreshInterval, setRefreshInterval] = useState(
-    widget?.config?.refresh_rate ?? widget?.refresh_interval_seconds ?? 300
+    widget?.config?.refresh_rate ?? widget?.refresh_interval_seconds ?? 300,
   );
-  const [dataSource, setDataSource] = useState(widget?.config?.data_source ?? 'dashboard_summary');
-  const [metricField, setMetricField] = useState(widget?.config?.metric_field ?? 'total_credits');
+  const [dataSource, setDataSource] = useState(
+    widget?.config?.data_source ?? "dashboard_summary",
+  );
+  const [metricField, setMetricField] = useState(
+    widget?.config?.metric_field ?? "total_credits",
+  );
 
   const handleSave = () => {
     onSave({
-      title: title || 'Untitled Widget',
+      title: title || "Untitled Widget",
       size,
       refresh_interval_seconds: refreshInterval,
       config: {
@@ -38,7 +51,9 @@ export default function WidgetConfigurator({ widget, onSave, onCancel }: WidgetC
     <div className="space-y-4 p-4 bg-white rounded-xl border border-gray-200">
       <h4 className="font-semibold text-gray-900">Widget settings</h4>
       <div>
-        <label className="block text-sm font-medium text-gray-700 mb-1">Title</label>
+        <label className="block text-sm font-medium text-gray-700 mb-1">
+          Title
+        </label>
         <input
           type="text"
           value={title}
@@ -48,19 +63,25 @@ export default function WidgetConfigurator({ widget, onSave, onCancel }: WidgetC
         />
       </div>
       <div>
-        <label className="block text-sm font-medium text-gray-700 mb-1">Size</label>
+        <label className="block text-sm font-medium text-gray-700 mb-1">
+          Size
+        </label>
         <select
           value={size}
           onChange={(e) => setSize(e.target.value as WidgetSize)}
           className="w-full border border-gray-300 rounded-lg px-3 py-2"
         >
           {SIZES.map((s) => (
-            <option key={s} value={s}>{s}</option>
+            <option key={s} value={s}>
+              {s}
+            </option>
           ))}
         </select>
       </div>
       <div>
-        <label className="block text-sm font-medium text-gray-700 mb-1">Refresh (seconds)</label>
+        <label className="block text-sm font-medium text-gray-700 mb-1">
+          Refresh (seconds)
+        </label>
         <select
           value={refreshInterval}
           onChange={(e) => setRefreshInterval(Number(e.target.value))}
@@ -68,13 +89,21 @@ export default function WidgetConfigurator({ widget, onSave, onCancel }: WidgetC
         >
           {REFRESH_OPTIONS.map((s) => (
             <option key={s} value={s}>
-              {s === 60 ? '1 min' : s === 300 ? '5 min' : s === 600 ? '10 min' : '1 hour'}
+              {s === 60
+                ? "1 min"
+                : s === 300
+                  ? "5 min"
+                  : s === 600
+                    ? "10 min"
+                    : "1 hour"}
             </option>
           ))}
         </select>
       </div>
       <div>
-        <label className="block text-sm font-medium text-gray-700 mb-1">Data source</label>
+        <label className="block text-sm font-medium text-gray-700 mb-1">
+          Data source
+        </label>
         <input
           type="text"
           value={dataSource}
@@ -83,7 +112,9 @@ export default function WidgetConfigurator({ widget, onSave, onCancel }: WidgetC
         />
       </div>
       <div>
-        <label className="block text-sm font-medium text-gray-700 mb-1">Metric field</label>
+        <label className="block text-sm font-medium text-gray-700 mb-1">
+          Metric field
+        </label>
         <select
           value={metricField}
           onChange={(e) => setMetricField(e.target.value)}

--- a/project-portal/project-portal-web/src/components/reports/WidgetLibrary.tsx
+++ b/project-portal/project-portal-web/src/components/reports/WidgetLibrary.tsx
@@ -1,13 +1,17 @@
-'use client';
+"use client";
 
-import { BarChart3, Hash, Table, Gauge } from 'lucide-react';
-import type { WidgetType } from '@/store/reports.types';
+import { BarChart3, Hash, Table, Gauge } from "lucide-react";
+import type { WidgetType } from "@/lib/store/store";
 
-const WIDGET_TYPES: { type: WidgetType; label: string; icon: typeof BarChart3 }[] = [
-  { type: 'chart', label: 'Chart', icon: BarChart3 },
-  { type: 'metric', label: 'Metric', icon: Hash },
-  { type: 'table', label: 'Table', icon: Table },
-  { type: 'gauge', label: 'Gauge', icon: Gauge },
+const WIDGET_TYPES: {
+  type: WidgetType;
+  label: string;
+  icon: typeof BarChart3;
+}[] = [
+  { type: "chart", label: "Chart", icon: BarChart3 },
+  { type: "metric", label: "Metric", icon: Hash },
+  { type: "table", label: "Table", icon: Table },
+  { type: "gauge", label: "Gauge", icon: Gauge },
 ];
 
 interface WidgetLibraryProps {
@@ -15,7 +19,10 @@ interface WidgetLibraryProps {
   disabled?: boolean;
 }
 
-export default function WidgetLibrary({ onSelect, disabled }: WidgetLibraryProps) {
+export default function WidgetLibrary({
+  onSelect,
+  disabled,
+}: WidgetLibraryProps) {
   return (
     <div className="grid grid-cols-2 gap-2">
       {WIDGET_TYPES.map(({ type, label, icon: Icon }) => (

--- a/project-portal/project-portal-web/src/components/reports/widgets/ChartWidget.tsx
+++ b/project-portal/project-portal-web/src/components/reports/widgets/ChartWidget.tsx
@@ -1,16 +1,16 @@
-'use client';
+"use client";
 
-import { useEffect } from 'react';
-import { useReportsStore } from '@/store/store';
-import type { DashboardWidget } from '@/store/reports.types';
-import { BarChart3 } from 'lucide-react';
+import { useEffect } from "react";
+import { useStore } from "@/lib/store/store";
+import type { DashboardWidget } from "@/lib/store/store";
+import { BarChart3 } from "lucide-react";
 
 interface ChartWidgetProps {
   widget: DashboardWidget;
 }
 
 export default function ChartWidget({ widget }: ChartWidgetProps) {
-  const { dashboardSummary, fetchDashboardSummary } = useReportsStore();
+  const { dashboardSummary, fetchDashboardSummary } = useStore();
   const config = widget.config ?? {};
   const title = widget.title;
 

--- a/project-portal/project-portal-web/src/components/reports/widgets/GaugeWidget.tsx
+++ b/project-portal/project-portal-web/src/components/reports/widgets/GaugeWidget.tsx
@@ -1,20 +1,20 @@
-'use client';
+"use client";
 
-import { useEffect } from 'react';
-import { useReportsStore } from '@/store/store';
-import type { DashboardWidget } from '@/store/reports.types';
+import { useEffect } from "react";
+import { useStore } from "@/lib/store/store";
+import type { DashboardWidget } from "@/lib/store/store";
 
 interface GaugeWidgetProps {
   widget: DashboardWidget;
 }
 
 export default function GaugeWidget({ widget }: GaugeWidgetProps) {
-  const { dashboardSummary, fetchDashboardSummary } = useReportsStore();
+  const { dashboardSummary, fetchDashboardSummary } = useStore();
   const config = widget.config ?? {};
   const title = widget.title;
   const min = config.min_value ?? 0;
   const max = config.max_value ?? 100;
-  const metricKey = config.metric_field ?? 'total_credits';
+  const metricKey = config.metric_field ?? "total_credits";
 
   useEffect(() => {
     fetchDashboardSummary();
@@ -23,7 +23,10 @@ export default function GaugeWidget({ widget }: GaugeWidgetProps) {
   const metrics = dashboardSummary?.performance_metrics ?? {};
   const meta = metrics[metricKey];
   const value = meta?.value ?? 0;
-  const pct = max > min ? Math.min(100, Math.max(0, ((value - min) / (max - min)) * 100)) : 0;
+  const pct =
+    max > min
+      ? Math.min(100, Math.max(0, ((value - min) / (max - min)) * 100))
+      : 0;
 
   return (
     <div className="p-4 h-full min-h-[160px] flex flex-col">

--- a/project-portal/project-portal-web/src/components/reports/widgets/MetricWidget.tsx
+++ b/project-portal/project-portal-web/src/components/reports/widgets/MetricWidget.tsx
@@ -1,21 +1,21 @@
-'use client';
+"use client";
 
-import { useEffect } from 'react';
-import { useReportsStore } from '@/store/store';
-import type { DashboardWidget } from '@/store/reports.types';
-import { TrendingUp, TrendingDown } from 'lucide-react';
+import { useEffect } from "react";
+import { useStore } from "@/lib/store/store";
+import type { DashboardWidget } from "@/lib/store/store";
+import { TrendingUp, TrendingDown } from "lucide-react";
 
 interface MetricWidgetProps {
   widget: DashboardWidget;
 }
 
 export default function MetricWidget({ widget }: MetricWidgetProps) {
-  const { dashboardSummary, fetchDashboardSummary } = useReportsStore();
+  const { dashboardSummary, fetchDashboardSummary } = useStore();
   const config = widget.config ?? {};
   const title = widget.title;
-  const metricKey = config.metric_field ?? 'total_credits';
-  const prefix = config.prefix ?? '';
-  const suffix = config.suffix ?? '';
+  const metricKey = config.metric_field ?? "total_credits";
+  const prefix = config.prefix ?? "";
+  const suffix = config.suffix ?? "";
 
   useEffect(() => {
     fetchDashboardSummary();
@@ -24,14 +24,14 @@ export default function MetricWidget({ widget }: MetricWidgetProps) {
   const metrics = dashboardSummary?.performance_metrics ?? {};
   const meta = metrics[metricKey];
   const fallback = dashboardSummary
-    ? (metricKey === 'total_projects' && dashboardSummary.total_projects) ||
-      (metricKey === 'total_credits' && dashboardSummary.total_credits) ||
-      (metricKey === 'total_revenue' && dashboardSummary.total_revenue) ||
+    ? (metricKey === "total_projects" && dashboardSummary.total_projects) ||
+      (metricKey === "total_credits" && dashboardSummary.total_credits) ||
+      (metricKey === "total_revenue" && dashboardSummary.total_revenue) ||
       null
     : null;
   const value = meta?.value ?? fallback ?? 0;
   const change = meta?.change_percent ?? 0;
-  const trend = meta?.trend ?? (change >= 0 ? 'up' : 'down');
+  const trend = meta?.trend ?? (change >= 0 ? "up" : "down");
 
   return (
     <div className="p-4 h-full min-h-[120px] flex flex-col justify-center">
@@ -39,7 +39,7 @@ export default function MetricWidget({ widget }: MetricWidgetProps) {
       <div className="flex items-baseline gap-2">
         <span className="text-2xl font-bold text-gray-900">
           {prefix}
-          {typeof value === 'number' && (value >= 1000 || value <= -1000)
+          {typeof value === "number" && (value >= 1000 || value <= -1000)
             ? value.toLocaleString()
             : value}
           {suffix}
@@ -47,11 +47,16 @@ export default function MetricWidget({ widget }: MetricWidgetProps) {
         {change !== 0 && (
           <span
             className={`inline-flex items-center text-sm font-medium ${
-              trend === 'up' ? 'text-emerald-600' : 'text-red-600'
+              trend === "up" ? "text-emerald-600" : "text-red-600"
             }`}
           >
-            {trend === 'up' ? <TrendingUp className="w-4 h-4 mr-0.5" /> : <TrendingDown className="w-4 h-4 mr-0.5" />}
-            {change > 0 ? '+' : ''}{change.toFixed(1)}%
+            {trend === "up" ? (
+              <TrendingUp className="w-4 h-4 mr-0.5" />
+            ) : (
+              <TrendingDown className="w-4 h-4 mr-0.5" />
+            )}
+            {change > 0 ? "+" : ""}
+            {change.toFixed(1)}%
           </span>
         )}
       </div>

--- a/project-portal/project-portal-web/src/components/reports/widgets/TableWidget.tsx
+++ b/project-portal/project-portal-web/src/components/reports/widgets/TableWidget.tsx
@@ -1,15 +1,15 @@
-'use client';
+"use client";
 
-import { useEffect } from 'react';
-import { useReportsStore } from '@/store/store';
-import type { DashboardWidget } from '@/store/reports.types';
+import { useEffect } from "react";
+import { useStore } from "@/lib/store/store";
+import type { DashboardWidget } from "@/lib/store/store";
 
 interface TableWidgetProps {
   widget: DashboardWidget;
 }
 
 export default function TableWidget({ widget }: TableWidgetProps) {
-  const { dashboardSummary, fetchDashboardSummary } = useReportsStore();
+  const { dashboardSummary, fetchDashboardSummary } = useStore();
   const title = widget.title;
 
   useEffect(() => {

--- a/project-portal/project-portal-web/src/lib/store/reports/reports.api.ts
+++ b/project-portal/project-portal-web/src/lib/store/reports/reports.api.ts
@@ -1,7 +1,7 @@
-import { getReportsApiBase } from '@/lib/api';
-import api from '@/lib/api/apiClient';
-import axios from 'axios';
-import type { AxiosRequestConfig } from 'axios';
+import { getReportsApiBase } from "@/lib/api";
+import api from "@/lib/api/apiClient";
+import axios from "axios";
+import type { AxiosRequestConfig } from "axios";
 import type {
   CreateReportRequest,
   UpdateReportRequest,
@@ -19,7 +19,7 @@ import type {
   DatasetMetadata,
   BenchmarkDataset,
   WidgetConfig,
-} from './reports.types';
+} from "./reports.types";
 
 async function reportsRequest<T>(config: AxiosRequestConfig): Promise<T> {
   try {
@@ -35,17 +35,17 @@ async function reportsRequest<T>(config: AxiosRequestConfig): Promise<T> {
         let message = res.statusText || `Request failed (${res.status})`;
         const data = res.data;
         if (data) {
-          if (typeof data === 'object') {
+          if (typeof data === "object") {
             const errData = data as any;
             if (errData.error) {
               message = errData.error;
             } else if (errData.message) {
               message = errData.message;
             }
-          } else if (typeof data === 'string') {
+          } else if (typeof data === "string") {
             const text = data.trim();
-            if (text && !text.startsWith('<!') && !text.startsWith('<html')) {
-              message = text.length > 200 ? text.slice(0, 200) + '...' : text;
+            if (text && !text.startsWith("<!") && !text.startsWith("<html")) {
+              message = text.length > 200 ? text.slice(0, 200) + "..." : text;
             }
           }
         }
@@ -56,10 +56,12 @@ async function reportsRequest<T>(config: AxiosRequestConfig): Promise<T> {
   }
 }
 
-export async function apiCreateReport(body: CreateReportRequest): Promise<ReportDefinition> {
+export async function apiCreateReport(
+  body: CreateReportRequest,
+): Promise<ReportDefinition> {
   return reportsRequest<ReportDefinition>({
-    method: 'POST',
-    url: 'reports/builder',
+    method: "POST",
+    url: "reports/builder",
     data: body,
   });
 }
@@ -73,28 +75,33 @@ export async function apiListReports(params?: {
   page_size?: number;
 }): Promise<ListReportsResponse> {
   const q = new URLSearchParams();
-  if (params?.category) q.set('category', params.category);
-  if (params?.visibility) q.set('visibility', params.visibility);
-  if (params?.is_template !== undefined) q.set('is_template', String(params.is_template));
-  if (params?.search) q.set('search', params.search);
-  if (params?.page !== undefined) q.set('page', String(params.page));
-  if (params?.page_size !== undefined) q.set('page_size', String(params.page_size));
+  if (params?.category) q.set("category", params.category);
+  if (params?.visibility) q.set("visibility", params.visibility);
+  if (params?.is_template !== undefined)
+    q.set("is_template", String(params.is_template));
+  if (params?.search) q.set("search", params.search);
+  if (params?.page !== undefined) q.set("page", String(params.page));
+  if (params?.page_size !== undefined)
+    q.set("page_size", String(params.page_size));
   return reportsRequest<ListReportsResponse>({
-    method: 'GET',
+    method: "GET",
     url: `reports?${q.toString()}`,
   });
 }
 
 export async function apiGetReport(id: string): Promise<ReportDefinition> {
   return reportsRequest<ReportDefinition>({
-    method: 'GET',
+    method: "GET",
     url: `reports/${id}`,
   });
 }
 
-export async function apiUpdateReport(id: string, body: UpdateReportRequest): Promise<ReportDefinition> {
+export async function apiUpdateReport(
+  id: string,
+  body: UpdateReportRequest,
+): Promise<ReportDefinition> {
   return reportsRequest<ReportDefinition>({
-    method: 'PUT',
+    method: "PUT",
     url: `reports/${id}`,
     data: body,
   });
@@ -102,14 +109,17 @@ export async function apiUpdateReport(id: string, body: UpdateReportRequest): Pr
 
 export async function apiDeleteReport(id: string): Promise<void> {
   await reportsRequest<void>({
-    method: 'DELETE',
+    method: "DELETE",
     url: `reports/${id}`,
   });
 }
 
-export async function apiCloneReport(id: string, name: string): Promise<ReportDefinition> {
+export async function apiCloneReport(
+  id: string,
+  name: string,
+): Promise<ReportDefinition> {
   return reportsRequest<ReportDefinition>({
-    method: 'POST',
+    method: "POST",
     url: `reports/${id}/clone`,
     data: { name },
   });
@@ -117,23 +127,29 @@ export async function apiCloneReport(id: string, name: string): Promise<ReportDe
 
 export async function apiListTemplates(): Promise<ReportDefinition[]> {
   const data = await reportsRequest<{ templates: ReportDefinition[] }>({
-    method: 'GET',
-    url: 'reports/templates',
+    method: "GET",
+    url: "reports/templates",
   });
   return data?.templates ?? [];
 }
 
-export async function apiExecuteReport(id: string, body?: ExecuteReportRequest): Promise<ReportExecution> {
+export async function apiExecuteReport(
+  id: string,
+  body?: ExecuteReportRequest,
+): Promise<ReportExecution> {
   return reportsRequest<ReportExecution>({
-    method: 'POST',
+    method: "POST",
     url: `reports/${id}/execute`,
     data: body,
   });
 }
 
-export async function apiExportReport(id: string, format: string = 'csv'): Promise<{ execution_id: string; status: string }> {
+export async function apiExportReport(
+  id: string,
+  format: string = "csv",
+): Promise<{ execution_id: string; status: string }> {
   return reportsRequest<{ execution_id: string; status: string }>({
-    method: 'GET',
+    method: "GET",
     url: `reports/${id}/export?format=${format}`,
   });
 }
@@ -146,43 +162,46 @@ export async function apiListExecutions(params?: {
   page_size?: number;
 }): Promise<ListExecutionsResponse> {
   const q = new URLSearchParams();
-  if (params?.report_id) q.set('report_id', params.report_id);
-  if (params?.schedule_id) q.set('schedule_id', params.schedule_id);
-  if (params?.status) q.set('status', params.status);
-  if (params?.page !== undefined) q.set('page', String(params.page));
-  if (params?.page_size !== undefined) q.set('page_size', String(params.page_size));
+  if (params?.report_id) q.set("report_id", params.report_id);
+  if (params?.schedule_id) q.set("schedule_id", params.schedule_id);
+  if (params?.status) q.set("status", params.status);
+  if (params?.page !== undefined) q.set("page", String(params.page));
+  if (params?.page_size !== undefined)
+    q.set("page_size", String(params.page_size));
   return reportsRequest<ListExecutionsResponse>({
-    method: 'GET',
+    method: "GET",
     url: `reports/executions?${q.toString()}`,
   });
 }
 
-export async function apiGetExecution(executionId: string): Promise<ReportExecution> {
+export async function apiGetExecution(
+  executionId: string,
+): Promise<ReportExecution> {
   return reportsRequest<ReportExecution>({
-    method: 'GET',
+    method: "GET",
     url: `reports/executions/${executionId}`,
   });
 }
 
 export async function apiCancelExecution(executionId: string): Promise<void> {
   await reportsRequest<void>({
-    method: 'POST',
+    method: "POST",
     url: `reports/executions/${executionId}/cancel`,
   });
 }
 
 export async function apiGetDatasets(): Promise<DatasetMetadata[]> {
   const data = await reportsRequest<{ datasets: DatasetMetadata[] }>({
-    method: 'GET',
-    url: 'reports/datasets',
+    method: "GET",
+    url: "reports/datasets",
   });
   return data?.datasets ?? [];
 }
 
 export async function apiGetDashboardSummary(): Promise<DashboardSummary> {
   return reportsRequest<DashboardSummary>({
-    method: 'GET',
-    url: 'reports/dashboard/summary',
+    method: "GET",
+    url: "reports/dashboard/summary",
   });
 }
 
@@ -198,32 +217,43 @@ export async function apiGetTimeSeriesData(params: {
     end_time: params.end_time,
     ...(params.interval && { interval: params.interval }),
   });
-  return reportsRequest<{ data: Array<{ time: string; value: number; label?: string }> }>({
-    method: 'GET',
+  return reportsRequest<{
+    data: Array<{ time: string; value: number; label?: string }>;
+  }>({
+    method: "GET",
     url: `reports/dashboard/timeseries?${q.toString()}`,
   });
 }
 
-export async function apiGetWidgets(section?: string): Promise<DashboardWidget[]> {
-  const url = section ? `reports/dashboard/widgets?section=${encodeURIComponent(section)}` : 'reports/dashboard/widgets';
+export async function apiGetWidgets(
+  section?: string,
+): Promise<DashboardWidget[]> {
+  const url = section
+    ? `reports/dashboard/widgets?section=${encodeURIComponent(section)}`
+    : "reports/dashboard/widgets";
   const data = await reportsRequest<{ widgets: DashboardWidget[] }>({
-    method: 'GET',
+    method: "GET",
     url,
   });
   return data?.widgets ?? [];
 }
 
-export async function apiCreateWidget(widget: Omit<DashboardWidget, 'id' | 'created_at' | 'updated_at'>): Promise<DashboardWidget> {
+export async function apiCreateWidget(
+  widget: Omit<DashboardWidget, "id" | "created_at" | "updated_at">,
+): Promise<DashboardWidget> {
   return reportsRequest<DashboardWidget>({
-    method: 'POST',
-    url: 'reports/dashboard/widgets',
+    method: "POST",
+    url: "reports/dashboard/widgets",
     data: widget,
   });
 }
 
-export async function apiUpdateWidget(widgetId: string, widget: Partial<DashboardWidget> & { config: WidgetConfig }): Promise<DashboardWidget> {
+export async function apiUpdateWidget(
+  widgetId: string,
+  widget: Partial<DashboardWidget> & { config: WidgetConfig },
+): Promise<DashboardWidget> {
   return reportsRequest<DashboardWidget>({
-    method: 'PUT',
+    method: "PUT",
     url: `reports/dashboard/widgets/${widgetId}`,
     data: { ...widget, id: widgetId },
   });
@@ -231,15 +261,17 @@ export async function apiUpdateWidget(widgetId: string, widget: Partial<Dashboar
 
 export async function apiDeleteWidget(widgetId: string): Promise<void> {
   await reportsRequest<void>({
-    method: 'DELETE',
+    method: "DELETE",
     url: `reports/dashboard/widgets/${widgetId}`,
   });
 }
 
-export async function apiCreateSchedule(body: CreateScheduleRequest): Promise<ReportSchedule> {
+export async function apiCreateSchedule(
+  body: CreateScheduleRequest,
+): Promise<ReportSchedule> {
   return reportsRequest<ReportSchedule>({
-    method: 'POST',
-    url: 'reports/schedules',
+    method: "POST",
+    url: "reports/schedules",
     data: body,
   });
 }
@@ -251,26 +283,33 @@ export async function apiListSchedules(params?: {
   page_size?: number;
 }): Promise<{ schedules: ReportSchedule[]; total: number }> {
   const q = new URLSearchParams();
-  if (params?.report_id) q.set('report_id', params.report_id);
-  if (params?.is_active !== undefined) q.set('is_active', String(params.is_active));
-  if (params?.page !== undefined) q.set('page', String(params.page));
-  if (params?.page_size !== undefined) q.set('page_size', String(params.page_size));
+  if (params?.report_id) q.set("report_id", params.report_id);
+  if (params?.is_active !== undefined)
+    q.set("is_active", String(params.is_active));
+  if (params?.page !== undefined) q.set("page", String(params.page));
+  if (params?.page_size !== undefined)
+    q.set("page_size", String(params.page_size));
   return reportsRequest<{ schedules: ReportSchedule[]; total: number }>({
-    method: 'GET',
+    method: "GET",
     url: `reports/schedules?${q.toString()}`,
   });
 }
 
-export async function apiGetSchedule(scheduleId: string): Promise<ReportSchedule> {
+export async function apiGetSchedule(
+  scheduleId: string,
+): Promise<ReportSchedule> {
   return reportsRequest<ReportSchedule>({
-    method: 'GET',
+    method: "GET",
     url: `reports/schedules/${scheduleId}`,
   });
 }
 
-export async function apiUpdateSchedule(scheduleId: string, body: CreateScheduleRequest): Promise<ReportSchedule> {
+export async function apiUpdateSchedule(
+  scheduleId: string,
+  body: CreateScheduleRequest,
+): Promise<ReportSchedule> {
   return reportsRequest<ReportSchedule>({
-    method: 'PUT',
+    method: "PUT",
     url: `reports/schedules/${scheduleId}`,
     data: body,
   });
@@ -278,23 +317,28 @@ export async function apiUpdateSchedule(scheduleId: string, body: CreateSchedule
 
 export async function apiDeleteSchedule(scheduleId: string): Promise<void> {
   await reportsRequest<void>({
-    method: 'DELETE',
+    method: "DELETE",
     url: `reports/schedules/${scheduleId}`,
   });
 }
 
-export async function apiToggleSchedule(scheduleId: string, active: boolean): Promise<{ message: string; active: boolean }> {
+export async function apiToggleSchedule(
+  scheduleId: string,
+  active: boolean,
+): Promise<{ message: string; active: boolean }> {
   return reportsRequest<{ message: string; active: boolean }>({
-    method: 'POST',
+    method: "POST",
     url: `reports/schedules/${scheduleId}/toggle`,
     data: { active },
   });
 }
 
-export async function apiBenchmarkComparison(body: BenchmarkComparisonRequest): Promise<BenchmarkComparisonResponse> {
+export async function apiBenchmarkComparison(
+  body: BenchmarkComparisonRequest,
+): Promise<BenchmarkComparisonResponse> {
   return reportsRequest<BenchmarkComparisonResponse>({
-    method: 'POST',
-    url: 'reports/benchmark/comparison',
+    method: "POST",
+    url: "reports/benchmark/comparison",
     data: body,
   });
 }
@@ -306,12 +350,12 @@ export async function apiListBenchmarks(params?: {
   year?: number;
 }): Promise<BenchmarkDataset[]> {
   const q = new URLSearchParams();
-  if (params?.category) q.set('category', params.category);
-  if (params?.methodology) q.set('methodology', params.methodology);
-  if (params?.region) q.set('region', params.region);
-  if (params?.year !== undefined) q.set('year', String(params.year));
+  if (params?.category) q.set("category", params.category);
+  if (params?.methodology) q.set("methodology", params.methodology);
+  if (params?.region) q.set("region", params.region);
+  if (params?.year !== undefined) q.set("year", String(params.year));
   const data = await reportsRequest<{ benchmarks: BenchmarkDataset[] }>({
-    method: 'GET',
+    method: "GET",
     url: `reports/benchmarks?${q.toString()}`,
   });
   return data?.benchmarks ?? [];

--- a/project-portal/project-portal-web/src/lib/store/reports/reports.selectors.ts
+++ b/project-portal/project-portal-web/src/lib/store/reports/reports.selectors.ts
@@ -6,9 +6,9 @@ import type {
   DashboardSummary,
   BenchmarkComparisonResponse,
   DatasetMetadata,
-} from './reports.types';
+} from "./reports.types";
 
-export type ReportsState = {
+export interface ReportsState {
   reports: ReportDefinition[];
   reportsTotal: number;
   reportsPage: number;
@@ -39,28 +39,44 @@ export type ReportsState = {
   templates: ReportDefinition[];
   templatesLoading: boolean;
   templatesError: string | null;
-};
+}
 
-export function selectReportById(state: ReportsState, id: string): ReportDefinition | undefined {
+export function selectReportById(
+  state: ReportsState,
+  id: string,
+): ReportDefinition | undefined {
   const fromList = state.reports.find((r) => r.id === id);
   if (fromList) return fromList;
-  if (state.currentReport && state.currentReport.id === id) return state.currentReport;
+  if (state.currentReport && state.currentReport.id === id)
+    return state.currentReport;
   return undefined;
 }
 
-export function selectExecutionById(state: ReportsState, id: string): ReportExecution | undefined {
+export function selectExecutionById(
+  state: ReportsState,
+  id: string,
+): ReportExecution | undefined {
   return state.executions.find((e) => e.id === id);
 }
 
-export function selectScheduleById(state: ReportsState, id: string): ReportSchedule | undefined {
+export function selectScheduleById(
+  state: ReportsState,
+  id: string,
+): ReportSchedule | undefined {
   return state.schedules.find((s) => s.id === id);
 }
 
-export function selectWidgetById(state: ReportsState, id: string): DashboardWidget | undefined {
+export function selectWidgetById(
+  state: ReportsState,
+  id: string,
+): DashboardWidget | undefined {
   return state.widgets.find((w) => w.id === id);
 }
 
-export function selectReportsStatus(state: ReportsState): { loading: boolean; error: string | null } {
+export function selectReportsStatus(state: ReportsState): {
+  loading: boolean;
+  error: string | null;
+} {
   return { loading: state.reportsLoading, error: state.reportsError };
 }
 
@@ -78,10 +94,16 @@ export function selectDashboardSummaryWithCache(state: ReportsState): {
   };
 }
 
-export function selectExecutionsForReport(state: ReportsState, reportId: string): ReportExecution[] {
+export function selectExecutionsForReport(
+  state: ReportsState,
+  reportId: string,
+): ReportExecution[] {
   return state.executions.filter((e) => e.report_definition_id === reportId);
 }
 
-export function selectSchedulesForReport(state: ReportsState, reportId: string): ReportSchedule[] {
+export function selectSchedulesForReport(
+  state: ReportsState,
+  reportId: string,
+): ReportSchedule[] {
   return state.schedules.filter((s) => s.report_definition_id === reportId);
 }

--- a/project-portal/project-portal-web/src/lib/store/reports/reports.slice.ts
+++ b/project-portal/project-portal-web/src/lib/store/reports/reports.slice.ts
@@ -1,4 +1,4 @@
-import { create } from 'zustand';
+import type { StateCreator } from "zustand";
 import type {
   ReportDefinition,
   ReportExecution,
@@ -13,8 +13,8 @@ import type {
   BenchmarkComparisonResponse,
   DatasetMetadata,
   WidgetConfig,
-} from './reports.types';
-import * as api from './reports.api';
+} from "./reports.types";
+import * as api from "./reports.api";
 
 const DASHBOARD_SUMMARY_CACHE_MS = 60 * 1000;
 
@@ -25,7 +25,9 @@ export interface ReportsSlice {
   reportsLoading: boolean;
   reportsError: string | null;
   currentReport: ReportDefinition | null;
-  fetchReports: (params?: Parameters<typeof api.apiListReports>[0]) => Promise<void>;
+  fetchReports: (
+    params?: Parameters<typeof api.apiListReports>[0],
+  ) => Promise<void>;
   fetchReport: (id: string) => Promise<void>;
   createReport: (body: CreateReportRequest) => Promise<ReportDefinition>;
   updateReport: (id: string, body: UpdateReportRequest) => Promise<void>;
@@ -43,17 +45,27 @@ export interface ReportsSlice {
   executionsTotal: number;
   executionsLoading: boolean;
   executionsError: string | null;
-  fetchExecutions: (params?: Parameters<typeof api.apiListExecutions>[0]) => Promise<void>;
-  executeReport: (id: string, body?: ExecuteReportRequest) => Promise<ReportExecution>;
+  fetchExecutions: (
+    params?: Parameters<typeof api.apiListExecutions>[0],
+  ) => Promise<void>;
+  executeReport: (
+    id: string,
+    body?: ExecuteReportRequest,
+  ) => Promise<ReportExecution>;
   fetchExecution: (executionId: string) => Promise<ReportExecution>;
   cancelExecution: (executionId: string) => Promise<void>;
-  pollExecutionUntilDone: (executionId: string, onProgress?: (e: ReportExecution) => void) => Promise<ReportExecution>;
+  pollExecutionUntilDone: (
+    executionId: string,
+    onProgress?: (e: ReportExecution) => void,
+  ) => Promise<ReportExecution>;
 
   schedules: ReportSchedule[];
   schedulesTotal: number;
   schedulesLoading: boolean;
   schedulesError: string | null;
-  fetchSchedules: (params?: Parameters<typeof api.apiListSchedules>[0]) => Promise<void>;
+  fetchSchedules: (
+    params?: Parameters<typeof api.apiListSchedules>[0],
+  ) => Promise<void>;
   createSchedule: (body: CreateScheduleRequest) => Promise<ReportSchedule>;
   updateSchedule: (id: string, body: CreateScheduleRequest) => Promise<void>;
   deleteSchedule: (id: string) => Promise<void>;
@@ -69,8 +81,13 @@ export interface ReportsSlice {
   widgetsLoading: boolean;
   widgetsError: string | null;
   fetchWidgets: (section?: string) => Promise<void>;
-  createWidget: (widget: Omit<DashboardWidget, 'id' | 'created_at' | 'updated_at'>) => Promise<DashboardWidget>;
-  updateWidget: (widgetId: string, widget: Partial<DashboardWidget> & { config: WidgetConfig }) => Promise<void>;
+  createWidget: (
+    widget: Omit<DashboardWidget, "id" | "created_at" | "updated_at">,
+  ) => Promise<DashboardWidget>;
+  updateWidget: (
+    widgetId: string,
+    widget: Partial<DashboardWidget> & { config: WidgetConfig },
+  ) => Promise<void>;
   deleteWidget: (widgetId: string) => Promise<void>;
 
   datasets: DatasetMetadata[];
@@ -120,7 +137,12 @@ const initialState = {
   benchmarkError: null as string | null,
 };
 
-export const useReportsStore = create<ReportsSlice>((set, get) => ({
+export const createReportsSlice: StateCreator<
+  ReportsSlice,
+  [],
+  [],
+  ReportsSlice
+> = (set, get) => ({
   ...initialState,
 
   fetchReports: async (params) => {
@@ -151,7 +173,11 @@ export const useReportsStore = create<ReportsSlice>((set, get) => ({
 
   createReport: async (body) => {
     const report = await api.apiCreateReport(body);
-    set((s) => ({ reports: [report, ...s.reports], reportsTotal: s.reportsTotal + 1, currentReport: report }));
+    set((s) => ({
+      reports: [report, ...s.reports],
+      reportsTotal: s.reportsTotal + 1,
+      currentReport: report,
+    }));
     return report;
   },
 
@@ -174,7 +200,11 @@ export const useReportsStore = create<ReportsSlice>((set, get) => ({
 
   cloneReport: async (id, name) => {
     const report = await api.apiCloneReport(id, name);
-    set((s) => ({ reports: [report, ...s.reports], reportsTotal: s.reportsTotal + 1, currentReport: report }));
+    set((s) => ({
+      reports: [report, ...s.reports],
+      reportsTotal: s.reportsTotal + 1,
+      currentReport: report,
+    }));
     return report;
   },
 
@@ -208,7 +238,10 @@ export const useReportsStore = create<ReportsSlice>((set, get) => ({
 
   executeReport: async (id, body) => {
     const execution = await api.apiExecuteReport(id, body);
-    set((s) => ({ executions: [execution, ...s.executions], executionsTotal: s.executionsTotal + 1 }));
+    set((s) => ({
+      executions: [execution, ...s.executions],
+      executionsTotal: s.executionsTotal + 1,
+    }));
     return execution;
   },
 
@@ -220,7 +253,7 @@ export const useReportsStore = create<ReportsSlice>((set, get) => ({
     await api.apiCancelExecution(executionId);
     set((s) => ({
       executions: s.executions.map((e) =>
-        e.id === executionId ? { ...e, status: 'failed' as const } : e
+        e.id === executionId ? { ...e, status: "failed" as const } : e,
       ),
     }));
   },
@@ -229,7 +262,7 @@ export const useReportsStore = create<ReportsSlice>((set, get) => ({
     const poll = async (): Promise<ReportExecution> => {
       const e = await api.apiGetExecution(executionId);
       onProgress?.(e);
-      if (e.status === 'completed' || e.status === 'failed') return e;
+      if (e.status === "completed" || e.status === "failed") return e;
       await new Promise((r) => setTimeout(r, 1500));
       return poll();
     };
@@ -257,14 +290,19 @@ export const useReportsStore = create<ReportsSlice>((set, get) => ({
 
   createSchedule: async (body) => {
     const schedule = await api.apiCreateSchedule(body);
-    set((s) => ({ schedules: [schedule, ...s.schedules], schedulesTotal: s.schedulesTotal + 1 }));
+    set((s) => ({
+      schedules: [schedule, ...s.schedules],
+      schedulesTotal: s.schedulesTotal + 1,
+    }));
     return schedule;
   },
 
   updateSchedule: async (id, body) => {
     const updated = await api.apiUpdateSchedule(id, body);
     set((s) => ({
-      schedules: s.schedules.map((sched) => (sched.id === id ? updated : sched)),
+      schedules: s.schedules.map((sched) =>
+        sched.id === id ? updated : sched,
+      ),
     }));
   },
 
@@ -279,13 +317,19 @@ export const useReportsStore = create<ReportsSlice>((set, get) => ({
   toggleSchedule: async (id, active) => {
     await api.apiToggleSchedule(id, active);
     set((s) => ({
-      schedules: s.schedules.map((sched) => (sched.id === id ? { ...sched, is_active: active } : sched)),
+      schedules: s.schedules.map((sched) =>
+        sched.id === id ? { ...sched, is_active: active } : sched,
+      ),
     }));
   },
 
   fetchDashboardSummary: async (force = false) => {
     const { dashboardSummaryCachedAt } = get();
-    if (!force && dashboardSummaryCachedAt && Date.now() - dashboardSummaryCachedAt < DASHBOARD_SUMMARY_CACHE_MS) {
+    if (
+      !force &&
+      dashboardSummaryCachedAt &&
+      Date.now() - dashboardSummaryCachedAt < DASHBOARD_SUMMARY_CACHE_MS
+    ) {
       return;
     }
     set({ dashboardSummaryLoading: true, dashboardSummaryError: null });
@@ -298,7 +342,10 @@ export const useReportsStore = create<ReportsSlice>((set, get) => ({
         dashboardSummaryCachedAt: Date.now(),
       });
     } catch (e) {
-      set({ dashboardSummaryLoading: false, dashboardSummaryError: (e as Error).message });
+      set({
+        dashboardSummaryLoading: false,
+        dashboardSummaryError: (e as Error).message,
+      });
     }
   },
 
@@ -314,7 +361,9 @@ export const useReportsStore = create<ReportsSlice>((set, get) => ({
 
   createWidget: async (widget) => {
     const created = await api.apiCreateWidget(widget);
-    set((s) => ({ widgets: [...s.widgets, created].sort((a, b) => a.position - b.position) }));
+    set((s) => ({
+      widgets: [...s.widgets, created].sort((a, b) => a.position - b.position),
+    }));
     return created;
   },
 
@@ -344,7 +393,11 @@ export const useReportsStore = create<ReportsSlice>((set, get) => ({
     set({ benchmarkLoading: true, benchmarkError: null });
     try {
       const result = await api.apiBenchmarkComparison(body);
-      set({ benchmarkResult: result, benchmarkLoading: false, benchmarkError: null });
+      set({
+        benchmarkResult: result,
+        benchmarkLoading: false,
+        benchmarkError: null,
+      });
     } catch (e) {
       set({ benchmarkLoading: false, benchmarkError: (e as Error).message });
     }
@@ -353,4 +406,4 @@ export const useReportsStore = create<ReportsSlice>((set, get) => ({
   clearBenchmark: () => set({ benchmarkResult: null, benchmarkError: null }),
 
   clearReports: () => set(initialState),
-}));
+});

--- a/project-portal/project-portal-web/src/lib/store/reports/reports.types.ts
+++ b/project-portal/project-portal-web/src/lib/store/reports/reports.types.ts
@@ -1,11 +1,15 @@
-export type ReportCategory = 'financial' | 'operational' | 'compliance' | 'custom';
-export type ReportVisibility = 'private' | 'shared' | 'public';
-export type ExportFormat = 'csv' | 'excel' | 'pdf' | 'json';
-export type DeliveryMethod = 'email' | 's3' | 'webhook';
-export type ExecutionStatus = 'pending' | 'processing' | 'completed' | 'failed';
-export type WidgetType = 'chart' | 'metric' | 'table' | 'gauge';
-export type WidgetSize = 'small' | 'medium' | 'large' | 'full';
-export type AggregateFunction = 'SUM' | 'AVG' | 'COUNT' | 'MIN' | 'MAX';
+export type ReportCategory =
+  | "financial"
+  | "operational"
+  | "compliance"
+  | "custom";
+export type ReportVisibility = "private" | "shared" | "public";
+export type ExportFormat = "csv" | "excel" | "pdf" | "json";
+export type DeliveryMethod = "email" | "s3" | "webhook";
+export type ExecutionStatus = "pending" | "processing" | "completed" | "failed";
+export type WidgetType = "chart" | "metric" | "table" | "gauge";
+export type WidgetSize = "small" | "medium" | "large" | "full";
+export type AggregateFunction = "SUM" | "AVG" | "COUNT" | "MIN" | "MAX";
 
 export interface FieldConfig {
   name: string;
@@ -22,7 +26,7 @@ export interface FilterConfig {
   field: string;
   operator: string;
   value: unknown;
-  logic?: 'AND' | 'OR';
+  logic?: "AND" | "OR";
 }
 
 export interface GroupConfig {
@@ -33,7 +37,7 @@ export interface GroupConfig {
 
 export interface SortConfig {
   field: string;
-  direction: 'asc' | 'desc';
+  direction: "asc" | "desc";
   order: number;
 }
 
@@ -174,7 +178,7 @@ export interface MetricSummary {
   change: number;
   change_percent: number;
   period: string;
-  trend: 'up' | 'down' | 'stable';
+  trend: "up" | "down" | "stable";
 }
 
 export interface TimeSeriesPoint {
@@ -227,13 +231,13 @@ export interface BenchmarkResult {
   benchmark_value: number;
   difference: number;
   difference_percent: number;
-  performance_level: 'above' | 'at' | 'below';
+  performance_level: "above" | "at" | "below";
 }
 
 export interface GapAnalysisResult {
   metric: string;
   gap: number;
-  priority: 'high' | 'medium' | 'low';
+  priority: "high" | "medium" | "low";
   recommendation: string;
 }
 

--- a/project-portal/project-portal-web/src/lib/store/store.ts
+++ b/project-portal/project-portal-web/src/lib/store/store.ts
@@ -20,6 +20,8 @@ import type { FinancingSlice } from "./financing/financing.types";
 import { createFinancingSlice } from "./financing/financingSlice";
 import type { GeospatialSlice } from "./geospatial/geospatial.types";
 import { createGeospatialSlice } from "./geospatial/geospatialSlice";
+import type { ReportsSlice } from "./reports/reports.slice";
+import { createReportsSlice } from "./reports/reports.slice";
 
 // Unified store state type
 export type StoreState = AuthSlice &
@@ -29,7 +31,8 @@ export type StoreState = AuthSlice &
   HealthSlice &
   NotificationsSlice &
   FinancingSlice &
-  GeospatialSlice;
+  GeospatialSlice &
+  ReportsSlice;
 
 // Helper to check if token is expired or about to expire (60s buffer)
 const isTokenExpiringSoon = (expiresIn: number | null): boolean => {
@@ -49,6 +52,7 @@ export const useStore = create<StoreState>()(
       ...createNotificationsSlice(...args),
       ...createFinancingSlice(...args),
       ...createGeospatialSlice(...args),
+      ...createReportsSlice(...args),
     }),
     {
       name: "project-portal-store",
@@ -78,12 +82,12 @@ export const useStore = create<StoreState>()(
             }));
           }
 
-          
           const path = window.location.pathname;
           const isAuthPage = path === "/login" || path === "/register";
           const isAuthenticated = state?.isAuthenticated === true;
           const expiresIn = state?.expiresIn ?? null;
-          const shouldRefresh = !isAuthPage && isAuthenticated && isTokenExpiringSoon(expiresIn);
+          const shouldRefresh =
+            !isAuthPage && isAuthenticated && isTokenExpiringSoon(expiresIn);
 
           if (shouldRefresh) {
             state?.refreshSession?.().catch((error: unknown) => {
@@ -101,3 +105,55 @@ export const useStore = create<StoreState>()(
   ),
 );
 
+// Re-export reports types
+export type {
+  ReportCategory,
+  ReportVisibility,
+  ExportFormat,
+  DeliveryMethod,
+  ExecutionStatus,
+  WidgetType,
+  WidgetSize,
+  AggregateFunction,
+  FieldConfig,
+  FilterConfig,
+  GroupConfig,
+  SortConfig,
+  CalculationConfig,
+  ReportConfig,
+  ReportDefinition,
+  ReportSchedule,
+  ReportExecution,
+  BenchmarkDataset,
+  DashboardWidget,
+  WidgetConfig,
+  MetricSummary,
+  TimeSeriesPoint,
+  ActivityItem,
+  DashboardSummary,
+  DatasetMetadata,
+  FieldMetadata,
+  BenchmarkResult,
+  GapAnalysisResult,
+  BenchmarkComparisonResponse,
+  CreateReportRequest,
+  UpdateReportRequest,
+  ExecuteReportRequest,
+  CreateScheduleRequest,
+  BenchmarkComparisonRequest,
+  ListReportsResponse,
+  ListExecutionsResponse,
+} from "./reports/reports.types";
+
+// Re-export reports selectors
+export {
+  selectReportById,
+  selectExecutionById,
+  selectScheduleById,
+  selectWidgetById,
+  selectReportsStatus,
+  selectDashboardSummaryWithCache,
+  selectExecutionsForReport,
+  selectSchedulesForReport,
+} from "./reports/reports.selectors";
+export type { ReportsState } from "./reports/reports.selectors";

--- a/project-portal/project-portal-web/src/store/store.ts
+++ b/project-portal/project-portal-web/src/store/store.ts
@@ -1,16 +1,15 @@
 /**
- * Unified store entry. Reports and integrations slices are registered here.
+ * Unified store entry. Integrations and notifications slices are registered here.
  * Extend with auth, projects, collaboration, search as needed.
  */
 
-export { useReportsStore } from './reportsSlice';
-export type { ReportsSlice } from './reportsSlice';
-export * from './reports.selectors';
-export * from './reports.types';
+export { useIntegrationStore } from "./integrationSlice";
+export type { IntegrationSlice } from "./integrationSlice";
+export * from "./integration.selectors";
+export * from "./integration.types";
 
-export { useIntegrationStore } from './integrationSlice';
-export type { IntegrationSlice } from './integrationSlice';
-export * from './integration.selectors';
-export * from './integration.types';
-
-export type { Notification, NotificationType, NotificationsSlice } from './notification.types';
+export type {
+  Notification,
+  NotificationType,
+  NotificationsSlice,
+} from "./notification.types";

--- a/project-portal/project-portal-web/src/test/reports.test.ts
+++ b/project-portal/project-portal-web/src/test/reports.test.ts
@@ -1,5 +1,5 @@
 // @vitest-environment node
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach } from "vitest";
 import {
   apiListReports,
   apiGetReport,
@@ -28,10 +28,10 @@ import {
   apiToggleSchedule,
   apiBenchmarkComparison,
   apiListBenchmarks,
-} from '@/store/reports.api';
-import api from '@/lib/api/apiClient';
+} from "@/lib/store/reports/reports.api";
+import api from "@/lib/api/apiClient";
 
-vi.mock('@/lib/api/apiClient', () => ({
+vi.mock("@/lib/api/apiClient", () => ({
   default: {
     request: vi.fn(),
   },
@@ -42,7 +42,7 @@ vi.mock('@/lib/api/apiClient', () => ({
 function mockFetch(body: unknown, status = 200) {
   vi.mocked(api.request).mockResolvedValue({
     status,
-    statusText: status === 200 ? 'OK' : 'Error',
+    statusText: status === 200 ? "OK" : "Error",
     data: body,
     headers: {},
     config: {},
@@ -50,10 +50,10 @@ function mockFetch(body: unknown, status = 200) {
 }
 
 function mockFetchError(message: string, status = 400) {
-  const error = new Error('Request failed');
+  const error = new Error("Request failed");
   (error as any).response = {
     status,
-    statusText: 'Bad Request',
+    statusText: "Bad Request",
     data: { error: message },
     headers: {},
     config: {},
@@ -63,7 +63,7 @@ function mockFetchError(message: string, status = 400) {
 }
 
 function mockFetchRawError(status: number, statusText: string, data: string) {
-  const error = new Error('Request failed');
+  const error = new Error("Request failed");
   (error as any).response = {
     status,
     statusText,
@@ -78,50 +78,50 @@ function mockFetchRawError(status: number, statusText: string, data: string) {
 // ─── fixtures ────────────────────────────────────────────────────────────────
 
 const REPORT = {
-  id: 'r-1',
-  name: 'Test Report',
-  description: 'desc',
-  category: 'custom' as const,
-  config: { dataset: 'projects', fields: [{ name: 'id' }] },
-  visibility: 'private' as const,
+  id: "r-1",
+  name: "Test Report",
+  description: "desc",
+  category: "custom" as const,
+  config: { dataset: "projects", fields: [{ name: "id" }] },
+  visibility: "private" as const,
   version: 1,
   is_template: false,
-  created_at: '2024-01-01T00:00:00Z',
-  updated_at: '2024-01-01T00:00:00Z',
+  created_at: "2024-01-01T00:00:00Z",
+  updated_at: "2024-01-01T00:00:00Z",
 };
 
 const EXECUTION = {
-  id: 'e-1',
-  report_definition_id: 'r-1',
-  triggered_at: '2024-01-01T00:00:00Z',
-  status: 'completed' as const,
-  created_at: '2024-01-01T00:00:00Z',
+  id: "e-1",
+  report_definition_id: "r-1",
+  triggered_at: "2024-01-01T00:00:00Z",
+  status: "completed" as const,
+  created_at: "2024-01-01T00:00:00Z",
 };
 
 const SCHEDULE = {
-  id: 's-1',
-  report_definition_id: 'r-1',
-  name: 'Daily',
-  cron_expression: '0 8 * * *',
-  timezone: 'UTC',
+  id: "s-1",
+  report_definition_id: "r-1",
+  name: "Daily",
+  cron_expression: "0 8 * * *",
+  timezone: "UTC",
   is_active: true,
-  format: 'csv' as const,
-  delivery_method: 'email' as const,
+  format: "csv" as const,
+  delivery_method: "email" as const,
   delivery_config: {},
-  created_at: '2024-01-01T00:00:00Z',
-  updated_at: '2024-01-01T00:00:00Z',
+  created_at: "2024-01-01T00:00:00Z",
+  updated_at: "2024-01-01T00:00:00Z",
 };
 
 const WIDGET = {
-  id: 'w-1',
-  widget_type: 'metric' as const,
-  title: 'Credits',
-  config: { data_source: 'dashboard_summary' },
-  size: 'medium' as const,
+  id: "w-1",
+  widget_type: "metric" as const,
+  title: "Credits",
+  config: { data_source: "dashboard_summary" },
+  size: "medium" as const,
   position: 0,
   refresh_interval_seconds: 300,
-  created_at: '2024-01-01T00:00:00Z',
-  updated_at: '2024-01-01T00:00:00Z',
+  created_at: "2024-01-01T00:00:00Z",
+  updated_at: "2024-01-01T00:00:00Z",
 };
 
 const SUMMARY = {
@@ -135,105 +135,121 @@ const SUMMARY = {
 
 // ─── tests ───────────────────────────────────────────────────────────────────
 
-describe('Reports API client', () => {
+describe("Reports API client", () => {
   beforeEach(() => {
     vi.clearAllMocks();
   });
 
   // ── Report CRUD ──────────────────────────────────────────────────────────
 
-  describe('apiListReports', () => {
-    it('returns reports list', async () => {
-      const payload = { reports: [REPORT], total: 1, page: 1, page_size: 20, total_pages: 1 };
+  describe("apiListReports", () => {
+    it("returns reports list", async () => {
+      const payload = {
+        reports: [REPORT],
+        total: 1,
+        page: 1,
+        page_size: 20,
+        total_pages: 1,
+      };
       mockFetch(payload);
       const result = await apiListReports({ page: 1, page_size: 20 });
       expect(result.reports).toHaveLength(1);
       expect(result.total).toBe(1);
       const config = vi.mocked(api.request).mock.calls[0][0];
-      expect(config.url).toContain('reports?');
+      expect(config.url).toContain("reports?");
     });
 
-    it('passes filter params in query string', async () => {
-      mockFetch({ reports: [], total: 0, page: 1, page_size: 20, total_pages: 0 });
-      await apiListReports({ category: 'financial', is_template: true, search: 'foo' });
+    it("passes filter params in query string", async () => {
+      mockFetch({
+        reports: [],
+        total: 0,
+        page: 1,
+        page_size: 20,
+        total_pages: 0,
+      });
+      await apiListReports({
+        category: "financial",
+        is_template: true,
+        search: "foo",
+      });
       const config = vi.mocked(api.request).mock.calls[0][0];
       const url = config.url as string;
-      expect(url).toContain('category=financial');
-      expect(url).toContain('is_template=true');
-      expect(url).toContain('search=foo');
+      expect(url).toContain("category=financial");
+      expect(url).toContain("is_template=true");
+      expect(url).toContain("search=foo");
     });
 
-    it('throws on API error', async () => {
-      mockFetchError('unauthorized', 401);
-      await expect(apiListReports()).rejects.toThrow('unauthorized');
+    it("throws on API error", async () => {
+      mockFetchError("unauthorized", 401);
+      await expect(apiListReports()).rejects.toThrow("unauthorized");
     });
   });
 
-  describe('apiGetReport', () => {
-    it('returns a single report', async () => {
+  describe("apiGetReport", () => {
+    it("returns a single report", async () => {
       mockFetch(REPORT);
-      const result = await apiGetReport('r-1');
-      expect(result.id).toBe('r-1');
+      const result = await apiGetReport("r-1");
+      expect(result.id).toBe("r-1");
     });
   });
 
-  describe('apiCreateReport', () => {
-    it('posts to /builder and returns created report', async () => {
+  describe("apiCreateReport", () => {
+    it("posts to /builder and returns created report", async () => {
       mockFetch(REPORT, 201);
       const result = await apiCreateReport({
-        name: 'Test Report',
-        config: { dataset: 'projects', fields: [{ name: 'id' }] },
+        name: "Test Report",
+        config: { dataset: "projects", fields: [{ name: "id" }] },
       });
-      expect(result.id).toBe('r-1');
+      expect(result.id).toBe("r-1");
       const config = vi.mocked(api.request).mock.calls[0][0];
-      expect(config.url).toContain('builder');
-      expect(config.method).toBe('POST');
+      expect(config.url).toContain("builder");
+      expect(config.method).toBe("POST");
     });
   });
 
-  describe('apiUpdateReport', () => {
-    it('puts to /:id and returns updated report', async () => {
-      mockFetch({ ...REPORT, name: 'Updated' });
-      const result = await apiUpdateReport('r-1', { name: 'Updated' });
-      expect(result.name).toBe('Updated');
+  describe("apiUpdateReport", () => {
+    it("puts to /:id and returns updated report", async () => {
+      mockFetch({ ...REPORT, name: "Updated" });
+      const result = await apiUpdateReport("r-1", { name: "Updated" });
+      expect(result.name).toBe("Updated");
       const config = vi.mocked(api.request).mock.calls[0][0];
-      expect(config.method).toBe('PUT');
+      expect(config.method).toBe("PUT");
     });
   });
 
-  describe('apiDeleteReport', () => {
-    it('sends DELETE and resolves on 204', async () => {
+  describe("apiDeleteReport", () => {
+    it("sends DELETE and resolves on 204", async () => {
       mockFetch(null, 204);
-      await expect(apiDeleteReport('r-1')).resolves.toBeUndefined();
+      await expect(apiDeleteReport("r-1")).resolves.toBeUndefined();
     });
 
-    it('throws on error', async () => {
-      mockFetchError('not found', 404);
-      await expect(apiDeleteReport('r-1')).rejects.toThrow('not found');
+    it("throws on error", async () => {
+      mockFetchError("not found", 404);
+      await expect(apiDeleteReport("r-1")).rejects.toThrow("not found");
     });
   });
 
-  describe('apiCloneReport', () => {
-    it('posts to /:id/clone', async () => {
-      mockFetch({ ...REPORT, id: 'r-2', name: 'Copy' }, 201);
-      const result = await apiCloneReport('r-1', 'Copy');
-      expect(result.id).toBe('r-2');
+  describe("apiCloneReport", () => {
+    it("posts to /:id/clone", async () => {
+      mockFetch({ ...REPORT, id: "r-2", name: "Copy" }, 201);
+      const result = await apiCloneReport("r-1", "Copy");
+      expect(result.id).toBe("r-2");
       const config = vi.mocked(api.request).mock.calls[0][0];
-      expect(config.url).toContain('r-1/clone');
+      expect(config.url).toContain("r-1/clone");
     });
   });
 
   // ── Templates ────────────────────────────────────────────────────────────
 
-  describe('apiListTemplates', () => {
-    it('returns templates array', async () => {
+  describe("apiListTemplates", () => {
+    it("returns templates array", async () => {
       mockFetch({ templates: [{ ...REPORT, is_template: true }] });
       const result = await apiListTemplates();
       expect(result).toHaveLength(1);
       expect(result[0].is_template).toBe(true);
     });
 
-    it('returns empty array when templates key missing', async () => {
+    it("returns empty array when templates key missing", async () => {
       mockFetch({});
       const result = await apiListTemplates();
       expect(result).toEqual([]);
@@ -242,70 +258,81 @@ describe('Reports API client', () => {
 
   // ── Execution ────────────────────────────────────────────────────────────
 
-  describe('apiExecuteReport', () => {
-    it('posts to /:id/execute', async () => {
+  describe("apiExecuteReport", () => {
+    it("posts to /:id/execute", async () => {
       mockFetch(EXECUTION, 202);
-      const result = await apiExecuteReport('r-1', { format: 'csv' });
-      expect(result.id).toBe('e-1');
+      const result = await apiExecuteReport("r-1", { format: "csv" });
+      expect(result.id).toBe("e-1");
       const config = vi.mocked(api.request).mock.calls[0][0];
-      expect(config.url).toContain('r-1/execute');
-      expect(config.method).toBe('POST');
+      expect(config.url).toContain("r-1/execute");
+      expect(config.method).toBe("POST");
     });
   });
 
-  describe('apiExportReport', () => {
-    it('returns execution_id for async export', async () => {
-      mockFetch({ execution_id: 'e-1', status: 'pending' }, 202);
-      const result = await apiExportReport('r-1', 'pdf');
-      expect(result.execution_id).toBe('e-1');
+  describe("apiExportReport", () => {
+    it("returns execution_id for async export", async () => {
+      mockFetch({ execution_id: "e-1", status: "pending" }, 202);
+      const result = await apiExportReport("r-1", "pdf");
+      expect(result.execution_id).toBe("e-1");
       const config = vi.mocked(api.request).mock.calls[0][0];
-      expect(config.url).toContain('format=pdf');
+      expect(config.url).toContain("format=pdf");
     });
   });
 
-  describe('apiListExecutions', () => {
-    it('returns executions list', async () => {
-      mockFetch({ executions: [EXECUTION], total: 1, page: 1, page_size: 20, total_pages: 1 });
-      const result = await apiListExecutions({ report_id: 'r-1' });
+  describe("apiListExecutions", () => {
+    it("returns executions list", async () => {
+      mockFetch({
+        executions: [EXECUTION],
+        total: 1,
+        page: 1,
+        page_size: 20,
+        total_pages: 1,
+      });
+      const result = await apiListExecutions({ report_id: "r-1" });
       expect(result.executions).toHaveLength(1);
       const config = vi.mocked(api.request).mock.calls[0][0];
-      expect(config.url).toContain('report_id=r-1');
+      expect(config.url).toContain("report_id=r-1");
     });
   });
 
-  describe('apiGetExecution', () => {
-    it('returns a single execution', async () => {
+  describe("apiGetExecution", () => {
+    it("returns a single execution", async () => {
       mockFetch(EXECUTION);
-      const result = await apiGetExecution('e-1');
-      expect(result.id).toBe('e-1');
+      const result = await apiGetExecution("e-1");
+      expect(result.id).toBe("e-1");
     });
   });
 
-  describe('apiCancelExecution', () => {
-    it('posts to /cancel', async () => {
-      mockFetch({ message: 'cancelled' });
-      await expect(apiCancelExecution('e-1')).resolves.toBeUndefined();
+  describe("apiCancelExecution", () => {
+    it("posts to /cancel", async () => {
+      mockFetch({ message: "cancelled" });
+      await expect(apiCancelExecution("e-1")).resolves.toBeUndefined();
       const config = vi.mocked(api.request).mock.calls[0][0];
-      expect(config.url).toContain('e-1/cancel');
+      expect(config.url).toContain("e-1/cancel");
     });
   });
 
   // ── Datasets ─────────────────────────────────────────────────────────────
 
-  describe('apiGetDatasets', () => {
-    it('returns datasets array', async () => {
-      const ds = { name: 'projects', display_name: 'Projects', description: '', fields: [] };
+  describe("apiGetDatasets", () => {
+    it("returns datasets array", async () => {
+      const ds = {
+        name: "projects",
+        display_name: "Projects",
+        description: "",
+        fields: [],
+      };
       mockFetch({ datasets: [ds] });
       const result = await apiGetDatasets();
       expect(result).toHaveLength(1);
-      expect(result[0].name).toBe('projects');
+      expect(result[0].name).toBe("projects");
     });
   });
 
   // ── Dashboard ────────────────────────────────────────────────────────────
 
-  describe('apiGetDashboardSummary', () => {
-    it('returns summary object', async () => {
+  describe("apiGetDashboardSummary", () => {
+    it("returns summary object", async () => {
       mockFetch(SUMMARY);
       const result = await apiGetDashboardSummary();
       expect(result.total_projects).toBe(5);
@@ -313,186 +340,207 @@ describe('Reports API client', () => {
     });
   });
 
-  describe('apiGetTimeSeriesData', () => {
-    it('passes required params and returns data', async () => {
-      const points = [{ time: '2024-01-01T00:00:00Z', value: 42 }];
+  describe("apiGetTimeSeriesData", () => {
+    it("passes required params and returns data", async () => {
+      const points = [{ time: "2024-01-01T00:00:00Z", value: 42 }];
       mockFetch({ data: points });
       const result = await apiGetTimeSeriesData({
-        metric: 'carbon_sequestered',
-        start_time: '2024-01-01T00:00:00Z',
-        end_time: '2024-12-31T00:00:00Z',
-        interval: 'month',
+        metric: "carbon_sequestered",
+        start_time: "2024-01-01T00:00:00Z",
+        end_time: "2024-12-31T00:00:00Z",
+        interval: "month",
       });
       expect(result.data).toHaveLength(1);
       const config = vi.mocked(api.request).mock.calls[0][0];
-      expect(config.url).toContain('metric=carbon_sequestered');
-      expect(config.url).toContain('interval=month');
+      expect(config.url).toContain("metric=carbon_sequestered");
+      expect(config.url).toContain("interval=month");
     });
   });
 
   // ── Widgets ──────────────────────────────────────────────────────────────
 
-  describe('apiGetWidgets', () => {
-    it('returns widgets array', async () => {
+  describe("apiGetWidgets", () => {
+    it("returns widgets array", async () => {
       mockFetch({ widgets: [WIDGET] });
       const result = await apiGetWidgets();
       expect(result).toHaveLength(1);
     });
 
-    it('passes section param', async () => {
+    it("passes section param", async () => {
       mockFetch({ widgets: [] });
-      await apiGetWidgets('main');
+      await apiGetWidgets("main");
       const config = vi.mocked(api.request).mock.calls[0][0];
-      expect(config.url).toContain('section=main');
+      expect(config.url).toContain("section=main");
     });
   });
 
-  describe('apiCreateWidget', () => {
-    it('posts widget and returns created', async () => {
+  describe("apiCreateWidget", () => {
+    it("posts widget and returns created", async () => {
       mockFetch(WIDGET, 201);
       const { id, created_at, updated_at, ...body } = WIDGET;
       const result = await apiCreateWidget(body);
-      expect(result.id).toBe('w-1');
+      expect(result.id).toBe("w-1");
     });
   });
 
-  describe('apiUpdateWidget', () => {
-    it('puts to /:widgetId', async () => {
-      mockFetch({ ...WIDGET, title: 'Updated' });
-      const result = await apiUpdateWidget('w-1', { ...WIDGET, config: WIDGET.config });
-      expect(result.title).toBe('Updated');
+  describe("apiUpdateWidget", () => {
+    it("puts to /:widgetId", async () => {
+      mockFetch({ ...WIDGET, title: "Updated" });
+      const result = await apiUpdateWidget("w-1", {
+        ...WIDGET,
+        config: WIDGET.config,
+      });
+      expect(result.title).toBe("Updated");
       const config = vi.mocked(api.request).mock.calls[0][0];
-      expect(config.url).toContain('w-1');
-      expect(config.method).toBe('PUT');
+      expect(config.url).toContain("w-1");
+      expect(config.method).toBe("PUT");
     });
   });
 
-  describe('apiDeleteWidget', () => {
-    it('sends DELETE', async () => {
+  describe("apiDeleteWidget", () => {
+    it("sends DELETE", async () => {
       mockFetch(null, 204);
-      await expect(apiDeleteWidget('w-1')).resolves.toBeUndefined();
+      await expect(apiDeleteWidget("w-1")).resolves.toBeUndefined();
     });
   });
 
   // ── Schedules ────────────────────────────────────────────────────────────
 
-  describe('apiCreateSchedule', () => {
-    it('posts to /schedules', async () => {
+  describe("apiCreateSchedule", () => {
+    it("posts to /schedules", async () => {
       mockFetch(SCHEDULE, 201);
       const result = await apiCreateSchedule({
-        report_definition_id: 'r-1',
-        name: 'Daily',
-        cron_expression: '0 8 * * *',
-        format: 'csv',
-        delivery_method: 'email',
+        report_definition_id: "r-1",
+        name: "Daily",
+        cron_expression: "0 8 * * *",
+        format: "csv",
+        delivery_method: "email",
         delivery_config: {},
       });
-      expect(result.id).toBe('s-1');
+      expect(result.id).toBe("s-1");
       const config = vi.mocked(api.request).mock.calls[0][0];
-      expect(config.url).toContain('schedules');
-      expect(config.method).toBe('POST');
+      expect(config.url).toContain("schedules");
+      expect(config.method).toBe("POST");
     });
   });
 
-  describe('apiListSchedules', () => {
-    it('returns schedules and total', async () => {
+  describe("apiListSchedules", () => {
+    it("returns schedules and total", async () => {
       mockFetch({ schedules: [SCHEDULE], total: 1 });
       const result = await apiListSchedules({ is_active: true });
       expect(result.schedules).toHaveLength(1);
       expect(result.total).toBe(1);
       const config = vi.mocked(api.request).mock.calls[0][0];
-      expect(config.url).toContain('is_active=true');
+      expect(config.url).toContain("is_active=true");
     });
   });
 
-  describe('apiGetSchedule', () => {
-    it('returns a single schedule', async () => {
+  describe("apiGetSchedule", () => {
+    it("returns a single schedule", async () => {
       mockFetch(SCHEDULE);
-      const result = await apiGetSchedule('s-1');
-      expect(result.id).toBe('s-1');
+      const result = await apiGetSchedule("s-1");
+      expect(result.id).toBe("s-1");
     });
   });
 
-  describe('apiUpdateSchedule', () => {
-    it('puts to /:scheduleId', async () => {
-      mockFetch({ ...SCHEDULE, name: 'Weekly' });
-      const result = await apiUpdateSchedule('s-1', {
-        report_definition_id: 'r-1',
-        name: 'Weekly',
-        cron_expression: '0 9 * * 1',
-        format: 'csv',
-        delivery_method: 'email',
+  describe("apiUpdateSchedule", () => {
+    it("puts to /:scheduleId", async () => {
+      mockFetch({ ...SCHEDULE, name: "Weekly" });
+      const result = await apiUpdateSchedule("s-1", {
+        report_definition_id: "r-1",
+        name: "Weekly",
+        cron_expression: "0 9 * * 1",
+        format: "csv",
+        delivery_method: "email",
         delivery_config: {},
       });
-      expect(result.name).toBe('Weekly');
+      expect(result.name).toBe("Weekly");
     });
   });
 
-  describe('apiDeleteSchedule', () => {
-    it('sends DELETE', async () => {
+  describe("apiDeleteSchedule", () => {
+    it("sends DELETE", async () => {
       mockFetch(null, 204);
-      await expect(apiDeleteSchedule('s-1')).resolves.toBeUndefined();
+      await expect(apiDeleteSchedule("s-1")).resolves.toBeUndefined();
     });
   });
 
-  describe('apiToggleSchedule', () => {
-    it('posts to /:scheduleId/toggle', async () => {
-      mockFetch({ message: 'schedule updated', active: false });
-      const result = await apiToggleSchedule('s-1', false);
+  describe("apiToggleSchedule", () => {
+    it("posts to /:scheduleId/toggle", async () => {
+      mockFetch({ message: "schedule updated", active: false });
+      const result = await apiToggleSchedule("s-1", false);
       expect(result.active).toBe(false);
       const config = vi.mocked(api.request).mock.calls[0][0];
-      expect(config.url).toContain('s-1/toggle');
-      expect(config.method).toBe('POST');
+      expect(config.url).toContain("s-1/toggle");
+      expect(config.method).toBe("POST");
       expect(config.data).toEqual({ active: false });
     });
   });
 
   // ── Benchmarks ───────────────────────────────────────────────────────────
 
-  describe('apiBenchmarkComparison', () => {
-    it('posts to /benchmark/comparison', async () => {
+  describe("apiBenchmarkComparison", () => {
+    it("posts to /benchmark/comparison", async () => {
       const response = {
-        project_id: 'p-1',
+        project_id: "p-1",
         project_metrics: {},
         benchmarks: [],
         percentile_rank: {},
         gap_analysis: [],
       };
       mockFetch(response);
-      const result = await apiBenchmarkComparison({ project_id: 'p-1', category: 'carbon' });
-      expect(result.project_id).toBe('p-1');
+      const result = await apiBenchmarkComparison({
+        project_id: "p-1",
+        category: "carbon",
+      });
+      expect(result.project_id).toBe("p-1");
       const config = vi.mocked(api.request).mock.calls[0][0];
-      expect(config.url).toContain('benchmark/comparison');
+      expect(config.url).toContain("benchmark/comparison");
     });
   });
 
-  describe('apiListBenchmarks', () => {
-    it('returns benchmarks array', async () => {
-      const bm = { id: 'b-1', name: 'BM', category: 'carbon', data: {}, year: 2024, is_active: true, created_at: '', updated_at: '' };
+  describe("apiListBenchmarks", () => {
+    it("returns benchmarks array", async () => {
+      const bm = {
+        id: "b-1",
+        name: "BM",
+        category: "carbon",
+        data: {},
+        year: 2024,
+        is_active: true,
+        created_at: "",
+        updated_at: "",
+      };
       mockFetch({ benchmarks: [bm] });
-      const result = await apiListBenchmarks({ category: 'carbon' });
+      const result = await apiListBenchmarks({ category: "carbon" });
       expect(result).toHaveLength(1);
       const config = vi.mocked(api.request).mock.calls[0][0];
-      expect(config.url).toContain('category=carbon');
+      expect(config.url).toContain("category=carbon");
     });
   });
 
   // ── Error handling ───────────────────────────────────────────────────────
 
-  describe('error handling', () => {
-    it('throws with error message from JSON body', async () => {
-      mockFetchError('report not found', 404);
-      await expect(apiGetReport('bad-id')).rejects.toThrow('report not found');
+  describe("error handling", () => {
+    it("throws with error message from JSON body", async () => {
+      mockFetchError("report not found", 404);
+      await expect(apiGetReport("bad-id")).rejects.toThrow("report not found");
     });
 
-    it('throws with statusText when body is not JSON', async () => {
-      mockFetchRawError(500, 'Internal Server Error', '');
-      await expect(apiGetReport('r-1')).rejects.toThrow('Internal Server Error');
+    it("throws with statusText when body is not JSON", async () => {
+      mockFetchRawError(500, "Internal Server Error", "");
+      await expect(apiGetReport("r-1")).rejects.toThrow(
+        "Internal Server Error",
+      );
     });
 
-    it('does not expose HTML error pages as error message', async () => {
-      mockFetchRawError(502, 'Bad Gateway', '<!DOCTYPE html><html><body><h1>502 Bad Gateway</h1></body></html>');
-      await expect(apiGetReport('r-1')).rejects.toThrow('Bad Gateway');
+    it("does not expose HTML error pages as error message", async () => {
+      mockFetchRawError(
+        502,
+        "Bad Gateway",
+        "<!DOCTYPE html><html><body><h1>502 Bad Gateway</h1></body></html>",
+      );
+      await expect(apiGetReport("r-1")).rejects.toThrow("Bad Gateway");
     });
   });
 });


### PR DESCRIPTION
Summary:
Resolves #424. Unifies the separate `useReportsStore` instance with the primary `useStore` instance defined in `lib/store/store.ts`. This eliminates duplicate React contexts, prevents potential state synchronization issues, and establishes a consistent state management pattern across the portal.
I successfully migrated the standalone reports store from store/ into the unified main store at lib/store/. All reports state is now managed by the single useStore instance.

Files Created:

- lib/store/reports/reports.types.ts - All report type definitions (moved from store/reports.types.ts)
- lib/store/reports/reports.api.ts - Reports API client (moved from store/reports.api.ts)
- lib/store/reports/reports.selectors.ts - Reports selectors (moved from store/reports.selectors.ts)
- lib/store/reports/reports.slice.ts - Reports slice using StateCreator pattern (converted from standalone create() call)

Files Modified:

- lib/store/store.ts - Integrated createReportsSlice, added ReportsSlice to StoreState, added re-exports for all reports types and selectors
- app/(portal)/reports/page.tsx - Changed import from useReportsStore → useStore, types from @/store/reports.types → @/lib/store/store
- components/reports/ReportsList.tsx - Import useStore from @/lib/store/store
- components/reports/ReportBuilder.tsx - Import useStore from @/lib/store/store
- components/reports/ExecutionHistory.tsx - Import useStore from @/lib/store/store
- components/reports/DashboardGrid.tsx - Import useStore from @/lib/store/store
- components/reports/DatasetExplorer.tsx - Import useStore from @/lib/store/store
- components/reports/ScheduleForm.tsx - Import useStore from @/lib/store/store
- components/reports/BenchmarkComparison.tsx - Import useStore from @/lib/store/store
- components/reports/widgets/ChartWidget.tsx - Import useStore from @/lib/store/store
- components/reports/widgets/MetricWidget.tsx - Import useStore from @/lib/store/store
- components/reports/widgets/TableWidget.tsx - Import useStore from @/lib/store/store
- components/reports/widgets/GaugeWidget.tsx - Import useStore from @/lib/store/store
- app/(portal)/analytics/page.tsx - Import useStore from @/lib/store/store, API from @/lib/store/reports/reports.api
- test/reports.test.ts - Import API functions from @/lib/store/reports/reports.api
- store/store.ts - Removed reports re-exports (only integration/notification exports remain)

Files Deleted:

- store/reportsSlice.ts
- store/reports.types.ts
- store/reports.selectors.ts
- store/reports.api.ts

Architecture:

- All reports state is now part of the unified useStore Zustand instance
- The createReportsSlice uses the StateCreator pattern matching all other slices
- Reports types and selectors are re-exported from lib/store/store.ts
- No more duplicate or conflicting state management

Closes #424 