### PR TITLE
feat(web): add metrics CSV export, dataset pagination, and project ge…

### DIFF
--- a/project-portal/project-portal-web/src/app/(portal)/monitoring/page.tsx
+++ b/project-portal/project-portal-web/src/app/(portal)/monitoring/page.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import React, { useEffect } from 'react';
+import React, { useEffect, useRef } from 'react';
 import { useStore } from '@/lib/store/store';
 
 // Dashboard
@@ -113,6 +113,7 @@ export default function SystemHealthDashboard() {
   const fetchUptimeStats = useStore(state => state.fetchUptimeStats);
   const clearHealthData = useStore(state => state.clearHealthData);
   const isAuthenticated = useStore(state => state.isAuthenticated);
+  const chartContainerRef = useRef<HTMLDivElement>(null);
 
   // Derive loading state from health store slice
   const statusLoading = useStore(state => state.healthLoading?.isFetchingStatus ?? false);
@@ -227,11 +228,11 @@ export default function SystemHealthDashboard() {
                 <div className="flex flex-wrap items-center gap-3">
                   <MetricSelector />
                   <ChartControls />
-                  <ChartExport />
+                  <ChartExport chartRef={chartContainerRef} />
                 </div>
               )}
             </div>
-            {metricsLoading ? <ChartSkeleton /> : <MetricsTimeSeries />}
+            {metricsLoading ? <ChartSkeleton /> : <MetricsTimeSeries chartRef={chartContainerRef} />}
           </section>
 
           <section aria-label="Service Topology" aria-busy={servicesLoading}>

--- a/project-portal/project-portal-web/src/app/(portal)/projects/[id]/page.tsx
+++ b/project-portal/project-portal-web/src/app/(portal)/projects/[id]/page.tsx
@@ -29,6 +29,7 @@ import TaskBoard from '@/components/collaboration/TaskBoard';
 import ResourceLibrary from '@/components/collaboration/ResourceLibrary';
 import { ROLES_CAN_MANAGE } from '@/lib/store/collaboration/collaboration.types';
 import SatelliteInsights from '@/components/insights/SatelliteInsights';
+import CarbonMap from '@/components/maps/CarbonMap';
 
 export default function ProjectDetailPage() {
   const params = useParams();
@@ -225,7 +226,7 @@ export default function ProjectDetailPage() {
       {/* Tabs */}
       <div className="bg-white rounded-2xl border border-gray-200">
         <div className="flex border-b border-gray-200 overflow-x-auto">
-          {['overview', 'monitoring', 'documents', 'financing', 'team', 'activity', 'comments', 'tasks', 'resources'].map((tab) => (
+          {['overview', 'monitoring', 'geospatial', 'documents', 'financing', 'team', 'activity', 'comments', 'tasks', 'resources'].map((tab) => (
             <button
               key={tab}
               onClick={() => setActiveTab(tab)}
@@ -344,6 +345,16 @@ export default function ProjectDetailPage() {
                 <Droplets className="w-12 h-12 text-gray-300 mx-auto mb-3" />
                 <h3 className="text-lg font-bold text-gray-900 mb-2">Monitoring Dashboard</h3>
                 <p className="text-gray-600">Real-time monitoring data will be available here once sensors are connected.</p>
+              </div>
+            </div>
+          )}
+
+          {activeTab === 'geospatial' && (
+            <div className="space-y-4">
+              <div className="rounded-xl border border-gray-200 bg-white p-4">
+                <h3 className="text-lg font-bold text-gray-900 mb-2">Project Geospatial Map</h3>
+                <p className="text-sm text-gray-600 mb-4">Explore project boundaries, geofences, and satellite layers for this project.</p>
+                <CarbonMap projectId={project.id} height="h-[480px]" className="w-full" />
               </div>
             </div>
           )}

--- a/project-portal/project-portal-web/src/components/maps/CarbonMap.tsx
+++ b/project-portal/project-portal-web/src/components/maps/CarbonMap.tsx
@@ -36,25 +36,6 @@ interface CarbonMapProps {
   onProjectClick?: (projectId: string, coordinates: [number, number]) => void;
 }
 
-/** Extended ProjectGeometry with optional properties */
-interface ExtendedProjectGeometry extends ProjectGeometry {
-  center?: {
-    lng: number;
-    lat: number;
-  };
-  areaHectares?: number;
-  carbonData?: {
-    density: number;
-    total: number;
-    unit: string;
-  };
-}
-
-/** Extended SatelliteImage with optional url */
-interface ExtendedSatelliteImage extends SatelliteImage {
-  url?: string;
-}
-
 // ============================================================================
 // Constants
 // ============================================================================
@@ -104,7 +85,7 @@ export const CarbonMap: React.FC<CarbonMapProps> = ({
   const [mapStyle, setMapStyle] = useState<MapStyle>("light");
   const [showSatellite, setShowSatellite] = useState(false);
   const [showCarbon, setShowCarbon] = useState(true);
-  const [geometry, setGeometry] = useState<ExtendedProjectGeometry | null>(null);
+  const [geometry, setGeometry] = useState<ProjectGeometry | null>(null);
   const [geometryLoading, setGeometryLoading] = useState(true);
   const [geometryError, setGeometryError] = useState<string | null>(null);
   const [mapLoaded, setMapLoaded] = useState(false);
@@ -159,7 +140,7 @@ export const CarbonMap: React.FC<CarbonMapProps> = ({
           geo = await geospatialApi.getProjectGeometry(projectId);
         }
 
-        setGeometry(geo as ExtendedProjectGeometry);
+        setGeometry(geo as ProjectGeometry);
       } catch (err: any) {
         setGeometryError(err.message || "Failed to load project geometry");
         showErrorToast("Failed to load project geometry");
@@ -331,7 +312,7 @@ export const CarbonMap: React.FC<CarbonMapProps> = ({
 
     // Add satellite overlay if enabled
     if (showSatellite && satelliteImages.length > 0) {
-      addSatelliteOverlay(mapInstance, satelliteImages as ExtendedSatelliteImage[]);
+      addSatelliteOverlay(mapInstance, satelliteImages as SatelliteImage[]);
     }
 
     // Add geofences
@@ -350,7 +331,7 @@ export const CarbonMap: React.FC<CarbonMapProps> = ({
   // Layer Builders
   // ============================================================================
 
-  const addGeometryLayer = (mapInstance: mapboxgl.Map, geo: ExtendedProjectGeometry) => {
+  const addGeometryLayer = (mapInstance: mapboxgl.Map, geo: ProjectGeometry) => {
     const sourceId = `geometry-${geo.projectId}`;
 
     // Remove existing source if present
@@ -393,19 +374,20 @@ export const CarbonMap: React.FC<CarbonMapProps> = ({
     layers.current.push(outlineLayerId);
 
     // Add center marker if center coordinates exist
-    if (geo.center && geo.center.lng && geo.center.lat) {
+    const center = (geo as ProjectGeometry & { center?: { lng: number; lat: number } }).center;
+    if (center && center.lng && center.lat) {
       const marker = new mapboxgl.Marker({
         color: "#10B981",
         scale: 1.2,
         draggable: editable,
       })
-        .setLngLat([geo.center.lng, geo.center.lat])
+        .setLngLat([center.lng, center.lat])
         .addTo(mapInstance);
 
       markers.current.push(marker);
 
       // Add popup
-      const areaText = geo.areaHectares ? `${geo.areaHectares.toFixed(2)} ha` : "N/A";
+      const areaText = (geo as ProjectGeometry & { areaHectares?: number }).areaHectares ? `${(geo as ProjectGeometry & { areaHectares?: number }).areaHectares?.toFixed(2)} ha` : "N/A";
       const popup = new mapboxgl.Popup({ offset: 25 })
         .setHTML(`
           <div class="p-2">
@@ -420,11 +402,12 @@ export const CarbonMap: React.FC<CarbonMapProps> = ({
     }
   };
 
-  const addCarbonOverlay = (mapInstance: mapboxgl.Map, geo: ExtendedProjectGeometry) => {
+  const addCarbonOverlay = (mapInstance: mapboxgl.Map, geo: ProjectGeometry) => {
     // This would be a heatmap or choropleth based on carbon data
     // For now, we'll add a simple heatmap layer
     
-    if (!geo.carbonData || !mapInstance.getSource("carbon-scribe")) return;
+    const carbonData = (geo as ProjectGeometry & { carbonData?: { density: number; total: number; unit: string } }).carbonData;
+    if (!carbonData || !mapInstance.getSource("carbon-scribe")) return;
 
     const heatmapLayerId = `carbon-heatmap-${geo.projectId}`;
     
@@ -453,7 +436,7 @@ export const CarbonMap: React.FC<CarbonMapProps> = ({
     layers.current.push(heatmapLayerId);
   };
 
-  const addSatelliteOverlay = (mapInstance: mapboxgl.Map, images: ExtendedSatelliteImage[]) => {
+  const addSatelliteOverlay = (mapInstance: mapboxgl.Map, images: SatelliteImage[]) => {
     if (images.length === 0) return;
 
     const sourceId = "satellite-overlay";
@@ -464,7 +447,7 @@ export const CarbonMap: React.FC<CarbonMapProps> = ({
 
     // Use the most recent image or fallback to tile URL
     const latestImage = images[images.length - 1];
-    const tileUrl = latestImage?.url || geospatialApi.getTileUrl("{z}", "{x}", "{y}");
+    const tileUrl = (latestImage as SatelliteImage & { url?: string }).url || latestImage?.tileUrl || geospatialApi.getTileUrl("{z}", "{x}", "{y}");
 
     mapInstance.addSource(sourceId, {
       type: "raster",

--- a/project-portal/project-portal-web/src/components/monitoring/metrics/ChartExport.tsx
+++ b/project-portal/project-portal-web/src/components/monitoring/metrics/ChartExport.tsx
@@ -1,16 +1,57 @@
 'use client';
 
-import React from 'react';
-import { Download } from 'lucide-react';
+import React, { useMemo, useState } from 'react';
+import { Download, Loader2 } from 'lucide-react';
+import { useStore } from '@/lib/store/store';
+import { showErrorToast, showSuccessToast } from '@/lib/utils/toast';
+import { serializeMetricsToCsv } from './exportUtils';
 
-export default function ChartExport() {
-    return (
-        <button
-            className="flex items-center gap-1.5 px-3 py-1.5 border border-gray-300 rounded-md text-sm font-medium text-gray-700 bg-white hover:bg-gray-50 transition-colors focus:ring-2 focus:ring-offset-1 focus:ring-blue-500"
-            onClick={() => alert('Exporting data as CSV (Simulated)')}
-        >
-            <Download className="w-4 h-4" />
-            <span>Export CSV</span>
-        </button>
-    );
+interface ChartExportProps {
+  chartRef?: React.RefObject<HTMLElement | null>;
+}
+
+export default function ChartExport({ chartRef }: ChartExportProps) {
+  const metrics = useStore((state) => state.metrics);
+  const [isExporting, setIsExporting] = useState(false);
+
+  const exportFileName = useMemo(() => {
+    const date = new Date().toISOString().slice(0, 10);
+    return `metrics-export-${date}.csv`;
+  }, []);
+
+  const handleExport = async () => {
+    if (isExporting) return;
+
+    setIsExporting(true);
+
+    try {
+      const csv = serializeMetricsToCsv(metrics ?? []);
+      const blob = new Blob([csv], { type: 'text/csv;charset=utf-8;' });
+      const href = URL.createObjectURL(blob);
+      const link = document.createElement('a');
+      link.href = href;
+      link.download = exportFileName;
+      link.click();
+      URL.revokeObjectURL(href);
+      showSuccessToast('Metrics CSV downloaded');
+    } catch (error) {
+      console.error('Failed to export metrics CSV', error);
+      showErrorToast('Failed to export metrics CSV');
+    } finally {
+      setIsExporting(false);
+    }
+  };
+
+  return (
+    <button
+      type="button"
+      className="flex items-center gap-1.5 px-3 py-1.5 border border-gray-300 rounded-md text-sm font-medium text-gray-700 bg-white hover:bg-gray-50 transition-colors focus:ring-2 focus:ring-offset-1 focus:ring-blue-500 disabled:cursor-not-allowed disabled:opacity-60"
+      onClick={handleExport}
+      disabled={isExporting || !metrics?.length}
+      aria-busy={isExporting}
+    >
+      {isExporting ? <Loader2 className="w-4 h-4 animate-spin" /> : <Download className="w-4 h-4" />}
+      <span>{isExporting ? 'Exporting...' : 'Export CSV'}</span>
+    </button>
+  );
 }

--- a/project-portal/project-portal-web/src/components/monitoring/metrics/MetricsTimeSeries.tsx
+++ b/project-portal/project-portal-web/src/components/monitoring/metrics/MetricsTimeSeries.tsx
@@ -1,10 +1,14 @@
 'use client';
 
-import React from 'react';
+import React, { forwardRef } from 'react';
 import { useStore } from '@/lib/store/store';
 import { LineChart, Line, XAxis, YAxis, CartesianGrid, Tooltip, ResponsiveContainer } from 'recharts';
 
-export default function MetricsTimeSeries() {
+interface MetricsTimeSeriesProps {
+    chartRef?: React.RefObject<HTMLElement | null>;
+}
+
+const MetricsTimeSeries = forwardRef<HTMLElement, MetricsTimeSeriesProps>(function MetricsTimeSeries({ chartRef }, ref) {
     const metrics = useStore((state) => state.metrics);
     const isLoading = useStore((state) => state.healthLoading.isFetchingMetrics);
 
@@ -21,7 +25,7 @@ export default function MetricsTimeSeries() {
     }
 
     return (
-        <div className="h-[300px] w-full">
+        <div className="h-[300px] w-full" ref={chartRef as React.RefObject<HTMLDivElement>}>
             <ResponsiveContainer width="100%" height="100%">
                 <LineChart data={metrics} margin={{ top: 10, right: 10, left: -20, bottom: 0 }}>
                     <CartesianGrid strokeDasharray="3 3" vertical={false} stroke="#E5E7EB" />
@@ -57,4 +61,6 @@ export default function MetricsTimeSeries() {
             </ResponsiveContainer>
         </div>
     );
-}
+});
+
+export default MetricsTimeSeries;

--- a/project-portal/project-portal-web/src/components/monitoring/metrics/exportUtils.test.ts
+++ b/project-portal/project-portal-web/src/components/monitoring/metrics/exportUtils.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from 'vitest';
+import { serializeMetricsToCsv } from './exportUtils';
+
+describe('serializeMetricsToCsv', () => {
+  it('exports header and rows for the available metrics', () => {
+    const csv = serializeMetricsToCsv([
+      {
+        id: 'm-1',
+        name: 'latency',
+        value: 42,
+        unit: 'ms',
+        timestamp: '2026-07-29T10:00:00Z',
+      },
+      {
+        id: 'm-2',
+        name: 'error rate',
+        value: 0.2,
+        unit: '%',
+        timestamp: '2026-07-29T10:05:00Z',
+      },
+    ] as any);
+
+    expect(csv).toContain('id,name,value,unit,timestamp');
+    expect(csv).toContain('m-1,latency,42,ms,2026-07-29T10:00:00Z');
+    expect(csv).toContain('m-2,error rate,0.2,%,2026-07-29T10:05:00Z');
+  });
+
+  it('returns the header only for an empty metric list', () => {
+    const csv = serializeMetricsToCsv([]);
+
+    expect(csv).toBe('id,name,value,unit,timestamp\n');
+  });
+});

--- a/project-portal/project-portal-web/src/components/monitoring/metrics/exportUtils.ts
+++ b/project-portal/project-portal-web/src/components/monitoring/metrics/exportUtils.ts
@@ -1,0 +1,26 @@
+import type { SystemMetric } from '@/lib/store/health/health.types';
+
+export function serializeMetricsToCsv(metrics: SystemMetric[]) {
+  const headers = ['id', 'name', 'value', 'unit', 'timestamp'];
+  const rows = metrics.map((metric) => {
+    const values = [
+      metric.id ?? '',
+      metric.name ?? '',
+      metric.value ?? '',
+      metric.unit ?? '',
+      metric.timestamp ?? '',
+    ];
+
+    return values.map((value) => escapeCsvCell(String(value))).join(',');
+  });
+
+  return [headers.join(','), ...rows].join('\n') + '\n';
+}
+
+function escapeCsvCell(value: string) {
+  if (!value.includes(',') && !value.includes('"') && !value.includes('\n')) {
+    return value;
+  }
+
+  return `"${value.replace(/"/g, '""')}"`;
+}

--- a/project-portal/project-portal-web/src/components/reports/DatasetExplorer.tsx
+++ b/project-portal/project-portal-web/src/components/reports/DatasetExplorer.tsx
@@ -2,19 +2,39 @@
 
 import { useEffect } from "react";
 import { useStore } from "@/lib/store/store";
-import { Database, Loader2, ChevronDown, ChevronRight } from "lucide-react";
+import { Database, Loader2, ChevronDown, ChevronRight, ChevronLeft } from "lucide-react";
 import { useState } from "react";
 
+const PAGE_SIZE = 8;
+
 export default function DatasetExplorer() {
-  const { datasets, datasetsLoading, datasetsError, fetchDatasets } =
-    useStore();
+  const {
+    datasets,
+    datasetsLoading,
+    datasetsError,
+    datasetsPage,
+    datasetsPageSize,
+    datasetsTotal,
+    datasetsHasMore,
+    fetchDatasets,
+  } = useStore();
   const [expanded, setExpanded] = useState<string | null>(null);
+  const [loadingMore, setLoadingMore] = useState(false);
 
   useEffect(() => {
-    fetchDatasets();
+    void fetchDatasets({ page: 1, pageSize: PAGE_SIZE });
   }, [fetchDatasets]);
 
-  if (datasetsLoading && datasets.length === 0) {
+  const handlePageChange = async (nextPage: number) => {
+    setLoadingMore(true);
+    try {
+      await fetchDatasets({ page: nextPage, pageSize: datasetsPageSize || PAGE_SIZE });
+    } finally {
+      setLoadingMore(false);
+    }
+  };
+
+  if ((datasetsLoading && datasets.length === 0) || (loadingMore && datasets.length === 0)) {
     return (
       <div className="flex items-center justify-center py-12">
         <Loader2 className="w-8 h-8 animate-spin text-emerald-600" />
@@ -115,6 +135,40 @@ export default function DatasetExplorer() {
           );
         })}
       </div>
+
+      <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-3 border border-gray-200 rounded-xl bg-white p-4">
+        <div className="text-sm text-gray-600">
+          Page {datasetsPage} of {Math.max(1, Math.ceil((datasetsTotal || 0) / (datasetsPageSize || PAGE_SIZE)))}
+          {datasetsTotal ? ` • ${datasetsTotal} total datasets` : ''}
+        </div>
+        <div className="flex items-center gap-2">
+          <button
+            type="button"
+            onClick={() => void handlePageChange(Math.max(1, datasetsPage - 1))}
+            disabled={datasetsPage <= 1 || loadingMore}
+            className="inline-flex items-center gap-1 rounded-lg border border-gray-300 px-3 py-2 text-sm font-medium text-gray-700 disabled:cursor-not-allowed disabled:opacity-60"
+          >
+            <ChevronLeft className="h-4 w-4" />
+            Prev
+          </button>
+          <button
+            type="button"
+            onClick={() => void handlePageChange(datasetsPage + 1)}
+            disabled={!datasetsHasMore || loadingMore}
+            className="inline-flex items-center gap-1 rounded-lg border border-gray-300 px-3 py-2 text-sm font-medium text-gray-700 disabled:cursor-not-allowed disabled:opacity-60"
+          >
+            Next
+            <ChevronRight className="h-4 w-4" />
+          </button>
+        </div>
+      </div>
+
+      {loadingMore && (
+        <div className="flex items-center justify-center py-2 text-sm text-gray-500">
+          <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+          Loading next page…
+        </div>
+      )}
     </div>
   );
 }

--- a/project-portal/project-portal-web/src/lib/store/geospatial/geospatial.types.ts
+++ b/project-portal/project-portal-web/src/lib/store/geospatial/geospatial.types.ts
@@ -11,6 +11,16 @@ export interface ProjectGeometry {
   geometry: Geometry;
   createdAt: string;
   updatedAt: string;
+  center?: {
+    lng: number;
+    lat: number;
+  };
+  areaHectares?: number;
+  carbonData?: {
+    density: number;
+    total: number;
+    unit: string;
+  };
 }
 
 export interface Geofence {
@@ -46,6 +56,7 @@ export interface SatelliteImage {
   resolution?: number;
   ndvi?: number;
   geometry?: Geometry;
+  url?: string;
 }
 
 export interface SatelliteTimeSeries {

--- a/project-portal/project-portal-web/src/lib/store/reports/reports.api.ts
+++ b/project-portal/project-portal-web/src/lib/store/reports/reports.api.ts
@@ -190,12 +190,19 @@ export async function apiCancelExecution(executionId: string): Promise<void> {
   });
 }
 
-export async function apiGetDatasets(): Promise<DatasetMetadata[]> {
-  const data = await reportsRequest<{ datasets: DatasetMetadata[] }>({
+export async function apiGetDatasets(params?: {
+  page?: number;
+  pageSize?: number;
+}): Promise<{ datasets: DatasetMetadata[]; total?: number }> {
+  const q = new URLSearchParams();
+  if (params?.page !== undefined) q.set("page", String(params.page));
+  if (params?.pageSize !== undefined) q.set("page_size", String(params.pageSize));
+
+  const data = await reportsRequest<{ datasets: DatasetMetadata[]; total?: number }>({
     method: "GET",
-    url: "reports/datasets",
+    url: `reports/datasets${q.toString() ? `?${q.toString()}` : ""}`,
   });
-  return data?.datasets ?? [];
+  return { datasets: data?.datasets ?? [], total: data?.total ?? data?.datasets?.length ?? 0 };
 }
 
 export async function apiGetDashboardSummary(): Promise<DashboardSummary> {

--- a/project-portal/project-portal-web/src/lib/store/reports/reports.slice.ts
+++ b/project-portal/project-portal-web/src/lib/store/reports/reports.slice.ts
@@ -14,6 +14,7 @@ import type {
   DatasetMetadata,
   WidgetConfig,
 } from "./reports.types";
+
 import * as api from "./reports.api";
 
 const DASHBOARD_SUMMARY_CACHE_MS = 60 * 1000;
@@ -93,7 +94,11 @@ export interface ReportsSlice {
   datasets: DatasetMetadata[];
   datasetsLoading: boolean;
   datasetsError: string | null;
-  fetchDatasets: () => Promise<void>;
+  datasetsPage: number;
+  datasetsPageSize: number;
+  datasetsTotal: number;
+  datasetsHasMore: boolean;
+  fetchDatasets: (params?: { page?: number; pageSize?: number }) => Promise<void>;
 
   benchmarkResult: BenchmarkComparisonResponse | null;
   benchmarkLoading: boolean;
@@ -132,6 +137,10 @@ const initialState = {
   datasets: [],
   datasetsLoading: false,
   datasetsError: null as string | null,
+  datasetsPage: 1,
+  datasetsPageSize: 8,
+  datasetsTotal: 0,
+  datasetsHasMore: false,
   benchmarkResult: null as BenchmarkComparisonResponse | null,
   benchmarkLoading: false,
   benchmarkError: null as string | null,
@@ -379,11 +388,31 @@ export const createReportsSlice: StateCreator<
     set((s) => ({ widgets: s.widgets.filter((w) => w.id !== widgetId) }));
   },
 
-  fetchDatasets: async () => {
-    set({ datasetsLoading: true, datasetsError: null });
+  fetchDatasets: async (params = {}) => {
+    const page = params.page ?? 1;
+    const pageSize = params.pageSize ?? 8;
+
+    if (page === 1) {
+      set({ datasetsLoading: true, datasetsError: null });
+    } else {
+      set((state) => ({ datasetsLoading: state.datasetsLoading, datasetsError: null }));
+    }
+
     try {
-      const datasets = await api.apiGetDatasets();
-      set({ datasets, datasetsLoading: false, datasetsError: null });
+      const response = await api.apiGetDatasets({ page, pageSize });
+      const datasets = response.datasets ?? [];
+      const total = response.total ?? datasets.length;
+      const hasMore = page * pageSize < total;
+
+      set((state) => ({
+        datasets: page === 1 ? datasets : [...state.datasets, ...datasets],
+        datasetsLoading: false,
+        datasetsError: null,
+        datasetsPage: page,
+        datasetsPageSize: pageSize,
+        datasetsTotal: total,
+        datasetsHasMore: hasMore,
+      }));
     } catch (e) {
       set({ datasetsLoading: false, datasetsError: (e as Error).message });
     }

--- a/project-portal/project-portal-web/src/test/reports.test.ts
+++ b/project-portal/project-portal-web/src/test/reports.test.ts
@@ -324,8 +324,8 @@ describe("Reports API client", () => {
       };
       mockFetch({ datasets: [ds] });
       const result = await apiGetDatasets();
-      expect(result).toHaveLength(1);
-      expect(result[0].name).toBe("projects");
+      expect(result.datasets).toHaveLength(1);
+      expect(result.datasets[0].name).toBe("projects");
     });
   });
 

--- a/project-portal/project-portal-web/src/test/setup.ts
+++ b/project-portal/project-portal-web/src/test/setup.ts
@@ -1,4 +1,4 @@
-import '@testing-library/jest-dom'
+import '@testing-library/jest-dom/vitest'
 import { vi } from 'vitest'
 
 // Mock Next.js router


### PR DESCRIPTION
Summary
Implemented real CSV export for monitoring metrics from the chart toolbar with loading state and success/error toasts.
Added server-side style pagination for the dataset explorer with prev/next controls, loading feedback, and preserved expanded row state.
Wired CarbonMap into a reachable project geospatial tab so the map is now accessible from the project detail page.



Closes #505
Closes #506
Closes #507