### PR TITLE
fix: add PostGIS GIST spatial index on projects geometry column

### DIFF
--- a/project-portal/project-portal-backend/cmd/api/main.go
+++ b/project-portal/project-portal-backend/cmd/api/main.go
@@ -669,6 +669,8 @@ func runGeospatialDDL(db *gorm.DB) error {
 			alert_id UUID,
 			created_at TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP
 		)`,
+		"ALTER TABLE projects ADD COLUMN IF NOT EXISTS geometry GEOGRAPHY(GEOMETRY, 4326)",
+		"CREATE INDEX IF NOT EXISTS idx_projects_geometry ON projects USING GIST (geometry)",
 	}
 
 	for _, stmt := range stmts {

--- a/project-portal/project-portal-backend/internal/database/migrations/023_add_projects_geometry_index.up.sql
+++ b/project-portal/project-portal-backend/internal/database/migrations/023_add_projects_geometry_index.up.sql
@@ -1,0 +1,11 @@
+-- Migration: 023_add_projects_geometry_index
+-- Description: Add geometry column and GIST spatial index to projects table
+-- Date: 2026-08-07
+
+-- Add geometry column to projects table for direct spatial queries
+ALTER TABLE projects ADD COLUMN IF NOT EXISTS geometry GEOGRAPHY(GEOMETRY, 4326);
+
+-- Create GIST spatial index on the projects geometry column
+-- This enables efficient spatial intersection, proximity, and containment queries
+-- directly on the projects table without requiring a JOIN to project_geometries
+CREATE INDEX IF NOT EXISTS idx_projects_geometry ON projects USING GIST (geometry);


### PR DESCRIPTION
## Summary

Adds a PostGIS GIST spatial index migration for the projects table geometry column to resolve slow spatial intersection queries.

## Problem

- No `CREATE INDEX USING GIST` migration existed for the projects geometry column
- The `011_geospatial_tables.up.sql` migration has GIST indexes on `project_geometries` and `administrative_boundaries`, but the `projects` table itself had no geometry column or spatial index
- This caused slow spatial intersection queries when querying directly against the projects table

## Changes

### New migration file
- **`023_add_projects_geometry_index.up.sql`**: Adds a `geometry GEOGRAPHY(GEOMETRY, 4326)` column to the `projects` table and creates a GIST index (`idx_projects_geometry`) on it

### Updated application DDL
- **`cmd/api/main.go`**: Updated `runGeospatialDDL()` to include the same `ALTER TABLE ... ADD COLUMN` and `CREATE INDEX` statements for new deployments

## Testing
- The migration uses `IF NOT EXISTS` guards to be idempotent
- All statements follow the existing patterns used in `011_geospatial_tables.up.sql`

Closes #431