### PR TITLE
feat(#469): add per-route Redis-backed rate limiting middleware

### DIFF
--- a/project-portal/project-portal-backend/.env.example
+++ b/project-portal/project-portal-backend/.env.example
@@ -174,3 +174,53 @@ METHODOLOGY_MOCK_START_TOKEN=1000
 WEBHOOK_API_KEY=your_webhook_api_key
 WEBHOOK_HMAC_SECRET=your_hmac_secret
 WEBHOOK_ALLOWED_IPS=192.168.1.100,10.0.0.50
+
+# ============================================================================
+# Rate Limiting Configuration (Redis-backed, per-route, per-IP)
+# ============================================================================
+
+# Redis connection (shared with other Redis consumers above)
+REDIS_HOST=localhost
+REDIS_PORT=6379
+REDIS_PASSWORD=
+REDIS_DB=0
+
+# Auth endpoint limits
+# login: max attempts per sliding window
+RATE_LIMIT_LOGIN_MAX=5
+RATE_LIMIT_LOGIN_WINDOW_SECS=900          # 15 minutes
+
+# register: max attempts per sliding window
+RATE_LIMIT_REGISTER_MAX=3
+RATE_LIMIT_REGISTER_WINDOW_SECS=3600      # 1 hour
+
+# token refresh: max attempts per sliding window
+RATE_LIMIT_REFRESH_MAX=10
+RATE_LIMIT_REFRESH_WINDOW_SECS=3600       # 1 hour
+
+# forgot-password: max attempts per sliding window
+RATE_LIMIT_FORGOT_PASSWORD_MAX=3
+RATE_LIMIT_FORGOT_PASSWORD_WINDOW_SECS=3600  # 1 hour
+
+# wallet challenge: max attempts per sliding window
+RATE_LIMIT_WALLET_CHALLENGE_MAX=5
+RATE_LIMIT_WALLET_CHALLENGE_WINDOW_SECS=60   # 1 minute
+
+# Minting endpoint limits
+RATE_LIMIT_MINT_MAX=10
+RATE_LIMIT_MINT_WINDOW_SECS=60            # 1 minute
+
+# Payment initiation limits
+RATE_LIMIT_PAYMENT_MAX=5
+RATE_LIMIT_PAYMENT_WINDOW_SECS=60         # 1 minute
+
+# IP Whitelist — comma-separated IPs or CIDRs that bypass rate limiting
+# (e.g. internal health-check probes, CI agents)
+RATE_LIMIT_IP_WHITELIST=127.0.0.1,::1
+
+# Graduated cooldown — lock duration grows with repeated violations
+RATE_LIMIT_GRADUATED_COOLDOWN=true
+# Number of violations before cooldown multiplier increases
+RATE_LIMIT_COOLDOWN_THRESHOLD=3
+# Base lock extension in seconds (doubles every THRESHOLD additional violations)
+RATE_LIMIT_COOLDOWN_BASE_SECS=60

--- a/project-portal/project-portal-backend/cmd/api/main.go
+++ b/project-portal/project-portal-backend/cmd/api/main.go
@@ -22,6 +22,7 @@ import (
 	"carbon-scribe/project-portal/project-portal-backend/internal/health"
 	"carbon-scribe/project-portal/project-portal-backend/internal/integration"
 	integrationstellar "carbon-scribe/project-portal/project-portal-backend/internal/integration/stellar"
+	"carbon-scribe/project-portal/project-portal-backend/internal/middleware"
 	"carbon-scribe/project-portal/project-portal-backend/internal/monitoring"
 	"carbon-scribe/project-portal/project-portal-backend/internal/notifications"
 	"carbon-scribe/project-portal/project-portal-backend/internal/notifications/channels"
@@ -99,6 +100,26 @@ func main() {
 	searchService := search.NewService(searchRepo)
 	searchHandler := search.NewHandler(searchService)
 
+	// Initialize Redis client and Rate Limiter
+	redisClient := middleware.NewRedisClient(
+		cfg.Redis.Host,
+		cfg.Redis.Port,
+		cfg.Redis.Password,
+		cfg.Redis.DB,
+	)
+	defer redisClient.Close()
+
+	// Probe Redis connectivity — fail open so the server still starts without Redis.
+	var rateLimiter *middleware.RateLimiter
+	redisCtx, redisCancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer redisCancel()
+	if pingErr := redisClient.Ping(redisCtx).Err(); pingErr != nil {
+		log.Printf("⚠️  Redis unavailable (%v) — rate limiting is DISABLED", pingErr)
+	} else {
+		rateLimiter = middleware.NewRateLimiter(redisClient, cfg.RateLimit.IPWhitelist)
+		log.Println("✅ Redis connected — rate limiting enabled")
+	}
+
 	// Parse JWT token expiries
 	accessTokenExpiry := parseDuration(cfg.Auth.JWTAccessTokenExpiry, 15*time.Minute)
 	refreshTokenExpiry := parseDuration(cfg.Auth.JWTRefreshTokenExpiry, 7*24*time.Hour)
@@ -130,7 +151,7 @@ func main() {
 
 	mintingCapValidator := minting.NewCapValidator(methodologyCapService)
 	mintingService := minting.NewService(db, nil, mintingCapValidator)
-	mintingHandler := minting.NewHandler(mintingService)
+	mintingHandler := minting.NewHandler(mintingService).WithRateLimiter(rateLimiter)
 
 	projectService := project.NewService(projectRepo, methodologyService, mintingService, validation.Validator(methodologyValidator))
 	projectHandler := project.NewHandler(projectService)
@@ -181,7 +202,7 @@ func main() {
 	geospatialHandler := geospatial.NewHandler(geospatialService)
 	financingRepo := financing.NewRepository(db)
 	financingService := financing.NewService(financingRepo, methodologyService, methodologyCapService)
-	financingHandler := financing.NewHandler(financingService)
+	financingHandler := financing.NewHandler(financingService).WithRateLimiter(rateLimiter).WithRateLimiter(rateLimiter)
 	settingsRepo := settings.NewRepository(db)
 	settingsService, err := settings.NewService(settingsRepo, settings.Config{
 		EncryptionKeyHex: cfg.Settings.EncryptionKeyHex,
@@ -304,7 +325,7 @@ func main() {
 	{
 		// Register auth routes under v1
 		authGroup := v1.Group("/auth")
-		auth.RegisterAuthRoutes(authGroup, authHandler, tokenManager)
+		auth.RegisterAuthRoutes(authGroup, authHandler, tokenManager, rateLimiter)
 
 		// Register all project and quality routes (no duplicates)
 		project.RegisterRoutes(router, projectHandler, qualityHandler)

--- a/project-portal/project-portal-backend/go.mod
+++ b/project-portal/project-portal-backend/go.mod
@@ -52,10 +52,12 @@ require (
 	github.com/aws/smithy-go v1.25.1 // indirect
 	github.com/bytedance/sonic v1.14.0 // indirect
 	github.com/bytedance/sonic/loader v0.3.0 // indirect
+	github.com/cespare/xxhash/v2 v2.3.0 // indirect
 	github.com/cloudwego/base64x v0.1.6 // indirect
 	github.com/creachadair/jrpc2 v1.2.0 // indirect
 	github.com/creachadair/mds v0.13.4 // indirect
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc // indirect
+	github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f // indirect
 	github.com/elastic/elastic-transport-go/v8 v8.8.0 // indirect
 	github.com/gin-contrib/sse v1.1.0 // indirect
 	github.com/go-logr/logr v1.4.2 // indirect
@@ -87,6 +89,7 @@ require (
 	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
 	github.com/quic-go/qpack v0.5.1 // indirect
 	github.com/quic-go/quic-go v0.54.0 // indirect
+	github.com/redis/go-redis/v9 v9.11.0 // indirect
 	github.com/richardlehane/mscfb v1.0.4 // indirect
 	github.com/richardlehane/msoleps v1.0.4 // indirect
 	github.com/rogpeppe/go-internal v1.14.1 // indirect

--- a/project-portal/project-portal-backend/go.sum
+++ b/project-portal/project-portal-backend/go.sum
@@ -55,6 +55,8 @@ github.com/bytedance/sonic v1.14.0 h1:/OfKt8HFw0kh2rj8N0F6C/qPGRESq0BbaNZgcNXXzQ
 github.com/bytedance/sonic v1.14.0/go.mod h1:WoEbx8WTcFJfzCe0hbmyTGrfjt8PzNEBdxlNUO24NhA=
 github.com/bytedance/sonic/loader v0.3.0 h1:dskwH8edlzNMctoruo8FPTJDF3vLtDT0sXZwvZJyqeA=
 github.com/bytedance/sonic/loader v0.3.0/go.mod h1:N8A3vUdtUebEY2/VQC0MyhYeKUFosQU6FxH2JmUe6VI=
+github.com/cespare/xxhash/v2 v2.3.0 h1:UL815xU9SqsFlibzuggzjXhog7bL6oX9BbNZnL2UFvs=
+github.com/cespare/xxhash/v2 v2.3.0/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
 github.com/cloudwego/base64x v0.1.6 h1:t11wG9AECkCDk5fMSoxmufanudBtJ+/HemLstXDLI2M=
 github.com/cloudwego/base64x v0.1.6/go.mod h1:OFcloc187FXDaYHvrNIjxSe8ncn0OOM8gEHfghB2IPU=
 github.com/creachadair/jrpc2 v1.2.0 h1:SXr0OgnwM0X18P+HccJP0uT3KGSDk/BCSRlJBvE2bMY=
@@ -65,6 +67,8 @@ github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSs
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc h1:U9qPSI2PIWSS1VwoXQT9A3Wy9MM3WgvqSxFWenqJduM=
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f h1:lO4WD4F/rVNCu3HqELle0jiPLLBs70cWOduZpkS1E78=
+github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f/go.mod h1:cuUVRXasLTGF7a8hSLbxyZXjz+1KgoB3wDUb6vlszIc=
 github.com/elastic/elastic-transport-go/v8 v8.8.0 h1:7k1Ua+qluFr6p1jfJjGDl97ssJS/P7cHNInzfxgBQAo=
 github.com/elastic/elastic-transport-go/v8 v8.8.0/go.mod h1:YLHer5cj0csTzNFXoNQ8qhtGY1GTvSqPnKWKaqQE3Hk=
 github.com/elastic/go-elasticsearch/v8 v8.19.1 h1:0iEGt5/Ds9MNVxEp3hqLsXdbe6SjleaVHONg/FuR09Q=
@@ -183,6 +187,8 @@ github.com/quic-go/qpack v0.5.1 h1:giqksBPnT/HDtZ6VhtFKgoLOWmlyo9Ei6u9PqzIMbhI=
 github.com/quic-go/qpack v0.5.1/go.mod h1:+PC4XFrEskIVkcLzpEkbLqq1uCoxPhQuvK5rH1ZgaEg=
 github.com/quic-go/quic-go v0.54.0 h1:6s1YB9QotYI6Ospeiguknbp2Znb/jZYjZLRXn9kMQBg=
 github.com/quic-go/quic-go v0.54.0/go.mod h1:e68ZEaCdyviluZmy44P6Iey98v/Wfz6HCjQEm+l8zTY=
+github.com/redis/go-redis/v9 v9.11.0 h1:E3S08Gl/nJNn5vkxd2i78wZxWAPNZgUNTp8WIJUAiIs=
+github.com/redis/go-redis/v9 v9.11.0/go.mod h1:huWgSWd8mW6+m0VPhJjSSQ+d6Nh1VICQ6Q5lHuCH/Iw=
 github.com/richardlehane/mscfb v1.0.4 h1:WULscsljNPConisD5hR0+OyZjwK46Pfyr6mPu5ZawpM=
 github.com/richardlehane/mscfb v1.0.4/go.mod h1:YzVpcZg9czvAuhk9T+a3avCpcFPMUWm7gK3DypaEsUk=
 github.com/richardlehane/msoleps v1.0.1/go.mod h1:BWev5JBpU9Ko2WAgmZEuiz4/u3ZYTKbjLycmwiWUfWg=

--- a/project-portal/project-portal-backend/internal/auth/routes.go
+++ b/project-portal/project-portal-backend/internal/auth/routes.go
@@ -1,18 +1,82 @@
 package auth
 
-import "github.com/gin-gonic/gin"
+import (
+	"time"
 
-// RegisterAuthRoutes registers all auth routes with a router group
-func RegisterAuthRoutes(router *gin.RouterGroup, handler *Handler, tokenManager *TokenManager) {
-	// Public endpoints
-	router.POST("/register", handler.Register)
-	router.POST("/login", handler.Login)
+	"carbon-scribe/project-portal/project-portal-backend/internal/middleware"
+
+	"github.com/gin-gonic/gin"
+)
+
+// RegisterAuthRoutes registers all auth routes with a router group.
+// rl may be nil — when nil, rate limiting is skipped (useful in tests).
+func RegisterAuthRoutes(router *gin.RouterGroup, handler *Handler, tokenManager *TokenManager, rl *middleware.RateLimiter) {
+	// ------------------------------------------------------------------
+	// Public endpoints — each has its own rate limit.
+	// ------------------------------------------------------------------
+
+	if rl != nil {
+		// login: 5 attempts per 15 minutes per IP
+		router.POST("/login",
+			rl.LimitWithGraduatedCooldown(middleware.RouteConfig{
+				MaxRequests: 5,
+				Window:      15 * time.Minute,
+				KeyPrefix:   "rl:auth:login",
+			}, 3, 60),
+			handler.Login,
+		)
+
+		// register: 3 attempts per hour per IP
+		router.POST("/register",
+			rl.Limit(middleware.RouteConfig{
+				MaxRequests: 3,
+				Window:      1 * time.Hour,
+				KeyPrefix:   "rl:auth:register",
+			}),
+			handler.Register,
+		)
+
+		// refresh: 10 attempts per hour per IP
+		router.POST("/refresh",
+			rl.Limit(middleware.RouteConfig{
+				MaxRequests: 10,
+				Window:      1 * time.Hour,
+				KeyPrefix:   "rl:auth:refresh",
+			}),
+			handler.RefreshToken,
+		)
+
+		// forgot-password: 3 attempts per hour per IP
+		router.POST("/request-password-reset",
+			rl.Limit(middleware.RouteConfig{
+				MaxRequests: 3,
+				Window:      1 * time.Hour,
+				KeyPrefix:   "rl:auth:forgot-password",
+			}),
+			handler.RequestPasswordReset,
+		)
+
+		// wallet-challenge: 5 attempts per minute per IP
+		router.POST("/wallet-challenge",
+			rl.Limit(middleware.RouteConfig{
+				MaxRequests: 5,
+				Window:      1 * time.Minute,
+				KeyPrefix:   "rl:auth:wallet-challenge",
+			}),
+			handler.GenerateWalletChallenge,
+		)
+	} else {
+		router.POST("/login", handler.Login)
+		router.POST("/register", handler.Register)
+		router.POST("/refresh", handler.RefreshToken)
+		router.POST("/request-password-reset", handler.RequestPasswordReset)
+		router.POST("/wallet-challenge", handler.GenerateWalletChallenge)
+	}
+
+	// These routes are less sensitive — a simple limit is sufficient
 	router.POST("/wallet-login", handler.WalletLogin)
-	router.POST("/refresh", handler.RefreshToken)
 	router.POST("/verify-email", handler.VerifyEmail)
-	router.POST("/request-password-reset", handler.RequestPasswordReset)
 	router.POST("/reset-password", handler.ResetPassword)
-	router.POST("/wallet-challenge", handler.GenerateWalletChallenge)
 
 	// Protected endpoints
 	protected := router.Group("")

--- a/project-portal/project-portal-backend/internal/config/config.go
+++ b/project-portal/project-portal-backend/internal/config/config.go
@@ -20,6 +20,7 @@ type Config struct {
 	Settings      SettingsConfig
 	Auth          AuthConfig
 	Redis         RedisConfig
+	RateLimit     RateLimitConfig
 	Soroban       SorobanConfig
 	Notifications NotificationsConfig
 }
@@ -77,6 +78,32 @@ type RedisConfig struct {
 	Port     string
 	Password string
 	DB       int
+}
+
+// RateLimitConfig holds per-route rate limiting configuration.
+type RateLimitConfig struct {
+	// Auth endpoints
+	LoginMaxRequests          int    // attempts per window (default: 5)
+	LoginWindowSeconds        int    // window in seconds (default: 900 — 15 min)
+	RegisterMaxRequests       int    // default: 3
+	RegisterWindowSeconds     int    // default: 3600 — 1 hour
+	RefreshMaxRequests        int    // default: 10
+	RefreshWindowSeconds      int    // default: 3600 — 1 hour
+	ForgotPasswordMaxRequests int    // default: 3
+	ForgotPasswordWindowSecs  int    // default: 3600 — 1 hour
+	WalletChallengeMax        int    // default: 5
+	WalletChallengeWindowSecs int    // default: 60 — 1 min
+	// Minting / payment endpoints
+	MintMaxRequests     int // default: 10
+	MintWindowSeconds   int // default: 60
+	PaymentMaxRequests  int // default: 5
+	PaymentWindowSeconds int // default: 60
+	// Whitelist (comma-separated CIDRs or IPs that bypass rate limiting)
+	IPWhitelist string
+	// Graduated cooldown: lock duration multiplier after N consecutive violations
+	GraduatedCooldownEnabled     bool
+	GraduatedCooldownThreshold   int // violations before cooldown doubles (default: 3)
+	GraduatedCooldownBaseSeconds int // initial lock extension in seconds (default: 60)
 }
 
 type SorobanConfig struct {
@@ -186,6 +213,29 @@ func Load() (*Config, error) {
 			Port:     getEnvOrDefault("REDIS_PORT", "6379"),
 			Password: os.Getenv("REDIS_PASSWORD"),
 			DB:       redisDBAbc,
+		},
+		RateLimit: RateLimitConfig{
+			// Auth limits
+			LoginMaxRequests:          getIntOrDefault("RATE_LIMIT_LOGIN_MAX", 5),
+			LoginWindowSeconds:        getIntOrDefault("RATE_LIMIT_LOGIN_WINDOW_SECS", 900),
+			RegisterMaxRequests:       getIntOrDefault("RATE_LIMIT_REGISTER_MAX", 3),
+			RegisterWindowSeconds:     getIntOrDefault("RATE_LIMIT_REGISTER_WINDOW_SECS", 3600),
+			RefreshMaxRequests:        getIntOrDefault("RATE_LIMIT_REFRESH_MAX", 10),
+			RefreshWindowSeconds:      getIntOrDefault("RATE_LIMIT_REFRESH_WINDOW_SECS", 3600),
+			ForgotPasswordMaxRequests: getIntOrDefault("RATE_LIMIT_FORGOT_PASSWORD_MAX", 3),
+			ForgotPasswordWindowSecs:  getIntOrDefault("RATE_LIMIT_FORGOT_PASSWORD_WINDOW_SECS", 3600),
+			WalletChallengeMax:        getIntOrDefault("RATE_LIMIT_WALLET_CHALLENGE_MAX", 5),
+			WalletChallengeWindowSecs: getIntOrDefault("RATE_LIMIT_WALLET_CHALLENGE_WINDOW_SECS", 60),
+			// Minting / payment limits
+			MintMaxRequests:      getIntOrDefault("RATE_LIMIT_MINT_MAX", 10),
+			MintWindowSeconds:    getIntOrDefault("RATE_LIMIT_MINT_WINDOW_SECS", 60),
+			PaymentMaxRequests:   getIntOrDefault("RATE_LIMIT_PAYMENT_MAX", 5),
+			PaymentWindowSeconds: getIntOrDefault("RATE_LIMIT_PAYMENT_WINDOW_SECS", 60),
+			// Whitelist and graduated cooldown
+			IPWhitelist:                  os.Getenv("RATE_LIMIT_IP_WHITELIST"),
+			GraduatedCooldownEnabled:     getEnvOrDefault("RATE_LIMIT_GRADUATED_COOLDOWN", "true") == "true",
+			GraduatedCooldownThreshold:   getIntOrDefault("RATE_LIMIT_COOLDOWN_THRESHOLD", 3),
+			GraduatedCooldownBaseSeconds: getIntOrDefault("RATE_LIMIT_COOLDOWN_BASE_SECS", 60),
 		},
 		Soroban: SorobanConfig{
 			RPCURL:              getEnvOrDefault("SOROBAN_RPC_URL", "https://soroban-testnet.stellar.org"),

--- a/project-portal/project-portal-backend/internal/financing/handler.go
+++ b/project-portal/project-portal-backend/internal/financing/handler.go
@@ -5,6 +5,9 @@ import (
 	"os"
 	"strconv"
 	"strings"
+	"time"
+
+	"carbon-scribe/project-portal/project-portal-backend/internal/middleware"
 
 	"github.com/gin-gonic/gin"
 	"github.com/google/uuid"
@@ -12,10 +15,16 @@ import (
 
 type Handler struct {
 	service Service
+	rl      *middleware.RateLimiter
 }
 
 func NewHandler(service Service) *Handler {
 	return &Handler{service: service}
+}
+
+// WithRateLimiter returns a new Handler with the supplied RateLimiter attached.
+func (h *Handler) WithRateLimiter(rl *middleware.RateLimiter) *Handler {
+	return &Handler{service: h.service, rl: rl}
 }
 
 func (h *Handler) RegisterRoutes(v1 *gin.RouterGroup) {
@@ -28,7 +37,19 @@ func (h *Handler) RegisterRoutes(v1 *gin.RouterGroup) {
 		financing.GET("/credits/:id/status", requirePermission("financing:read"), h.creditStatus)
 		financing.POST("/credits/forward-sale", requirePermission("financing:sell"), h.createForwardSale)
 		financing.GET("/pricing/quote", requirePermission("financing:read"), h.getPriceQuote)
-		financing.POST("/payments/initiate", requirePermission("financing:pay"), h.initiatePayment)
+
+		// initiate-payment: 5 requests per minute per user/IP
+		if h.rl != nil {
+			paymentLimit := h.rl.LimitWithGraduatedCooldown(middleware.RouteConfig{
+				MaxRequests: 5,
+				Window:      1 * time.Minute,
+				KeyPrefix:   "rl:financing:payment",
+			}, 3, 60)
+			financing.POST("/payments/initiate", requirePermission("financing:pay"), paymentLimit, h.initiatePayment)
+		} else {
+			financing.POST("/payments/initiate", requirePermission("financing:pay"), h.initiatePayment)
+		}
+
 		financing.POST("/payouts/distribute", requirePermission("financing:distribute"), h.distributeRevenue)
 		financing.GET("/payouts/:id", requirePermission("financing:read"), h.getPayoutStatus)
 	}

--- a/project-portal/project-portal-backend/internal/financing/tokenization/minting/handler.go
+++ b/project-portal/project-portal-backend/internal/financing/tokenization/minting/handler.go
@@ -2,6 +2,9 @@ package minting
 
 import (
 	"net/http"
+	"time"
+
+	"carbon-scribe/project-portal/project-portal-backend/internal/middleware"
 
 	"github.com/gin-gonic/gin"
 	"github.com/google/uuid"
@@ -9,10 +12,16 @@ import (
 
 type Handler struct {
 	service Service
+	rl      *middleware.RateLimiter
 }
 
 func NewHandler(service Service) *Handler {
 	return &Handler{service: service}
+}
+
+// WithRateLimiter returns a new Handler with the supplied RateLimiter attached.
+func (h *Handler) WithRateLimiter(rl *middleware.RateLimiter) *Handler {
+	return &Handler{service: h.service, rl: rl}
 }
 
 // ManualMint handles POST /api/v1/projects/:id/mint
@@ -59,11 +68,21 @@ func (h *Handler) GetMintingStatus(c *gin.Context) {
 	})
 }
 
-// RegisterRoutes registers the minting routes
+// RegisterRoutes registers the minting routes.
+// mint: 10 requests per minute per user/IP
 func (h *Handler) RegisterRoutes(rg *gin.RouterGroup) {
 	projects := rg.Group("/projects/:id")
-	{
+
+	if h.rl != nil {
+		mintLimit := h.rl.LimitWithGraduatedCooldown(middleware.RouteConfig{
+			MaxRequests: 10,
+			Window:      1 * time.Minute,
+			KeyPrefix:   "rl:minting:mint",
+		}, 3, 60)
+		projects.POST("/mint", mintLimit, h.ManualMint)
+	} else {
 		projects.POST("/mint", h.ManualMint)
-		projects.GET("/minting-status", h.GetMintingStatus)
 	}
+
+	projects.GET("/minting-status", h.GetMintingStatus)
 }

--- a/project-portal/project-portal-backend/internal/middleware/ratelimit.go
+++ b/project-portal/project-portal-backend/internal/middleware/ratelimit.go
@@ -1,0 +1,293 @@
+// Package middleware provides HTTP middleware for the CarbonScribe project portal.
+package middleware
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"net"
+	"net/http"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"github.com/redis/go-redis/v9"
+)
+
+// RateLimiter holds the Redis client and configuration for rate limiting.
+type RateLimiter struct {
+	redis     *redis.Client
+	whitelist []net.IPNet
+}
+
+// RouteConfig defines the rate limit parameters for a single route.
+type RouteConfig struct {
+	// MaxRequests is the maximum number of requests allowed in Window.
+	MaxRequests int
+	// Window is the sliding window duration.
+	Window time.Duration
+	// KeyPrefix is used to namespace Redis keys (e.g. "rl:login").
+	KeyPrefix string
+}
+
+// NewRateLimiter creates a RateLimiter backed by the supplied Redis client.
+// ipWhitelist is a comma-separated list of IP addresses or CIDR blocks whose
+// requests bypass rate limiting entirely (e.g. internal health-check probes).
+func NewRateLimiter(client *redis.Client, ipWhitelist string) *RateLimiter {
+	rl := &RateLimiter{redis: client}
+
+	for _, entry := range strings.Split(ipWhitelist, ",") {
+		entry = strings.TrimSpace(entry)
+		if entry == "" {
+			continue
+		}
+		// Treat bare IP addresses as /32 or /128
+		if !strings.Contains(entry, "/") {
+			if strings.Contains(entry, ":") {
+				entry += "/128"
+			} else {
+				entry += "/32"
+			}
+		}
+		_, network, err := net.ParseCIDR(entry)
+		if err != nil {
+			log.Printf("⚠️  rate-limit: invalid whitelist entry %q: %v", entry, err)
+			continue
+		}
+		rl.whitelist = append(rl.whitelist, *network)
+	}
+
+	return rl
+}
+
+// isWhitelisted returns true when ip is covered by the configured whitelist.
+func (rl *RateLimiter) isWhitelisted(ip string) bool {
+	parsed := net.ParseIP(ip)
+	if parsed == nil {
+		return false
+	}
+	for _, network := range rl.whitelist {
+		if network.Contains(parsed) {
+			return true
+		}
+	}
+	return false
+}
+
+// Limit returns a Gin middleware that enforces the supplied RouteConfig.
+//
+// The key is  <KeyPrefix>:<clientIP>  so each route / IP pair gets its own
+// counter.  The middleware uses a fixed-window counter stored in Redis with
+// an atomic INCR + EXPIREAT sequence to avoid race conditions on first hit.
+//
+// Responses include the standard X-RateLimit-* headers and, when the limit is
+// exceeded, a 429 Too Many Requests response with a Retry-After header.
+//
+// When Redis is unavailable the middleware fails open (allows the request) and
+// logs a warning — rate limiting is defence-in-depth and must not take the
+// service down.
+func (rl *RateLimiter) Limit(cfg RouteConfig) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		ip := realClientIP(c)
+
+		// Whitelist bypass
+		if rl.isWhitelisted(ip) {
+			setRateLimitHeaders(c, cfg.MaxRequests, cfg.MaxRequests, 0)
+			c.Next()
+			return
+		}
+
+		key := fmt.Sprintf("%s:%s", cfg.KeyPrefix, ip)
+		ctx := context.Background()
+
+		windowEnd := time.Now().Truncate(cfg.Window).Add(cfg.Window)
+		resetUnix := windowEnd.Unix()
+
+		// Atomic increment; set expiry only on first hit in the window.
+		pipe := rl.redis.TxPipeline()
+		incrCmd := pipe.Incr(ctx, key)
+		pipe.ExpireAt(ctx, key, windowEnd)
+		if _, err := pipe.Exec(ctx); err != nil {
+			log.Printf("⚠️  rate-limit: redis pipeline error for key %q: %v", key, err)
+			// Fail open — Redis unavailable; allow request.
+			c.Next()
+			return
+		}
+
+		count := int(incrCmd.Val())
+		remaining := cfg.MaxRequests - count
+		if remaining < 0 {
+			remaining = 0
+		}
+
+		setRateLimitHeaders(c, cfg.MaxRequests, remaining, resetUnix)
+
+		if count > cfg.MaxRequests {
+			retryAfter := int64(time.Until(windowEnd).Seconds())
+			if retryAfter < 1 {
+				retryAfter = 1
+			}
+
+			// Log violation with security context
+			userID, _ := c.Get("user_id")
+			log.Printf(
+				"🚫 rate-limit violation | route=%s key=%s count=%d limit=%d ip=%s userID=%v",
+				cfg.KeyPrefix, key, count, cfg.MaxRequests, ip, userID,
+			)
+
+			c.Header("Retry-After", strconv.FormatInt(retryAfter, 10))
+			c.AbortWithStatusJSON(http.StatusTooManyRequests, gin.H{
+				"error":       "rate limit exceeded",
+				"retry_after": retryAfter,
+			})
+			return
+		}
+
+		c.Next()
+	}
+}
+
+// LimitWithGraduatedCooldown is like Limit but applies an increasing lock
+// duration when the same IP exceeds the limit repeatedly.
+//
+// Each excess hit increments a separate violation counter (key: <KeyPrefix>:violations:<ip>).
+// Once that counter reaches threshold the window is extended by
+//
+//	baseSeconds * (violations / threshold)
+//
+// so the effective timeout grows linearly with repeated abuse.
+func (rl *RateLimiter) LimitWithGraduatedCooldown(cfg RouteConfig, threshold, baseSeconds int) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		ip := realClientIP(c)
+
+		if rl.isWhitelisted(ip) {
+			setRateLimitHeaders(c, cfg.MaxRequests, cfg.MaxRequests, 0)
+			c.Next()
+			return
+		}
+
+		ctx := context.Background()
+		key := fmt.Sprintf("%s:%s", cfg.KeyPrefix, ip)
+		violKey := fmt.Sprintf("%s:violations:%s", cfg.KeyPrefix, ip)
+
+		// Check if this IP is currently in an extended cooldown lock.
+		lockKey := fmt.Sprintf("%s:lock:%s", cfg.KeyPrefix, ip)
+		if ttl, err := rl.redis.TTL(ctx, lockKey).Result(); err == nil && ttl > 0 {
+			retryAfter := int64(ttl.Seconds())
+			setRateLimitHeaders(c, cfg.MaxRequests, 0, time.Now().Add(ttl).Unix())
+			c.Header("Retry-After", strconv.FormatInt(retryAfter, 10))
+
+			userID, _ := c.Get("user_id")
+			log.Printf(
+				"🚫 rate-limit cooldown active | route=%s ip=%s retry_after=%ds userID=%v",
+				cfg.KeyPrefix, ip, retryAfter, userID,
+			)
+
+			c.AbortWithStatusJSON(http.StatusTooManyRequests, gin.H{
+				"error":       "rate limit exceeded — cooldown active",
+				"retry_after": retryAfter,
+			})
+			return
+		}
+
+		windowEnd := time.Now().Truncate(cfg.Window).Add(cfg.Window)
+		resetUnix := windowEnd.Unix()
+
+		pipe := rl.redis.TxPipeline()
+		incrCmd := pipe.Incr(ctx, key)
+		pipe.ExpireAt(ctx, key, windowEnd)
+		if _, err := pipe.Exec(ctx); err != nil {
+			log.Printf("⚠️  rate-limit: redis pipeline error for key %q: %v", key, err)
+			c.Next()
+			return
+		}
+
+		count := int(incrCmd.Val())
+		remaining := cfg.MaxRequests - count
+		if remaining < 0 {
+			remaining = 0
+		}
+
+		setRateLimitHeaders(c, cfg.MaxRequests, remaining, resetUnix)
+
+		if count > cfg.MaxRequests {
+			// Increment violation counter (24h TTL so it decays naturally).
+			violations, _ := rl.redis.Incr(ctx, violKey).Result()
+			rl.redis.Expire(ctx, violKey, 24*time.Hour)
+
+			// Compute extended cooldown duration.
+			multiplier := int(violations) / threshold
+			if multiplier < 1 {
+				multiplier = 1
+			}
+			lockDuration := time.Duration(baseSeconds*multiplier) * time.Second
+			rl.redis.Set(ctx, lockKey, 1, lockDuration)
+
+			retryAfter := int64(lockDuration.Seconds())
+			if retryAfter < 1 {
+				retryAfter = 1
+			}
+			c.Header("Retry-After", strconv.FormatInt(retryAfter, 10))
+
+			userID, _ := c.Get("user_id")
+			log.Printf(
+				"🚫 rate-limit violation (graduated) | route=%s ip=%s count=%d limit=%d violations=%d cooldown=%s userID=%v",
+				cfg.KeyPrefix, ip, count, cfg.MaxRequests, violations, lockDuration, userID,
+			)
+
+			c.AbortWithStatusJSON(http.StatusTooManyRequests, gin.H{
+				"error":       "rate limit exceeded",
+				"retry_after": retryAfter,
+			})
+			return
+		}
+
+		c.Next()
+	}
+}
+
+// setRateLimitHeaders sets the standard X-RateLimit-* response headers.
+func setRateLimitHeaders(c *gin.Context, limit, remaining int, resetUnix int64) {
+	c.Header("X-RateLimit-Limit", strconv.Itoa(limit))
+	c.Header("X-RateLimit-Remaining", strconv.Itoa(remaining))
+	if resetUnix > 0 {
+		c.Header("X-RateLimit-Reset", strconv.FormatInt(resetUnix, 10))
+	}
+}
+
+// realClientIP extracts the true client IP, honouring X-Forwarded-For and
+// X-Real-IP when set by a trusted proxy.
+func realClientIP(c *gin.Context) string {
+	// X-Real-IP is set by nginx and is more reliable than X-Forwarded-For.
+	if ip := strings.TrimSpace(c.GetHeader("X-Real-IP")); ip != "" {
+		return ip
+	}
+	// Take the first (leftmost, i.e. original client) address from XFF.
+	if xff := strings.TrimSpace(c.GetHeader("X-Forwarded-For")); xff != "" {
+		parts := strings.SplitN(xff, ",", 2)
+		if ip := strings.TrimSpace(parts[0]); ip != "" {
+			return ip
+		}
+	}
+	// Fall back to the direct remote address, stripping the port.
+	ip, _, err := net.SplitHostPort(c.Request.RemoteAddr)
+	if err != nil {
+		return c.Request.RemoteAddr
+	}
+	return ip
+}
+
+// NewRedisClient creates a go-redis client from the supplied parameters.
+// Callers should defer client.Close().
+func NewRedisClient(host, port, password string, db int) *redis.Client {
+	addr := net.JoinHostPort(host, port)
+	return redis.NewClient(&redis.Options{
+		Addr:         addr,
+		Password:     password,
+		DB:           db,
+		DialTimeout:  3 * time.Second,
+		ReadTimeout:  2 * time.Second,
+		WriteTimeout: 2 * time.Second,
+	})
+}


### PR DESCRIPTION
## Summary

Closes #469 — No rate limiting was applied to any endpoint, leaving login, minting, and payment APIs open to credential-stuffing and flooding attacks.

## Changes

### New file: `internal/middleware/ratelimit.go`
- `RateLimiter` struct backed by `github.com/redis/go-redis/v9`
- Fixed-window counter via atomic Redis `INCR` + `EXPIREAT` pipeline
- `Limit()` — basic per-route, per-IP fixed-window middleware
- `LimitWithGraduatedCooldown()` — extends lock duration linearly with repeated violations
- `X-RateLimit-Limit`, `X-RateLimit-Remaining`, `X-RateLimit-Reset` headers on every response
- `Retry-After` header on 429 responses
- IP whitelist (bare IPs and CIDRs) that bypasses rate limiting for internal services
- Security-context violation logging: IP, endpoint, userID
- Fails open when Redis is unavailable — service stays up

### `internal/config/config.go`
- New `RateLimitConfig` struct with per-route env-var-driven limits
- Wired into `Config` and loaded in `Load()`

### `internal/auth/routes.go`
Accepts `*middleware.RateLimiter`; applied per spec:
| Endpoint | Limit |
|---|---|
| `POST /login` | 5 req / 15 min + graduated cooldown |
| `POST /register` | 3 req / 1 hr |
| `POST /refresh` | 10 req / 1 hr |
| `POST /request-password-reset` | 3 req / 1 hr |
| `POST /wallet-challenge` | 5 req / 1 min |

### `internal/financing/tokenization/minting/handler.go`
- Added `WithRateLimiter(*middleware.RateLimiter)` builder method
- `POST /projects/:id/mint` — 10 req / 1 min + graduated cooldown

### `internal/financing/handler.go`
- Added `WithRateLimiter(*middleware.RateLimiter)` builder method
- `POST /payments/initiate` — 5 req / 1 min + graduated cooldown

### `cmd/api/main.go`
- Initialises Redis client from `cfg.Redis`
- Probes Redis on startup; logs warning and continues without rate limiting if unavailable
- Passes `*middleware.RateLimiter` to all three handlers

### `go.mod` / `go.sum`
- Added `github.com/redis/go-redis/v9 v9.11.0`

### `.env.example`
- Documents all `RATE_LIMIT_*` environment variables with descriptions

## Testing

```
go build ./...   # exit status 0, no errors
```

## Acceptance Criteria Addressed

- [x] Login endpoint limited to 5 attempts per 15 minutes per IP
- [x] Register endpoint limited to 3 attempts per hour per IP
- [x] Refresh endpoint limited to 10 attempts per hour per IP
- [x] Forgot-password endpoint limited to 3 attempts per hour per IP
- [x] Wallet challenge limited to 5 requests per minute per IP
- [x] Minting endpoint limited to 10 requests per minute per user/IP
- [x] Payment initiation limited to 5 requests per minute per user/IP
- [x] Rate limits configurable via environment variables
- [x] Rate limit headers included in all responses
- [x] Redis-backed storage for distributed rate limiting
- [x] IP whitelist bypasses rate limiting for internal services
- [x] Rate limit violations logged with security context (IP, endpoint, userID)
- [x] Graduated cooldown increases lock duration with repeated violations