### PR TITLE
Implement stale-while-revalidate cache for project list

### DIFF
--- a/project-portal/project-portal-web/src/app/(portal)/projects/page.tsx
+++ b/project-portal/project-portal-web/src/app/(portal)/projects/page.tsx
@@ -28,6 +28,7 @@ const STATUSES = ['All', 'active', 'completed', 'pending'];
 export default function ProjectsPage() {
   const router = useRouter();
   const fetchProjects = useStore((state) => state.fetchProjects);
+  const refreshProjects = useStore((state) => state.refreshProjects);
   const loading = useStore((state) => state.loading);
   const errors = useStore((state) => state.errors);
   const filters = useStore((state) => state.filters);
@@ -76,16 +77,30 @@ export default function ProjectsPage() {
       <div className="bg-linear-to-r from-emerald-500 to-teal-600 rounded-2xl p-6 text-white">
         <div className="flex flex-col md:flex-row md:items-center justify-between">
           <div>
-            <h1 className="text-2xl md:text-3xl font-bold mb-2">Project Portfolio</h1>
+            <h1 className="text-2xl md:text-3xl font-bold mb-2 flex items-center gap-2">
+              Project Portfolio
+              {loading.isRefreshing && (
+                <Loader2 className="w-5 h-5 animate-spin" aria-label="Refreshing projects" />
+              )}
+            </h1>
             <p className="text-emerald-100">Manage all your regenerative agriculture projects in one place</p>
           </div>
-          <button
-            onClick={() => setShowCreateModal(true)}
-            className="mt-4 md:mt-0 px-6 py-3 bg-white text-emerald-700 rounded-xl font-semibold hover:bg-gray-100 transition-colors flex items-center"
-          >
-            <span>+ New Project</span>
-            <ChevronRight className="w-5 h-5 ml-2" />
-          </button>
+          <div className="flex items-center gap-3 mt-4 md:mt-0">
+            <button
+              onClick={() => refreshProjects()}
+              disabled={loading.isFetching}
+              className="px-4 py-3 bg-white/10 text-white rounded-xl font-semibold hover:bg-white/20 transition-colors flex items-center disabled:opacity-50 disabled:cursor-not-allowed"
+            >
+              <span>Refresh</span>
+            </button>
+            <button
+              onClick={() => setShowCreateModal(true)}
+              className="px-6 py-3 bg-white text-emerald-700 rounded-xl font-semibold hover:bg-gray-100 transition-colors flex items-center"
+            >
+              <span>+ New Project</span>
+              <ChevronRight className="w-5 h-5 ml-2" />
+            </button>
+          </div>
         </div>
       </div>
 

--- a/project-portal/project-portal-web/src/components/projects/ActiveProjectsGrid.tsx
+++ b/project-portal/project-portal-web/src/components/projects/ActiveProjectsGrid.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { useState } from 'react';
-import { MapPin, Calendar, Target, Users, ArrowUpRight, AlertCircle, FolderOpen } from 'lucide-react';
+import { MapPin, Calendar, Target, Users, ArrowUpRight, AlertCircle, FolderOpen, Loader2 } from 'lucide-react';
 import { useStore } from '@/lib/store/store';
 import ProjectLoadingSkeleton from './ProjectLoadingSkeleton';
 import CreateProjectModal from './CreateProjectModal';
@@ -66,7 +66,12 @@ const ActiveProjectsGrid = () => {
     <>
       <div className="bg-white rounded-2xl shadow-lg border border-gray-100 p-6">
         <div className="flex items-center justify-between mb-6">
-          <h2 className="text-xl font-bold text-gray-900">Active Projects</h2>
+          <div className="flex items-center gap-2">
+            <h2 className="text-xl font-bold text-gray-900">Active Projects</h2>
+            {loading.isRefreshing && (
+              <Loader2 className="w-4 h-4 text-emerald-500 animate-spin" aria-label="Refreshing projects" />
+            )}
+          </div>
           <Button onClick={() => setShowCreateModal(true)} variant="primary">
             New Project
             <ArrowUpRight className="w-4 h-4" />

--- a/project-portal/project-portal-web/src/lib/store/projects/projects.cache.ts
+++ b/project-portal/project-portal-web/src/lib/store/projects/projects.cache.ts
@@ -1,0 +1,28 @@
+import type { Project } from './projects.types';
+
+// Configurable TTL for the stale-while-revalidate cache.
+export const PROJECTS_CACHE_TTL_MS = 5 * 60 * 1000; // 5 minutes
+
+export interface ProjectsCacheEntry {
+  projects: Project[];
+  fetchedAt: number;
+}
+
+export type ProjectsCache = Record<string, ProjectsCacheEntry>;
+
+/**
+ * Cache is keyed by limit/offset only. Status/type/search filters are
+ * applied client-side (see projects.selectors.ts) and never hit the API,
+ * so they don't need to participate in the cache key.
+ */
+export function makeProjectsCacheKey(limit: number, offset: number): string {
+  return `${limit}:${offset}`;
+}
+
+export function isCacheEntryStale(
+  entry: ProjectsCacheEntry | undefined,
+  ttlMs: number = PROJECTS_CACHE_TTL_MS
+): boolean {
+  if (!entry) return true;
+  return Date.now() - entry.fetchedAt > ttlMs;
+}

--- a/project-portal/project-portal-web/src/lib/store/projects/projects.types.ts
+++ b/project-portal/project-portal-web/src/lib/store/projects/projects.types.ts
@@ -66,6 +66,7 @@ export interface ProjectStats {
 
 export interface ProjectsLoadingState {
   isFetching: boolean;
+  isRefreshing: boolean; // background SWR refresh — never blocks the UI
   isCreating: boolean;
   isUpdating: boolean;
   isDeleting: boolean;
@@ -86,9 +87,23 @@ export interface ProjectsSlice {
   errors: ProjectsErrorState;
   pagination: PaginationState;
   filters: ProjectFilters;
+  projectsCache: Record<string, { projects: Project[]; fetchedAt: number }>;
+  lastFetchedAt: number | null;
 
   // CRUD Actions
-  fetchProjects: (limit?: number, offset?: number) => Promise<void>;
+  fetchProjects: (
+    limit?: number,
+    offset?: number,
+    options?: { force?: boolean }
+  ) => Promise<void>;
+  refreshProjects: () => Promise<void>;
+  invalidateProjectsCache: () => void;
+  /** @internal used by fetchProjects to refresh stale cache entries without blocking the UI */
+  _refreshProjectsInBackground: (
+    limit: number,
+    offset: number,
+    key: string
+  ) => Promise<void>;
   fetchProjectById: (id: string) => Promise<void>;
   createProject: (data: ProjectCreateRequest) => Promise<Project | null>;
   updateProject: (id: string, data: ProjectUpdateRequest) => Promise<Project | null>;

--- a/project-portal/project-portal-web/src/lib/store/projects/projectsSlice.test.ts
+++ b/project-portal/project-portal-web/src/lib/store/projects/projectsSlice.test.ts
@@ -1,0 +1,160 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { createProjectsSlice } from "./projectsSlice";
+import type { ProjectsSlice, Project } from "./projects.types";
+import * as api from "./projects.api";
+
+vi.mock("./projects.api", () => ({
+  fetchProjectsApi: vi.fn(),
+  fetchProjectByIdApi: vi.fn(),
+  createProjectApi: vi.fn(),
+  updateProjectApi: vi.fn(),
+  deleteProjectApi: vi.fn(),
+}));
+
+vi.mock("@/lib/utils/toast", () => ({
+  showSuccessToast: vi.fn(),
+  showErrorToast: vi.fn(),
+}));
+
+const mockApi = vi.mocked(api);
+
+const makeProject = (overrides: Partial<Project> = {}): Project => ({
+  id: "p1",
+  name: "Test Project",
+  type: "Reforestation",
+  location: "Kenya",
+  area: 10,
+  start_date: "2024-01-01",
+  farmers: 5,
+  carbon_credits: 100,
+  progress: 50,
+  icon: "🌱",
+  status: "active",
+  created_at: "2024-01-01",
+  updated_at: "2024-01-01",
+  ...overrides,
+});
+
+describe("ProjectsSlice - stale-while-revalidate", () => {
+  let slice: ProjectsSlice;
+  let mockSet: any;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockSet = vi.fn((update) => {
+      if (typeof update === "function") {
+        const next = update(slice);
+        Object.assign(slice, next);
+      } else {
+        Object.assign(slice, update);
+      }
+    });
+    slice = createProjectsSlice(mockSet, () => slice, {} as any);
+  });
+
+  it("cache miss: fetches from the API and populates the cache", async () => {
+    mockApi.fetchProjectsApi.mockResolvedValue({ projects: [makeProject()] });
+
+    await slice.fetchProjects(10, 0);
+
+    expect(mockApi.fetchProjectsApi).toHaveBeenCalledTimes(1);
+    expect(slice.projects).toHaveLength(1);
+    expect(slice.projectsCache["10:0"]).toBeDefined();
+    expect(slice.lastFetchedAt).not.toBeNull();
+    expect(slice.loading.isFetching).toBe(false);
+  });
+
+  it("cache hit: serves cached data without calling the API or blocking the UI", async () => {
+    const cachedProject = makeProject({ id: "cached-1" });
+    slice.projectsCache = {
+      "10:0": { projects: [cachedProject], fetchedAt: Date.now() },
+    };
+
+    await slice.fetchProjects(10, 0);
+
+    expect(mockApi.fetchProjectsApi).not.toHaveBeenCalled();
+    expect(slice.projects[0].id).toBe("cached-1");
+    expect(slice.loading.isFetching).toBe(false);
+  });
+
+  it("stale cache: serves cached data immediately, then refreshes in the background", async () => {
+    const staleProject = makeProject({ id: "stale-1" });
+    const freshProject = makeProject({ id: "fresh-1" });
+    const staleTimestamp = Date.now() - 6 * 60 * 1000; // older than the 5-minute TTL
+
+    slice.projectsCache = {
+      "10:0": { projects: [staleProject], fetchedAt: staleTimestamp },
+    };
+
+    let resolveApiCall!: (value: { projects: Project[] }) => void;
+    const apiPromise = new Promise<{ projects: Project[] }>((resolve) => {
+      resolveApiCall = resolve;
+    });
+    mockApi.fetchProjectsApi.mockReturnValue(apiPromise as any);
+
+    await slice.fetchProjects(10, 0);
+
+    expect(slice.projects[0].id).toBe("stale-1");
+    expect(slice.loading.isFetching).toBe(false);
+    expect(slice.loading.isRefreshing).toBe(true);
+
+    resolveApiCall({ projects: [freshProject] });
+    await apiPromise;
+    await Promise.resolve();
+
+    expect(slice.projects[0].id).toBe("fresh-1");
+    expect(slice.loading.isRefreshing).toBe(false);
+    expect(slice.projectsCache["10:0"].projects[0].id).toBe("fresh-1");
+  });
+
+  it("manual refresh: forces a full reload with loading state even when cache is fresh", async () => {
+    const cachedProject = makeProject({ id: "cached-1" });
+    const freshProject = makeProject({ id: "fresh-1" });
+    slice.projectsCache = {
+      "10:0": { projects: [cachedProject], fetchedAt: Date.now() },
+    };
+    slice.pagination = { limit: 10, offset: 0, total: 1 };
+    mockApi.fetchProjectsApi.mockResolvedValue({ projects: [freshProject] });
+
+    await slice.refreshProjects();
+
+    expect(mockApi.fetchProjectsApi).toHaveBeenCalledWith(10, 0);
+    expect(slice.projects[0].id).toBe("fresh-1");
+  });
+
+  it("invalidates the cache after creating a project", async () => {
+    slice.projectsCache = {
+      "10:0": { projects: [makeProject()], fetchedAt: Date.now() },
+    };
+    mockApi.createProjectApi.mockResolvedValue(makeProject({ id: "new-1" }));
+
+    await slice.createProject({ name: "New", type: "Reforestation", location: "Kenya", area: 5 });
+
+    expect(slice.projectsCache).toEqual({});
+    expect(slice.lastFetchedAt).toBeNull();
+  });
+
+  it("invalidates the cache after updating a project", async () => {
+    slice.projects = [makeProject({ id: "p1" })];
+    slice.projectsCache = {
+      "10:0": { projects: [makeProject({ id: "p1" })], fetchedAt: Date.now() },
+    };
+    mockApi.updateProjectApi.mockResolvedValue(makeProject({ id: "p1", name: "Updated" }));
+
+    await slice.updateProject("p1", { name: "Updated" });
+
+    expect(slice.projectsCache).toEqual({});
+  });
+
+  it("invalidates the cache after deleting a project", async () => {
+    slice.projects = [makeProject({ id: "p1" })];
+    slice.projectsCache = {
+      "10:0": { projects: [makeProject({ id: "p1" })], fetchedAt: Date.now() },
+    };
+    mockApi.deleteProjectApi.mockResolvedValue(undefined as any);
+
+    await slice.deleteProject("p1");
+
+    expect(slice.projectsCache).toEqual({});
+  });
+});

--- a/project-portal/project-portal-web/src/lib/store/projects/projectsSlice.ts
+++ b/project-portal/project-portal-web/src/lib/store/projects/projectsSlice.ts
@@ -9,12 +9,14 @@ import {
 } from './projects.api';
 import { getErrorMessage } from '@/lib/utils/errorMessage';
 import { showSuccessToast, showErrorToast } from '@/lib/utils/toast';
+import { makeProjectsCacheKey, isCacheEntryStale } from './projects.cache';
 
 const initialState = {
   projects: [] as Project[],
   selectedProject: null as Project | null,
   loading: {
     isFetching: false,
+    isRefreshing: false,
     isCreating: false,
     isUpdating: false,
     isDeleting: false,
@@ -35,16 +37,35 @@ const initialState = {
     type: 'All',
     search: '',
   },
+  projectsCache: {} as Record<string, { projects: Project[]; fetchedAt: number }>,
+  lastFetchedAt: null as number | null,
 };
 
 export const createProjectsSlice: StateCreator<ProjectsSlice> = (set, get) => ({
   ...initialState,
 
-  // ── Fetch all projects (paginated) ──
-  fetchProjects: async (limit?: number, offset?: number) => {
+  // Fetch all projects (paginated, stale-while-revalidate)
+  fetchProjects: async (limit?: number, offset?: number, options?: { force?: boolean }) => {
     const pag = get().pagination;
     const fetchLimit = limit ?? pag.limit;
     const fetchOffset = offset ?? pag.offset;
+    const force = options?.force ?? false;
+    const key = makeProjectsCacheKey(fetchLimit, fetchOffset);
+    const cached = get().projectsCache[key];
+
+    if (cached && !force) {
+      set((state) => ({
+        projects: cached.projects,
+        pagination: { limit: fetchLimit, offset: fetchOffset, total: cached.projects.length },
+        lastFetchedAt: cached.fetchedAt,
+        errors: { ...state.errors, fetch: null },
+      }));
+
+      if (isCacheEntryStale(cached)) {
+        void get()._refreshProjectsInBackground(fetchLimit, fetchOffset, key);
+      }
+      return;
+    }
 
     set((state) => ({
       loading: { ...state.loading, isFetching: true },
@@ -53,24 +74,53 @@ export const createProjectsSlice: StateCreator<ProjectsSlice> = (set, get) => ({
 
     try {
       const { projects } = await fetchProjectsApi(fetchLimit, fetchOffset);
-      set({
+      const fetchedAt = Date.now();
+      set((state) => ({
         projects,
-        pagination: {
-          limit: fetchLimit,
-          offset: fetchOffset,
-          total: projects.length, // Backend doesn't return total count yet
-        },
-        loading: { ...get().loading, isFetching: false },
-      });
+        pagination: { limit: fetchLimit, offset: fetchOffset, total: projects.length },
+        lastFetchedAt: fetchedAt,
+        projectsCache: { ...state.projectsCache, [key]: { projects, fetchedAt } },
+        loading: { ...state.loading, isFetching: false },
+      }));
     } catch (error: unknown) {
-      set({
-        loading: { ...get().loading, isFetching: false },
-        errors: { ...get().errors, fetch: getErrorMessage(error) },
-      });
+      set((state) => ({
+        loading: { ...state.loading, isFetching: false },
+        errors: { ...state.errors, fetch: getErrorMessage(error) },
+      }));
     }
   },
 
-  // ── Fetch single project by ID ──
+  // Background refresh for stale cache entries (no skeleton)
+  _refreshProjectsInBackground: async (limit: number, offset: number, key: string) => {
+    set((state) => ({ loading: { ...state.loading, isRefreshing: true } }));
+
+    try {
+      const { projects } = await fetchProjectsApi(limit, offset);
+      const fetchedAt = Date.now();
+      const pag = get().pagination;
+      const isCurrentPage = pag.limit === limit && pag.offset === offset;
+
+      set((state) => ({
+        projectsCache: { ...state.projectsCache, [key]: { projects, fetchedAt } },
+        ...(isCurrentPage ? { projects, lastFetchedAt: fetchedAt } : {}),
+        loading: { ...state.loading, isRefreshing: false },
+      }));
+    } catch {
+      set((state) => ({ loading: { ...state.loading, isRefreshing: false } }));
+    }
+  },
+
+  // Manual refresh: always a full reload with loading state
+  refreshProjects: async () => {
+    const pag = get().pagination;
+    await get().fetchProjects(pag.limit, pag.offset, { force: true });
+  },
+
+  invalidateProjectsCache: () => {
+    set({ projectsCache: {}, lastFetchedAt: null });
+  },
+
+  // Fetch single project by ID
   fetchProjectById: async (id: string) => {
     set((state) => ({
       loading: { ...state.loading, isFetching: true },
@@ -79,19 +129,19 @@ export const createProjectsSlice: StateCreator<ProjectsSlice> = (set, get) => ({
 
     try {
       const project = await fetchProjectByIdApi(id);
-      set({
+      set((state) => ({
         selectedProject: project,
-        loading: { ...get().loading, isFetching: false },
-      });
+        loading: { ...state.loading, isFetching: false },
+      }));
     } catch (error: unknown) {
-      set({
-        loading: { ...get().loading, isFetching: false },
-        errors: { ...get().errors, fetch: getErrorMessage(error) },
-      });
+      set((state) => ({
+        loading: { ...state.loading, isFetching: false },
+        errors: { ...state.errors, fetch: getErrorMessage(error) },
+      }));
     }
   },
 
-  // ── Create project ──
+  // Create project
   createProject: async (data) => {
     set((state) => ({
       loading: { ...state.loading, isCreating: true },
@@ -104,29 +154,28 @@ export const createProjectsSlice: StateCreator<ProjectsSlice> = (set, get) => ({
         projects: [newProject, ...state.projects],
         loading: { ...state.loading, isCreating: false },
       }));
-      
-      // Show success toast
+      get().invalidateProjectsCache();
+
       showSuccessToast('Project created successfully', {
         description: data.name ? `"${data.name}" has been created` : undefined,
       });
-      
+
       return newProject;
     } catch (error: unknown) {
-      set({
-        loading: { ...get().loading, isCreating: false },
-        errors: { ...get().errors, create: getErrorMessage(error) },
-      });
-      
-      // Show error toast
+      set((state) => ({
+        loading: { ...state.loading, isCreating: false },
+        errors: { ...state.errors, create: getErrorMessage(error) },
+      }));
+
       showErrorToast('Failed to create project', {
         description: 'Please check your input and try again.',
       });
-      
+
       return null;
     }
   },
 
-  // ── Update project ──
+  // Update project
   updateProject: async (id, data) => {
     set((state) => ({
       loading: { ...state.loading, isUpdating: true },
@@ -136,36 +185,33 @@ export const createProjectsSlice: StateCreator<ProjectsSlice> = (set, get) => ({
     try {
       const updatedProject = await updateProjectApi(id, data);
       set((state) => ({
-        projects: state.projects.map((p) =>
-          p.id === id ? updatedProject : p
-        ),
+        projects: state.projects.map((p) => (p.id === id ? updatedProject : p)),
         selectedProject:
           state.selectedProject?.id === id ? updatedProject : state.selectedProject,
         loading: { ...state.loading, isUpdating: false },
       }));
-      
-      // Show success toast
+      get().invalidateProjectsCache();
+
       showSuccessToast('Project updated successfully', {
         description: data.name ? `"${data.name}" has been updated` : undefined,
       });
-      
+
       return updatedProject;
     } catch (error: unknown) {
-      set({
-        loading: { ...get().loading, isUpdating: false },
-        errors: { ...get().errors, update: getErrorMessage(error) },
-      });
-      
-      // Show error toast
+      set((state) => ({
+        loading: { ...state.loading, isUpdating: false },
+        errors: { ...state.errors, update: getErrorMessage(error) },
+      }));
+
       showErrorToast('Failed to update project', {
         description: 'Please try again or contact support.',
       });
-      
+
       return null;
     }
   },
 
-  // ── Delete project ──
+  // Delete project
   deleteProject: async (id) => {
     set((state) => ({
       loading: { ...state.loading, isDeleting: true },
@@ -176,31 +222,29 @@ export const createProjectsSlice: StateCreator<ProjectsSlice> = (set, get) => ({
       await deleteProjectApi(id);
       set((state) => ({
         projects: state.projects.filter((p) => p.id !== id),
-        selectedProject:
-          state.selectedProject?.id === id ? null : state.selectedProject,
+        selectedProject: state.selectedProject?.id === id ? null : state.selectedProject,
         loading: { ...state.loading, isDeleting: false },
       }));
-      
-      // Show success toast
+      get().invalidateProjectsCache();
+
       showSuccessToast('Project deleted successfully');
-      
+
       return true;
     } catch (error: unknown) {
-      set({
-        loading: { ...get().loading, isDeleting: false },
-        errors: { ...get().errors, delete: getErrorMessage(error) },
-      });
-      
-      // Show error toast
+      set((state) => ({
+        loading: { ...state.loading, isDeleting: false },
+        errors: { ...state.errors, delete: getErrorMessage(error) },
+      }));
+
       showErrorToast('Failed to delete project', {
         description: 'Please try again or contact support.',
       });
-      
+
       return false;
     }
   },
 
-  // ── UI State Actions ──
+  // UI State Actions
   setSelectedProject: (project) => set({ selectedProject: project }),
   clearSelectedProject: () => set({ selectedProject: null }),
 

--- a/project-portal/project-portal-web/src/test/DeveloperProjectFinancingPage.test.tsx
+++ b/project-portal/project-portal-web/src/test/DeveloperProjectFinancingPage.test.tsx
@@ -52,10 +52,11 @@ const defaultStoreState = {
   // Projects slice
   selectedProject: null,
   loading: {
-    isFetching: false,
-    isCreating: false,
-    isUpdating: false,
-    isDeleting: false,
+      isFetching: false,
+      isRefreshing: false,
+      isCreating: false,
+      isUpdating: false,
+      isDeleting: false,
   },
   errors: {
     fetch: null,


### PR DESCRIPTION
## Summary

Implements stale-while-revalidate (SWR) caching for the project list to avoid unnecessary API calls and blocking UI refreshes.

- Cache is keyed by `${limit}:${offset}`. Filters (`status`, `type`, `search`) are applied client-side via `useFilteredProjects` and never hit the API, so they're intentionally excluded from the cache key.
- TTL is 5 minutes (`PROJECTS_CACHE_TTL_MS`).
- On a cache hit within TTL, cached data is served immediately with no API call.
- On a stale cache hit (past TTL), cached data is served immediately while a background refresh runs — surfaced via the new `loading.isRefreshing` flag, which never blocks the UI (distinct from `loading.isFetching`, which still means "cold fetch, show skeleton").
- A manual `refreshProjects()` action forces a full reload with loading state even when the cache is fresh.
- Cache invalidates fully (`projectsCache = {}`) on create/update/delete.

### UI changes
- Spinner next to "Active Projects" heading (`ActiveProjectsGrid.tsx`) and "Project Portfolio" title (`projects/page.tsx`), shown when `loading.isRefreshing`.
- New "Refresh" button next to "+ New Project" on the projects page, calls `refreshProjects()`, disabled while `loading.isFetching`.

### Testing
- 7 new Vitest tests in `projectsSlice.test.ts` covering cache miss, cache hit, stale cache → background refresh, manual refresh, and invalidation on create/update/delete. All passing.
- Full test suite passing (173/173).
- Updated `DeveloperProjectFinancingPage.test.tsx` mock to include `isRefreshing: false` in `defaultStoreState.loading`, required by the type change.

## Pre-existing issues (unrelated to this PR)

Confirmed via `git stash` that both of these exist on the base branch independent of this work:

- **TypeScript error**: `src/components/monitoring/metrics/MetricsTimeSeries.tsx:42` — `Date` overload mismatch (`ReactNode` not assignable to `string | number | Date`). This causes `npm run build` to fail on `main` as well as on this branch.
- **`npm audit`**: 3 high-severity vulnerabilities and deprecation warnings (`xss-clean`, `critters`) — dependency issues, not introduced here.

Neither is addressed in this PR; flagging per the Definition of Done.

Closes #427 