### PR TITLE
feat: require email verification before account activation (Closes #470)

### DIFF
--- a/project-portal/project-portal-backend/internal/auth/service.go
+++ b/project-portal/project-portal-backend/internal/auth/service.go
@@ -65,7 +65,7 @@ func (s *Service) Register(email, password, fullName, organization string) (*Use
 		Organization:  organization,
 		Role:          "farmer",
 		EmailVerified: false,
-		IsActive:      true,
+		IsActive:      false, // pending email verification — cannot log in until verified (#470)
 		CreatedAt:     time.Now(),
 		UpdatedAt:     time.Now(),
 	}
@@ -98,6 +98,11 @@ func (s *Service) Login(email, password string, ipAddress, userAgent string) (*A
 	// Verify password
 	if err := utils.VerifyPassword(user.PasswordHash, password); err != nil {
 		return nil, errors.New("invalid email or password")
+	}
+
+	// Reject unverified users — they must confirm email ownership before login (#470)
+	if !user.EmailVerified {
+		return nil, errors.New("email not verified — please check your inbox for the verification link")
 	}
 
 	// Check if user is active
@@ -329,8 +334,9 @@ func (s *Service) VerifyEmail(token string) error {
 		return errors.New("user not found")
 	}
 
-	// Update email verified
+	// Update email verified and activate the account
 	user.EmailVerified = true
+	user.IsActive = true
 	user.UpdatedAt = time.Now()
 
 	if err := s.repository.UpdateUser(user); err != nil {


### PR DESCRIPTION
## Summary
Fixes the email-verification gap in the registration flow. Registered users were immediately set to `is_active=true`, which let anyone log in with an email/password before proving they own the email address.

## Changes (`internal/auth/service.go`)
1. **`Register`** — new users are now created with `is_active=false` (pending verification). They cannot log in until their email is confirmed.
2. **`Login`** — rejects unverified users with a clear error: `"email not verified — please check your inbox for the verification link"`.
3. **`VerifyEmail`** — now flips the account to `is_active=true` in addition to `email_verified=true`, so confirming the token actually activates the account.

The verification token plumbing (`Register` -> `generateAuthToken(..., "email_verification", 24h)`, the `POST /verify-email` route, and the `AuthToken` storage) already existed — the missing piece was that accounts were active from the start, so the token was never a gate.

## Notes
- Wallet-only users (Stellar `wallet-login`) are unaffected: they authenticate by wallet signature and have no real email, so they remain active.
- Seeded dev users (`internal/seed/seeder.go`) are already created with `email_verified=true`, so local login keeps working.
- `go build ./internal/auth/...` passes (exit 0).

Closes #470
