### PR TITLE
Feature/anthropic agents postgis spatial

### DIFF
--- a/agent-service/src/agents/compliance-report/compliance-report.agent.test.ts
+++ b/agent-service/src/agents/compliance-report/compliance-report.agent.test.ts
@@ -1,0 +1,271 @@
+import Anthropic from "@anthropic-ai/sdk";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const auditRecord = vi.fn().mockResolvedValue(undefined);
+vi.mock("../../shared/audit/audit-log.service.js", () => ({
+  auditLog: { record: (...args: unknown[]) => auditRecord(...args) },
+}));
+
+const toolRunnerMock = vi.fn();
+vi.mock("../../llm/client.js", () => ({
+  anthropic: {
+    beta: {
+      messages: {
+        toolRunner: (...args: unknown[]) => toolRunnerMock(...args),
+      },
+    },
+  },
+  DEFAULT_MODEL: "claude-opus-5",
+}));
+
+const { runComplianceReportAgent } =
+  await import("./compliance-report.agent.js");
+
+interface FakeRunnerOptions {
+  finalMessage?: { stop_reason: string; content: unknown[] };
+  error?: unknown;
+  messages?: unknown[];
+}
+
+function fakeRunner({ finalMessage, error, messages = [] }: FakeRunnerOptions) {
+  return {
+    params: { messages },
+    then(
+      onFulfilled?: ((value: unknown) => unknown) | null,
+      onRejected?: ((reason: unknown) => unknown) | null,
+    ) {
+      const base =
+        error !== undefined
+          ? Promise.reject(error)
+          : Promise.resolve(finalMessage);
+      return base.then(onFulfilled ?? undefined, onRejected ?? undefined);
+    },
+  };
+}
+
+function finalTextMessage(output: unknown) {
+  return {
+    stop_reason: "end_turn",
+    content: [{ type: "text", text: JSON.stringify(output) }],
+  };
+}
+
+describe("runComplianceReportAgent", () => {
+  beforeEach(() => {
+    toolRunnerMock.mockReset();
+    auditRecord.mockClear();
+  });
+
+  it("wires the tool runner with complianceReportTools, DEFAULT_MODEL, and SYSTEM_PROMPT", async () => {
+    toolRunnerMock.mockReturnValue(
+      fakeRunner({
+        finalMessage: finalTextMessage({
+          sections: [],
+          gaps: [],
+          citations: [],
+        }),
+      }),
+    );
+
+    await runComplianceReportAgent({
+      requestId: "req-0",
+      requestedBy: "user-1",
+      input: {},
+    });
+
+    expect(toolRunnerMock).toHaveBeenCalledTimes(1);
+    const params = toolRunnerMock.mock.calls[0]![0];
+    expect(params.model).toBe("claude-opus-5");
+    expect(params.system).toContain("compliance-report drafting agent");
+    expect(params.tools.map((t: { name: string }) => t.name)).toContain(
+      "get_company_retirement_evidence",
+    );
+  });
+
+  it.each([
+    {
+      label: "a complete draft with no gaps",
+      output: {
+        framework: "csrd",
+        sections: [{ name: "Scope 3 Emissions", content: "..." }],
+        gaps: [],
+        citations: [{ source: "retirement-ledger", reference: "R-001" }],
+      },
+    },
+    {
+      label: "a draft with flagged gaps and no framework match",
+      output: {
+        sections: [],
+        gaps: [{ description: "No retirement records found for period." }],
+        citations: [],
+      },
+    },
+  ])(
+    "always returns status needs-approval on success, never drafted ($label)",
+    async ({ output }) => {
+      toolRunnerMock.mockReturnValue(
+        fakeRunner({ finalMessage: finalTextMessage(output) }),
+      );
+
+      const result = await runComplianceReportAgent({
+        requestId: "req-guardrail",
+        requestedBy: "user-1",
+        input: {},
+      });
+
+      expect(result.status).toBe("needs-approval");
+      expect(result.status).not.toBe("drafted");
+    },
+  );
+
+  it("records a needs-approval audit entry (never drafted) and maps citations on success", async () => {
+    const output = {
+      framework: "cbam",
+      sections: [{ name: "Embedded Emissions", content: "..." }],
+      gaps: [{ description: "Missing supplier attestation for Q3." }],
+      citations: [{ source: "portfolio", reference: "P-42" }],
+    };
+    const assistantToolUseMessage = {
+      role: "assistant",
+      content: [
+        {
+          type: "tool_use",
+          id: "call_1",
+          name: "get_company_retirement_evidence",
+          input: {
+            companyId: "co-1",
+            framework: "cbam",
+            periodStart: "2026-01-01",
+            periodEnd: "2026-06-30",
+          },
+        },
+      ],
+    };
+
+    toolRunnerMock.mockReturnValue(
+      fakeRunner({
+        finalMessage: finalTextMessage(output),
+        messages: [{ role: "user", content: "..." }, assistantToolUseMessage],
+      }),
+    );
+
+    const result = await runComplianceReportAgent({
+      requestId: "req-1",
+      requestedBy: "user-1",
+      input: { companyId: "co-1" },
+    });
+
+    expect(result.status).toBe("needs-approval");
+    expect(result.citations).toEqual(output.citations);
+    expect(result.output).toEqual({
+      framework: output.framework,
+      sections: output.sections,
+      gaps: output.gaps,
+    });
+    expect(auditRecord).toHaveBeenCalledWith(
+      expect.objectContaining({
+        agent: "compliance-report",
+        requestId: "req-1",
+        status: "needs-approval",
+        toolCalls: [
+          {
+            name: "get_company_retirement_evidence",
+            input: {
+              companyId: "co-1",
+              framework: "cbam",
+              periodStart: "2026-01-01",
+              periodEnd: "2026-06-30",
+            },
+          },
+        ],
+      }),
+    );
+  });
+
+  it("returns a failed result distinguishing an Anthropic API failure, and records a failed audit entry", async () => {
+    const apiError = new Anthropic.APIError(
+      500,
+      { message: "internal error" },
+      "internal error",
+      undefined,
+    );
+    toolRunnerMock.mockReturnValue(fakeRunner({ error: apiError }));
+
+    const result = await runComplianceReportAgent({
+      requestId: "req-2",
+      requestedBy: "user-1",
+      input: {},
+    });
+
+    expect(result.status).toBe("failed");
+    expect((result.output as { error: string }).error).toContain(
+      "Anthropic API error",
+    );
+    expect(auditRecord).toHaveBeenCalledWith(
+      expect.objectContaining({
+        agent: "compliance-report",
+        requestId: "req-2",
+        status: "failed",
+      }),
+    );
+  });
+
+  it("returns a failed result distinguishing a non-API failure", async () => {
+    toolRunnerMock.mockReturnValue(
+      fakeRunner({ error: new Error("boom while iterating") }),
+    );
+
+    const result = await runComplianceReportAgent({
+      requestId: "req-4",
+      requestedBy: "user-1",
+      input: {},
+    });
+
+    expect(result.status).toBe("failed");
+    expect((result.output as { error: string }).error).toContain(
+      "Compliance-report agent tool execution failed",
+    );
+  });
+
+  it("returns a failed result when the final output cannot be parsed against the schema", async () => {
+    toolRunnerMock.mockReturnValue(
+      fakeRunner({
+        finalMessage: {
+          stop_reason: "end_turn",
+          content: [{ type: "text", text: "not json" }],
+        },
+      }),
+    );
+
+    const result = await runComplianceReportAgent({
+      requestId: "req-3",
+      requestedBy: "user-1",
+      input: {},
+    });
+
+    expect(result.status).toBe("failed");
+    expect((result.output as { error: string }).error).toContain(
+      "could not be parsed",
+    );
+    expect(auditRecord).toHaveBeenCalledWith(
+      expect.objectContaining({ status: "failed" }),
+    );
+  });
+
+  it("returns a failed result on a refusal-terminated turn", async () => {
+    toolRunnerMock.mockReturnValue(
+      fakeRunner({
+        finalMessage: { stop_reason: "refusal", content: [] },
+      }),
+    );
+
+    const result = await runComplianceReportAgent({
+      requestId: "req-5",
+      requestedBy: "user-1",
+      input: {},
+    });
+
+    expect(result.status).toBe("failed");
+    expect((result.output as { error: string }).error).toContain("declined");
+  });
+});

--- a/agent-service/src/agents/compliance-report/compliance-report.agent.ts
+++ b/agent-service/src/agents/compliance-report/compliance-report.agent.ts
@@ -1,6 +1,10 @@
+import Anthropic from "@anthropic-ai/sdk";
+import { betaZodOutputFormat } from "@anthropic-ai/sdk/helpers/beta/zod";
+import { z } from "zod";
 import { anthropic, DEFAULT_MODEL } from "../../llm/client.js";
 import { auditLog } from "../../shared/audit/audit-log.service.js";
 import type {
+  AgentCitation,
   AgentRunRequest,
   AgentRunResult,
 } from "../../shared/types/agent.types.js";
@@ -13,26 +17,191 @@ claim in the fetched evidence and cite the specific records used. Explicitly fla
 inconsistency that needs human review before this report can be submitted — never paper over
 missing data.`;
 
-// TODO: placeholder shape — wire the real tool runner call once
-// compliance-report.tools.ts is implemented. This agent's output must
-// always come back as status "needs-approval" (see shared/guardrails) —
-// no auto-submission to a regulator, ever.
+// This agent's output must always come back as status "needs-approval" (see
+// shared/guardrails) — no auto-submission to a regulator, ever. That is
+// enforced below in code, not by anything the model returns, so the schema
+// carries no status field of its own to hard-code around.
+const ComplianceReportOutputSchema = z.object({
+  framework: z
+    .enum(["csrd", "cbam", "corsia", "sbti", "ghg-protocol"])
+    .optional(),
+  sections: z.array(
+    z.object({
+      name: z.string(),
+      content: z.string(),
+    }),
+  ),
+  gaps: z
+    .array(
+      z.object({
+        description: z.string(),
+      }),
+    )
+    .describe(
+      "Data gaps or inconsistencies that need human review before this report can be submitted.",
+    ),
+  citations: z.array(
+    z.object({
+      source: z.string(),
+      reference: z.string(),
+    }),
+  ),
+});
+
+const outputFormat = betaZodOutputFormat(ComplianceReportOutputSchema);
+
+// Bounds retries against a still-unimplemented
+// get_company_retirement_evidence tool (tracked separately) so a
+// persistently failing tool call can't loop forever.
+const MAX_ITERATIONS = 8;
+
+interface ToolCallRecord {
+  name: string;
+  input: unknown;
+}
+
 export async function runComplianceReportAgent(
   req: AgentRunRequest,
 ): Promise<AgentRunResult> {
-  void anthropic;
-  void DEFAULT_MODEL;
-  void complianceReportTools;
-  void SYSTEM_PROMPT;
+  const runner = anthropic.beta.messages.toolRunner({
+    model: DEFAULT_MODEL,
+    max_tokens: 16000,
+    max_iterations: MAX_ITERATIONS,
+    system: SYSTEM_PROMPT,
+    tools: complianceReportTools,
+    output_config: { format: outputFormat },
+    messages: [
+      {
+        role: "user",
+        content: `Compliance report request (JSON):\n${JSON.stringify(req.input, null, 2)}`,
+      },
+    ],
+  });
+
+  function extractToolCalls(): ToolCallRecord[] {
+    const calls: ToolCallRecord[] = [];
+    for (const message of runner.params.messages) {
+      if (message.role !== "assistant" || typeof message.content === "string") {
+        continue;
+      }
+      for (const block of message.content) {
+        if (block.type === "tool_use") {
+          calls.push({ name: block.name, input: block.input });
+        }
+      }
+    }
+    return calls;
+  }
+
+  let finalMessage: Awaited<typeof runner>;
+  try {
+    finalMessage = await runner;
+  } catch (err) {
+    return failRun(req, extractToolCalls(), describeRunnerError(err));
+  }
+
+  const toolCalls = extractToolCalls();
+
+  // Refusal-terminated turns may cut a tool_use off mid-input (see
+  // BetaToolRunner), so there is no safe partial result to salvage here.
+  if (finalMessage.stop_reason === "refusal") {
+    return failRun(
+      req,
+      toolCalls,
+      "Anthropic declined to complete this compliance-report request.",
+    );
+  }
+
+  const textBlock = finalMessage.content.find(
+    (
+      block,
+    ): block is Extract<
+      (typeof finalMessage.content)[number],
+      { type: "text" }
+    > => block.type === "text",
+  );
+  if (!textBlock) {
+    return failRun(
+      req,
+      toolCalls,
+      "Compliance-report agent finished without producing a text response.",
+    );
+  }
+
+  let parsed: z.infer<typeof ComplianceReportOutputSchema>;
+  try {
+    parsed = outputFormat.parse(textBlock.text);
+  } catch (err) {
+    return failRun(
+      req,
+      toolCalls,
+      `Compliance-report agent returned output that could not be parsed: ${
+        err instanceof Error ? err.message : String(err)
+      }`,
+    );
+  }
 
   await auditLog.record({
     timestamp: new Date().toISOString(),
     agent: "compliance-report",
     requestId: req.requestId,
     requestedBy: req.requestedBy,
-    toolCalls: [],
+    toolCalls,
+    status: "needs-approval",
+  });
+
+  const citations: AgentCitation[] = parsed.citations;
+
+  // Hard-coded, not derived from the model's output: a compliance report
+  // always requires human sign-off before submission, regardless of how
+  // complete or confident the draft looks.
+  return {
+    agent: "compliance-report",
+    requestId: req.requestId,
+    status: "needs-approval",
+    output: {
+      framework: parsed.framework,
+      sections: parsed.sections,
+      gaps: parsed.gaps,
+    },
+    citations,
+  };
+}
+
+// The tool runner already catches an individual tool's run() throwing and
+// feeds it back to the model as an is_error tool_result (see
+// generateToolResponse in @anthropic-ai/sdk's BetaToolRunner) — the model
+// gets a chance to recover or flag the affected section as a gap. An error
+// only reaches here for a genuine Anthropic API failure (network, auth,
+// rate limit, 5xx) or something outside that per-tool recovery path, so the
+// two are distinguished by whether it is an Anthropic.APIError.
+function describeRunnerError(err: unknown): string {
+  if (err instanceof Anthropic.APIError) {
+    return `Anthropic API error: ${err.message}`;
+  }
+  return `Compliance-report agent tool execution failed: ${
+    err instanceof Error ? err.message : String(err)
+  }`;
+}
+
+async function failRun(
+  req: AgentRunRequest,
+  toolCalls: ToolCallRecord[],
+  message: string,
+): Promise<AgentRunResult> {
+  await auditLog.record({
+    timestamp: new Date().toISOString(),
+    agent: "compliance-report",
+    requestId: req.requestId,
+    requestedBy: req.requestedBy,
+    toolCalls,
     status: "failed",
   });
 
-  throw new Error("not implemented");
+  return {
+    agent: "compliance-report",
+    requestId: req.requestId,
+    status: "failed",
+    output: { error: message },
+  };
 }

--- a/agent-service/src/agents/compliance-report/compliance-report.controller.test.ts
+++ b/agent-service/src/agents/compliance-report/compliance-report.controller.test.ts
@@ -1,0 +1,88 @@
+import express from "express";
+import request from "supertest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { AgentRunResult } from "../../shared/types/agent.types.js";
+
+const runComplianceReportAgentMock = vi.fn();
+vi.mock("./compliance-report.agent.js", () => ({
+  runComplianceReportAgent: (...args: unknown[]) =>
+    runComplianceReportAgentMock(...args),
+}));
+
+const { complianceReportRouter } =
+  await import("./compliance-report.controller.js");
+
+function buildApp() {
+  const app = express();
+  app.use(express.json());
+  app.use("/agents/compliance-report", complianceReportRouter);
+  return app;
+}
+
+describe("complianceReportRouter POST /run", () => {
+  beforeEach(() => {
+    runComplianceReportAgentMock.mockReset();
+  });
+
+  it("returns 200 with the result body for a needs-approval outcome", async () => {
+    const result: AgentRunResult = {
+      agent: "compliance-report",
+      requestId: "req-1",
+      status: "needs-approval",
+      output: { sections: [], gaps: [] },
+      citations: [],
+    };
+    runComplianceReportAgentMock.mockResolvedValue(result);
+
+    const res = await request(buildApp())
+      .post("/agents/compliance-report/run")
+      .send({ requestId: "req-1", requestedBy: "user-1", input: {} });
+
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual(result);
+    expect(res.body.status).toBe("needs-approval");
+  });
+
+  it("returns 502 with a well-formed body for a failed outcome instead of throwing", async () => {
+    const result: AgentRunResult = {
+      agent: "compliance-report",
+      requestId: "req-2",
+      status: "failed",
+      output: { error: "Anthropic API error: internal error" },
+    };
+    runComplianceReportAgentMock.mockResolvedValue(result);
+
+    const res = await request(buildApp())
+      .post("/agents/compliance-report/run")
+      .send({ requestId: "req-2", requestedBy: "user-1", input: {} });
+
+    expect(res.status).toBe(502);
+    expect(res.body).toEqual(result);
+  });
+
+  it("forwards an unexpected thrown error to the next error handler", async () => {
+    runComplianceReportAgentMock.mockRejectedValue(new Error("unexpected"));
+
+    const app = buildApp();
+    app.use(
+      (
+        err: unknown,
+        _req: express.Request,
+        res: express.Response,
+        // eslint-disable-next-line @typescript-eslint/no-unused-vars
+        _next: express.NextFunction,
+      ) => {
+        res.status(500).json({
+          error: err instanceof Error ? err.message : "internal error",
+        });
+      },
+    );
+
+    const res = await request(app)
+      .post("/agents/compliance-report/run")
+      .send({ requestId: "req-3", requestedBy: "user-1", input: {} });
+
+    expect(res.status).toBe(500);
+    expect(res.body.error).toBe("unexpected");
+  });
+});

--- a/agent-service/src/agents/compliance-report/compliance-report.controller.ts
+++ b/agent-service/src/agents/compliance-report/compliance-report.controller.ts
@@ -1,14 +1,32 @@
 import { Router } from "express";
-import type { AgentRunRequest } from "../../shared/types/agent.types.js";
+import type {
+  AgentRunRequest,
+  AgentRunResult,
+} from "../../shared/types/agent.types.js";
 import { runComplianceReportAgent } from "./compliance-report.agent.js";
 
 export const complianceReportRouter = Router();
+
+// runComplianceReportAgent resolves (never throws) for every expected
+// outcome — including an LLM or tool failure, which comes back as
+// status: "failed" with a well-formed body rather than an exception. Map
+// that outcome to a status code here instead of letting every case fall
+// through to the generic 500 error handler.
+function statusCodeFor(result: AgentRunResult): number {
+  switch (result.status) {
+    case "drafted":
+    case "needs-approval":
+      return 200;
+    case "failed":
+      return 502;
+  }
+}
 
 complianceReportRouter.post("/run", async (req, res, next) => {
   try {
     const body = req.body as AgentRunRequest;
     const result = await runComplianceReportAgent(body);
-    res.json(result);
+    res.status(statusCodeFor(result)).json(result);
   } catch (err) {
     next(err);
   }

--- a/agent-service/src/agents/discovery/discovery.agent.test.ts
+++ b/agent-service/src/agents/discovery/discovery.agent.test.ts
@@ -1,0 +1,223 @@
+import Anthropic from "@anthropic-ai/sdk";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const auditRecord = vi.fn().mockResolvedValue(undefined);
+vi.mock("../../shared/audit/audit-log.service.js", () => ({
+  auditLog: { record: (...args: unknown[]) => auditRecord(...args) },
+}));
+
+const toolRunnerMock = vi.fn();
+vi.mock("../../llm/client.js", () => ({
+  anthropic: {
+    beta: {
+      messages: {
+        toolRunner: (...args: unknown[]) => toolRunnerMock(...args),
+      },
+    },
+  },
+  DEFAULT_MODEL: "claude-opus-5",
+}));
+
+const { runDiscoveryAgent } = await import("./discovery.agent.js");
+
+interface FakeRunnerOptions {
+  finalMessage?: { stop_reason: string; content: unknown[] };
+  error?: unknown;
+  messages?: unknown[];
+}
+
+function fakeRunner({ finalMessage, error, messages = [] }: FakeRunnerOptions) {
+  return {
+    params: { messages },
+    then(
+      onFulfilled?: ((value: unknown) => unknown) | null,
+      onRejected?: ((reason: unknown) => unknown) | null,
+    ) {
+      const base =
+        error !== undefined
+          ? Promise.reject(error)
+          : Promise.resolve(finalMessage);
+      return base.then(onFulfilled ?? undefined, onRejected ?? undefined);
+    },
+  };
+}
+
+describe("runDiscoveryAgent", () => {
+  beforeEach(() => {
+    toolRunnerMock.mockReset();
+    auditRecord.mockClear();
+  });
+
+  it("wires the tool runner with discoveryTools, DEFAULT_MODEL, and SYSTEM_PROMPT", async () => {
+    toolRunnerMock.mockReturnValue(
+      fakeRunner({
+        finalMessage: {
+          stop_reason: "end_turn",
+          content: [
+            {
+              type: "text",
+              text: JSON.stringify({ recommendations: [], citations: [] }),
+            },
+          ],
+        },
+      }),
+    );
+
+    await runDiscoveryAgent({
+      requestId: "req-0",
+      requestedBy: "user-1",
+      input: {},
+    });
+
+    expect(toolRunnerMock).toHaveBeenCalledTimes(1);
+    const params = toolRunnerMock.mock.calls[0]![0];
+    expect(params.model).toBe("claude-opus-5");
+    expect(params.system).toContain("credit-discovery agent");
+    expect(params.tools.map((t: { name: string }) => t.name)).toContain(
+      "search_marketplace_credits",
+    );
+  });
+
+  it("returns a drafted result and records a drafted audit entry on success", async () => {
+    const output = {
+      recommendations: [
+        { creditId: "credit-1", justification: "Matches sector and budget." },
+      ],
+      citations: [{ source: "marketplace", reference: "credit-1" }],
+    };
+    const assistantToolUseMessage = {
+      role: "assistant",
+      content: [
+        {
+          type: "tool_use",
+          id: "call_1",
+          name: "search_marketplace_credits",
+          input: { methodology: "REDD+" },
+        },
+      ],
+    };
+
+    toolRunnerMock.mockReturnValue(
+      fakeRunner({
+        finalMessage: {
+          stop_reason: "end_turn",
+          content: [{ type: "text", text: JSON.stringify(output) }],
+        },
+        messages: [{ role: "user", content: "..." }, assistantToolUseMessage],
+      }),
+    );
+
+    const result = await runDiscoveryAgent({
+      requestId: "req-1",
+      requestedBy: "user-1",
+      input: { budget: 1000 },
+    });
+
+    expect(result.status).toBe("drafted");
+    expect(result.citations).toEqual(output.citations);
+    expect(result.output).toEqual({
+      recommendations: output.recommendations,
+      notes: undefined,
+    });
+    expect(auditRecord).toHaveBeenCalledWith(
+      expect.objectContaining({
+        agent: "discovery",
+        requestId: "req-1",
+        status: "drafted",
+        toolCalls: [
+          {
+            name: "search_marketplace_credits",
+            input: { methodology: "REDD+" },
+          },
+        ],
+      }),
+    );
+  });
+
+  it("returns a failed result distinguishing an Anthropic API failure, and records a failed audit entry", async () => {
+    const apiError = new Anthropic.APIError(
+      500,
+      { message: "internal error" },
+      "internal error",
+      undefined,
+    );
+    toolRunnerMock.mockReturnValue(fakeRunner({ error: apiError }));
+
+    const result = await runDiscoveryAgent({
+      requestId: "req-2",
+      requestedBy: "user-1",
+      input: {},
+    });
+
+    expect(result.status).toBe("failed");
+    expect((result.output as { error: string }).error).toContain(
+      "Anthropic API error",
+    );
+    expect(auditRecord).toHaveBeenCalledWith(
+      expect.objectContaining({
+        agent: "discovery",
+        requestId: "req-2",
+        status: "failed",
+      }),
+    );
+  });
+
+  it("returns a failed result distinguishing a non-API failure", async () => {
+    toolRunnerMock.mockReturnValue(
+      fakeRunner({ error: new Error("boom while iterating") }),
+    );
+
+    const result = await runDiscoveryAgent({
+      requestId: "req-4",
+      requestedBy: "user-1",
+      input: {},
+    });
+
+    expect(result.status).toBe("failed");
+    expect((result.output as { error: string }).error).toContain(
+      "Discovery agent tool execution failed",
+    );
+  });
+
+  it("returns a failed result when the final output cannot be parsed against the schema", async () => {
+    toolRunnerMock.mockReturnValue(
+      fakeRunner({
+        finalMessage: {
+          stop_reason: "end_turn",
+          content: [{ type: "text", text: "not json" }],
+        },
+      }),
+    );
+
+    const result = await runDiscoveryAgent({
+      requestId: "req-3",
+      requestedBy: "user-1",
+      input: {},
+    });
+
+    expect(result.status).toBe("failed");
+    expect((result.output as { error: string }).error).toContain(
+      "could not be parsed",
+    );
+    expect(auditRecord).toHaveBeenCalledWith(
+      expect.objectContaining({ status: "failed" }),
+    );
+  });
+
+  it("returns a failed result on a refusal-terminated turn", async () => {
+    toolRunnerMock.mockReturnValue(
+      fakeRunner({
+        finalMessage: { stop_reason: "refusal", content: [] },
+      }),
+    );
+
+    const result = await runDiscoveryAgent({
+      requestId: "req-5",
+      requestedBy: "user-1",
+      input: {},
+    });
+
+    expect(result.status).toBe("failed");
+    expect((result.output as { error: string }).error).toContain("declined");
+  });
+});

--- a/agent-service/src/agents/discovery/discovery.agent.ts
+++ b/agent-service/src/agents/discovery/discovery.agent.ts
@@ -1,6 +1,10 @@
+import Anthropic from "@anthropic-ai/sdk";
+import { betaZodOutputFormat } from "@anthropic-ai/sdk/helpers/beta/zod";
+import { z } from "zod";
 import { anthropic, DEFAULT_MODEL } from "../../llm/client.js";
 import { auditLog } from "../../shared/audit/audit-log.service.js";
 import type {
+  AgentCitation,
   AgentRunRequest,
   AgentRunResult,
 } from "../../shared/types/agent.types.js";
@@ -13,24 +17,179 @@ for each. Always cite the specific credit records you relied on. Never claim a c
 "the best" without pointing to the data that supports it — this output feeds a compliance
 review, not just a recommendation widget.`;
 
-// TODO: this is a placeholder shape. Once the discovery.tools.ts calls are
-// real, run the tool runner and map its final message into AgentRunResult.
+// Forces the final turn into machine-readable JSON so citations can be
+// mapped onto the AgentCitation contract instead of scraped from prose.
+const DiscoveryOutputSchema = z.object({
+  recommendations: z.array(
+    z.object({
+      creditId: z.string(),
+      justification: z.string(),
+    }),
+  ),
+  citations: z.array(
+    z.object({
+      source: z.string(),
+      reference: z.string(),
+    }),
+  ),
+  notes: z
+    .string()
+    .optional()
+    .describe(
+      "Explanation for an empty or partial shortlist, e.g. no credits matched the buyer's criteria or the marketplace search was unavailable.",
+    ),
+});
+
+const outputFormat = betaZodOutputFormat(DiscoveryOutputSchema);
+
+// Bounds retries against a still-unimplemented search_marketplace_credits
+// tool (tracked separately) so a persistently failing tool call can't loop
+// forever.
+const MAX_ITERATIONS = 8;
+
+interface ToolCallRecord {
+  name: string;
+  input: unknown;
+}
+
 export async function runDiscoveryAgent(
   req: AgentRunRequest,
 ): Promise<AgentRunResult> {
-  void anthropic;
-  void DEFAULT_MODEL;
-  void discoveryTools;
-  void SYSTEM_PROMPT;
+  const runner = anthropic.beta.messages.toolRunner({
+    model: DEFAULT_MODEL,
+    max_tokens: 16000,
+    max_iterations: MAX_ITERATIONS,
+    system: SYSTEM_PROMPT,
+    tools: discoveryTools,
+    output_config: { format: outputFormat },
+    messages: [
+      {
+        role: "user",
+        content: `Buyer request (JSON):\n${JSON.stringify(req.input, null, 2)}`,
+      },
+    ],
+  });
+
+  function extractToolCalls(): ToolCallRecord[] {
+    const calls: ToolCallRecord[] = [];
+    for (const message of runner.params.messages) {
+      if (message.role !== "assistant" || typeof message.content === "string") {
+        continue;
+      }
+      for (const block of message.content) {
+        if (block.type === "tool_use") {
+          calls.push({ name: block.name, input: block.input });
+        }
+      }
+    }
+    return calls;
+  }
+
+  let finalMessage: Awaited<typeof runner>;
+  try {
+    finalMessage = await runner;
+  } catch (err) {
+    return failRun(req, extractToolCalls(), describeRunnerError(err));
+  }
+
+  const toolCalls = extractToolCalls();
+
+  // Refusal-terminated turns may cut a tool_use off mid-input (see
+  // BetaToolRunner), so there is no safe partial result to salvage here.
+  if (finalMessage.stop_reason === "refusal") {
+    return failRun(
+      req,
+      toolCalls,
+      "Anthropic declined to complete this discovery request.",
+    );
+  }
+
+  const textBlock = finalMessage.content.find(
+    (
+      block,
+    ): block is Extract<
+      (typeof finalMessage.content)[number],
+      { type: "text" }
+    > => block.type === "text",
+  );
+  if (!textBlock) {
+    return failRun(
+      req,
+      toolCalls,
+      "Discovery agent finished without producing a text response.",
+    );
+  }
+
+  let parsed: z.infer<typeof DiscoveryOutputSchema>;
+  try {
+    parsed = outputFormat.parse(textBlock.text);
+  } catch (err) {
+    return failRun(
+      req,
+      toolCalls,
+      `Discovery agent returned output that could not be parsed: ${
+        err instanceof Error ? err.message : String(err)
+      }`,
+    );
+  }
 
   await auditLog.record({
     timestamp: new Date().toISOString(),
     agent: "discovery",
     requestId: req.requestId,
     requestedBy: req.requestedBy,
-    toolCalls: [],
+    toolCalls,
+    status: "drafted",
+  });
+
+  const citations: AgentCitation[] = parsed.citations;
+
+  return {
+    agent: "discovery",
+    requestId: req.requestId,
+    status: "drafted",
+    output: {
+      recommendations: parsed.recommendations,
+      notes: parsed.notes,
+    },
+    citations,
+  };
+}
+
+// The tool runner already catches an individual tool's run() throwing and
+// feeds it back to the model as an is_error tool_result (see
+// generateToolResponse in @anthropic-ai/sdk's BetaToolRunner) — the model
+// gets a chance to recover or explain the gap in `notes`. An error only
+// reaches here for a genuine Anthropic API failure (network, auth, rate
+// limit, 5xx) or something outside that per-tool recovery path, so the two
+// are distinguished by whether it is an Anthropic.APIError.
+function describeRunnerError(err: unknown): string {
+  if (err instanceof Anthropic.APIError) {
+    return `Anthropic API error: ${err.message}`;
+  }
+  return `Discovery agent tool execution failed: ${
+    err instanceof Error ? err.message : String(err)
+  }`;
+}
+
+async function failRun(
+  req: AgentRunRequest,
+  toolCalls: ToolCallRecord[],
+  message: string,
+): Promise<AgentRunResult> {
+  await auditLog.record({
+    timestamp: new Date().toISOString(),
+    agent: "discovery",
+    requestId: req.requestId,
+    requestedBy: req.requestedBy,
+    toolCalls,
     status: "failed",
   });
 
-  throw new Error("not implemented");
+  return {
+    agent: "discovery",
+    requestId: req.requestId,
+    status: "failed",
+    output: { error: message },
+  };
 }

--- a/agent-service/src/agents/discovery/discovery.controller.test.ts
+++ b/agent-service/src/agents/discovery/discovery.controller.test.ts
@@ -1,0 +1,85 @@
+import express from "express";
+import request from "supertest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { AgentRunResult } from "../../shared/types/agent.types.js";
+
+const runDiscoveryAgentMock = vi.fn();
+vi.mock("./discovery.agent.js", () => ({
+  runDiscoveryAgent: (...args: unknown[]) => runDiscoveryAgentMock(...args),
+}));
+
+const { discoveryRouter } = await import("./discovery.controller.js");
+
+function buildApp() {
+  const app = express();
+  app.use(express.json());
+  app.use("/agents/discovery", discoveryRouter);
+  return app;
+}
+
+describe("discoveryRouter POST /run", () => {
+  beforeEach(() => {
+    runDiscoveryAgentMock.mockReset();
+  });
+
+  it("returns 200 with the result body for a drafted outcome", async () => {
+    const result: AgentRunResult = {
+      agent: "discovery",
+      requestId: "req-1",
+      status: "drafted",
+      output: { recommendations: [] },
+      citations: [],
+    };
+    runDiscoveryAgentMock.mockResolvedValue(result);
+
+    const res = await request(buildApp())
+      .post("/agents/discovery/run")
+      .send({ requestId: "req-1", requestedBy: "user-1", input: {} });
+
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual(result);
+  });
+
+  it("returns 502 with a well-formed body for a failed outcome instead of throwing", async () => {
+    const result: AgentRunResult = {
+      agent: "discovery",
+      requestId: "req-2",
+      status: "failed",
+      output: { error: "Anthropic API error: internal error" },
+    };
+    runDiscoveryAgentMock.mockResolvedValue(result);
+
+    const res = await request(buildApp())
+      .post("/agents/discovery/run")
+      .send({ requestId: "req-2", requestedBy: "user-1", input: {} });
+
+    expect(res.status).toBe(502);
+    expect(res.body).toEqual(result);
+  });
+
+  it("forwards an unexpected thrown error to the next error handler", async () => {
+    runDiscoveryAgentMock.mockRejectedValue(new Error("unexpected"));
+
+    const app = buildApp();
+    app.use(
+      (
+        err: unknown,
+        _req: express.Request,
+        res: express.Response,
+        // eslint-disable-next-line @typescript-eslint/no-unused-vars
+        _next: express.NextFunction,
+      ) => {
+        res.status(500).json({
+          error: err instanceof Error ? err.message : "internal error",
+        });
+      },
+    );
+
+    const res = await request(app)
+      .post("/agents/discovery/run")
+      .send({ requestId: "req-3", requestedBy: "user-1", input: {} });
+
+    expect(res.status).toBe(500);
+    expect(res.body.error).toBe("unexpected");
+  });
+});

--- a/agent-service/src/agents/discovery/discovery.controller.ts
+++ b/agent-service/src/agents/discovery/discovery.controller.ts
@@ -1,14 +1,32 @@
 import { Router } from "express";
-import type { AgentRunRequest } from "../../shared/types/agent.types.js";
+import type {
+  AgentRunRequest,
+  AgentRunResult,
+} from "../../shared/types/agent.types.js";
 import { runDiscoveryAgent } from "./discovery.agent.js";
 
 export const discoveryRouter = Router();
+
+// runDiscoveryAgent resolves (never throws) for every expected outcome —
+// including an LLM or tool failure, which comes back as status: "failed"
+// with a well-formed body rather than an exception. Map that outcome to a
+// status code here instead of letting every case fall through to the
+// generic 500 error handler.
+function statusCodeFor(result: AgentRunResult): number {
+  switch (result.status) {
+    case "drafted":
+    case "needs-approval":
+      return 200;
+    case "failed":
+      return 502;
+  }
+}
 
 discoveryRouter.post("/run", async (req, res, next) => {
   try {
     const body = req.body as AgentRunRequest;
     const result = await runDiscoveryAgent(body);
-    res.json(result);
+    res.status(statusCodeFor(result)).json(result);
   } catch (err) {
     next(err);
   }

--- a/agent-service/src/agents/pdd-draft/pdd-draft.agent.test.ts
+++ b/agent-service/src/agents/pdd-draft/pdd-draft.agent.test.ts
@@ -1,0 +1,233 @@
+import Anthropic from "@anthropic-ai/sdk";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const auditRecord = vi.fn().mockResolvedValue(undefined);
+vi.mock("../../shared/audit/audit-log.service.js", () => ({
+  auditLog: { record: (...args: unknown[]) => auditRecord(...args) },
+}));
+
+const toolRunnerMock = vi.fn();
+vi.mock("../../llm/client.js", () => ({
+  anthropic: {
+    beta: {
+      messages: {
+        toolRunner: (...args: unknown[]) => toolRunnerMock(...args),
+      },
+    },
+  },
+  DEFAULT_MODEL: "claude-opus-5",
+}));
+
+const { runPddDraftAgent } = await import("./pdd-draft.agent.js");
+
+interface FakeRunnerOptions {
+  finalMessage?: { stop_reason: string; content: unknown[] };
+  error?: unknown;
+  messages?: unknown[];
+}
+
+function fakeRunner({ finalMessage, error, messages = [] }: FakeRunnerOptions) {
+  return {
+    params: { messages },
+    then(
+      onFulfilled?: ((value: unknown) => unknown) | null,
+      onRejected?: ((reason: unknown) => unknown) | null,
+    ) {
+      const base =
+        error !== undefined
+          ? Promise.reject(error)
+          : Promise.resolve(finalMessage);
+      return base.then(onFulfilled ?? undefined, onRejected ?? undefined);
+    },
+  };
+}
+
+describe("runPddDraftAgent", () => {
+  beforeEach(() => {
+    toolRunnerMock.mockReset();
+    auditRecord.mockClear();
+  });
+
+  it("wires the tool runner with pddDraftTools, DEFAULT_MODEL, and SYSTEM_PROMPT", async () => {
+    toolRunnerMock.mockReturnValue(
+      fakeRunner({
+        finalMessage: {
+          stop_reason: "end_turn",
+          content: [
+            {
+              type: "text",
+              text: JSON.stringify({
+                sections: [],
+                incompleteSections: [],
+                citations: [],
+              }),
+            },
+          ],
+        },
+      }),
+    );
+
+    await runPddDraftAgent({
+      requestId: "req-0",
+      requestedBy: "user-1",
+      input: {},
+    });
+
+    expect(toolRunnerMock).toHaveBeenCalledTimes(1);
+    const params = toolRunnerMock.mock.calls[0]![0];
+    expect(params.model).toBe("claude-opus-5");
+    expect(params.system).toContain("PDD (Project Design Document)");
+    expect(params.tools.map((t: { name: string }) => t.name)).toContain(
+      "match_methodology",
+    );
+  });
+
+  it("returns a drafted result distinguishing drafted from incomplete sections, and records a drafted audit entry", async () => {
+    const output = {
+      methodology: "agroforestry",
+      sections: [{ name: "Project Description", content: "..." }],
+      incompleteSections: [
+        {
+          name: "Baseline Carbon Stock",
+          reason: "No soil sample data provided by the developer.",
+        },
+      ],
+      citations: [{ source: "methodology-registry", reference: "AGRO-01" }],
+    };
+    const assistantToolUseMessage = {
+      role: "assistant",
+      content: [
+        {
+          type: "tool_use",
+          id: "call_1",
+          name: "match_methodology",
+          input: { activityType: "agroforestry", country: "KE" },
+        },
+      ],
+    };
+
+    toolRunnerMock.mockReturnValue(
+      fakeRunner({
+        finalMessage: {
+          stop_reason: "end_turn",
+          content: [{ type: "text", text: JSON.stringify(output) }],
+        },
+        messages: [{ role: "user", content: "..." }, assistantToolUseMessage],
+      }),
+    );
+
+    const result = await runPddDraftAgent({
+      requestId: "req-1",
+      requestedBy: "user-1",
+      input: { activityType: "agroforestry" },
+    });
+
+    expect(result.status).toBe("drafted");
+    expect(result.citations).toEqual(output.citations);
+    expect(result.output).toEqual({
+      methodology: output.methodology,
+      sections: output.sections,
+      incompleteSections: output.incompleteSections,
+    });
+    expect(auditRecord).toHaveBeenCalledWith(
+      expect.objectContaining({
+        agent: "pdd-draft",
+        requestId: "req-1",
+        status: "drafted",
+        toolCalls: [
+          {
+            name: "match_methodology",
+            input: { activityType: "agroforestry", country: "KE" },
+          },
+        ],
+      }),
+    );
+  });
+
+  it("returns a failed result distinguishing an Anthropic API failure, and records a failed audit entry", async () => {
+    const apiError = new Anthropic.APIError(
+      500,
+      { message: "internal error" },
+      "internal error",
+      undefined,
+    );
+    toolRunnerMock.mockReturnValue(fakeRunner({ error: apiError }));
+
+    const result = await runPddDraftAgent({
+      requestId: "req-2",
+      requestedBy: "user-1",
+      input: {},
+    });
+
+    expect(result.status).toBe("failed");
+    expect((result.output as { error: string }).error).toContain(
+      "Anthropic API error",
+    );
+    expect(auditRecord).toHaveBeenCalledWith(
+      expect.objectContaining({
+        agent: "pdd-draft",
+        requestId: "req-2",
+        status: "failed",
+      }),
+    );
+  });
+
+  it("returns a failed result distinguishing a non-API failure", async () => {
+    toolRunnerMock.mockReturnValue(
+      fakeRunner({ error: new Error("boom while iterating") }),
+    );
+
+    const result = await runPddDraftAgent({
+      requestId: "req-4",
+      requestedBy: "user-1",
+      input: {},
+    });
+
+    expect(result.status).toBe("failed");
+    expect((result.output as { error: string }).error).toContain(
+      "PDD drafting agent tool execution failed",
+    );
+  });
+
+  it("returns a failed result when the final output cannot be parsed against the schema", async () => {
+    toolRunnerMock.mockReturnValue(
+      fakeRunner({
+        finalMessage: {
+          stop_reason: "end_turn",
+          content: [{ type: "text", text: "not json" }],
+        },
+      }),
+    );
+
+    const result = await runPddDraftAgent({
+      requestId: "req-3",
+      requestedBy: "user-1",
+      input: {},
+    });
+
+    expect(result.status).toBe("failed");
+    expect((result.output as { error: string }).error).toContain(
+      "could not be parsed",
+    );
+    expect(auditRecord).toHaveBeenCalledWith(
+      expect.objectContaining({ status: "failed" }),
+    );
+  });
+
+  it("returns a failed result on a refusal-terminated turn", async () => {
+    toolRunnerMock.mockReturnValue(
+      fakeRunner({
+        finalMessage: { stop_reason: "refusal", content: [] },
+      }),
+    );
+
+    const result = await runPddDraftAgent({
+      requestId: "req-5",
+      requestedBy: "user-1",
+      input: {},
+    });
+
+    expect(result.status).toBe("failed");
+    expect((result.output as { error: string }).error).toContain("declined");
+  });
+});

--- a/agent-service/src/agents/pdd-draft/pdd-draft.agent.ts
+++ b/agent-service/src/agents/pdd-draft/pdd-draft.agent.ts
@@ -1,6 +1,10 @@
+import Anthropic from "@anthropic-ai/sdk";
+import { betaZodOutputFormat } from "@anthropic-ai/sdk/helpers/beta/zod";
+import { z } from "zod";
 import { anthropic, DEFAULT_MODEL } from "../../llm/client.js";
 import { auditLog } from "../../shared/audit/audit-log.service.js";
 import type {
+  AgentCitation,
   AgentRunRequest,
   AgentRunResult,
 } from "../../shared/types/agent.types.js";
@@ -12,24 +16,186 @@ match it to the correct methodology, identify missing required documentation, an
 PDD sections you have enough grounded data for. Flag any section you cannot complete rather
 than inventing figures — this document supports carbon credit issuance.`;
 
-// TODO: placeholder shape — wire the real tool runner call once
-// pdd-draft.tools.ts is implemented.
+// Forces the final turn into machine-readable JSON so drafted sections are
+// kept structurally separate from ones the agent explicitly refused to
+// invent data for — the whole point of the "flag, don't fabricate" rule in
+// the prompt above.
+const PddOutputSchema = z.object({
+  methodology: z
+    .string()
+    .optional()
+    .describe("The matched methodology, if one could be determined."),
+  sections: z.array(
+    z.object({
+      name: z.string(),
+      content: z.string(),
+    }),
+  ),
+  incompleteSections: z.array(
+    z.object({
+      name: z.string(),
+      reason: z.string(),
+    }),
+  ),
+  citations: z.array(
+    z.object({
+      source: z.string(),
+      reference: z.string(),
+    }),
+  ),
+});
+
+const outputFormat = betaZodOutputFormat(PddOutputSchema);
+
+// Bounds retries against a still-unimplemented match_methodology tool
+// (tracked separately) so a persistently failing tool call can't loop
+// forever.
+const MAX_ITERATIONS = 8;
+
+interface ToolCallRecord {
+  name: string;
+  input: unknown;
+}
+
 export async function runPddDraftAgent(
   req: AgentRunRequest,
 ): Promise<AgentRunResult> {
-  void anthropic;
-  void DEFAULT_MODEL;
-  void pddDraftTools;
-  void SYSTEM_PROMPT;
+  const runner = anthropic.beta.messages.toolRunner({
+    model: DEFAULT_MODEL,
+    max_tokens: 16000,
+    max_iterations: MAX_ITERATIONS,
+    system: SYSTEM_PROMPT,
+    tools: pddDraftTools,
+    output_config: { format: outputFormat },
+    messages: [
+      {
+        role: "user",
+        content: `Project developer submission (JSON):\n${JSON.stringify(req.input, null, 2)}`,
+      },
+    ],
+  });
+
+  function extractToolCalls(): ToolCallRecord[] {
+    const calls: ToolCallRecord[] = [];
+    for (const message of runner.params.messages) {
+      if (message.role !== "assistant" || typeof message.content === "string") {
+        continue;
+      }
+      for (const block of message.content) {
+        if (block.type === "tool_use") {
+          calls.push({ name: block.name, input: block.input });
+        }
+      }
+    }
+    return calls;
+  }
+
+  let finalMessage: Awaited<typeof runner>;
+  try {
+    finalMessage = await runner;
+  } catch (err) {
+    return failRun(req, extractToolCalls(), describeRunnerError(err));
+  }
+
+  const toolCalls = extractToolCalls();
+
+  // Refusal-terminated turns may cut a tool_use off mid-input (see
+  // BetaToolRunner), so there is no safe partial result to salvage here.
+  if (finalMessage.stop_reason === "refusal") {
+    return failRun(
+      req,
+      toolCalls,
+      "Anthropic declined to complete this PDD drafting request.",
+    );
+  }
+
+  const textBlock = finalMessage.content.find(
+    (
+      block,
+    ): block is Extract<
+      (typeof finalMessage.content)[number],
+      { type: "text" }
+    > => block.type === "text",
+  );
+  if (!textBlock) {
+    return failRun(
+      req,
+      toolCalls,
+      "PDD drafting agent finished without producing a text response.",
+    );
+  }
+
+  let parsed: z.infer<typeof PddOutputSchema>;
+  try {
+    parsed = outputFormat.parse(textBlock.text);
+  } catch (err) {
+    return failRun(
+      req,
+      toolCalls,
+      `PDD drafting agent returned output that could not be parsed: ${
+        err instanceof Error ? err.message : String(err)
+      }`,
+    );
+  }
 
   await auditLog.record({
     timestamp: new Date().toISOString(),
     agent: "pdd-draft",
     requestId: req.requestId,
     requestedBy: req.requestedBy,
-    toolCalls: [],
+    toolCalls,
+    status: "drafted",
+  });
+
+  const citations: AgentCitation[] = parsed.citations;
+
+  return {
+    agent: "pdd-draft",
+    requestId: req.requestId,
+    status: "drafted",
+    output: {
+      methodology: parsed.methodology,
+      sections: parsed.sections,
+      incompleteSections: parsed.incompleteSections,
+    },
+    citations,
+  };
+}
+
+// The tool runner already catches an individual tool's run() throwing and
+// feeds it back to the model as an is_error tool_result (see
+// generateToolResponse in @anthropic-ai/sdk's BetaToolRunner) — the model
+// gets a chance to recover or flag the affected section as incomplete. An
+// error only reaches here for a genuine Anthropic API failure (network,
+// auth, rate limit, 5xx) or something outside that per-tool recovery path,
+// so the two are distinguished by whether it is an Anthropic.APIError.
+function describeRunnerError(err: unknown): string {
+  if (err instanceof Anthropic.APIError) {
+    return `Anthropic API error: ${err.message}`;
+  }
+  return `PDD drafting agent tool execution failed: ${
+    err instanceof Error ? err.message : String(err)
+  }`;
+}
+
+async function failRun(
+  req: AgentRunRequest,
+  toolCalls: ToolCallRecord[],
+  message: string,
+): Promise<AgentRunResult> {
+  await auditLog.record({
+    timestamp: new Date().toISOString(),
+    agent: "pdd-draft",
+    requestId: req.requestId,
+    requestedBy: req.requestedBy,
+    toolCalls,
     status: "failed",
   });
 
-  throw new Error("not implemented");
+  return {
+    agent: "pdd-draft",
+    requestId: req.requestId,
+    status: "failed",
+    output: { error: message },
+  };
 }

--- a/agent-service/src/agents/pdd-draft/pdd-draft.controller.test.ts
+++ b/agent-service/src/agents/pdd-draft/pdd-draft.controller.test.ts
@@ -1,0 +1,85 @@
+import express from "express";
+import request from "supertest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { AgentRunResult } from "../../shared/types/agent.types.js";
+
+const runPddDraftAgentMock = vi.fn();
+vi.mock("./pdd-draft.agent.js", () => ({
+  runPddDraftAgent: (...args: unknown[]) => runPddDraftAgentMock(...args),
+}));
+
+const { pddDraftRouter } = await import("./pdd-draft.controller.js");
+
+function buildApp() {
+  const app = express();
+  app.use(express.json());
+  app.use("/agents/pdd-draft", pddDraftRouter);
+  return app;
+}
+
+describe("pddDraftRouter POST /run", () => {
+  beforeEach(() => {
+    runPddDraftAgentMock.mockReset();
+  });
+
+  it("returns 200 with the result body for a drafted outcome", async () => {
+    const result: AgentRunResult = {
+      agent: "pdd-draft",
+      requestId: "req-1",
+      status: "drafted",
+      output: { sections: [], incompleteSections: [] },
+      citations: [],
+    };
+    runPddDraftAgentMock.mockResolvedValue(result);
+
+    const res = await request(buildApp())
+      .post("/agents/pdd-draft/run")
+      .send({ requestId: "req-1", requestedBy: "user-1", input: {} });
+
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual(result);
+  });
+
+  it("returns 502 with a well-formed body for a failed outcome instead of throwing", async () => {
+    const result: AgentRunResult = {
+      agent: "pdd-draft",
+      requestId: "req-2",
+      status: "failed",
+      output: { error: "Anthropic API error: internal error" },
+    };
+    runPddDraftAgentMock.mockResolvedValue(result);
+
+    const res = await request(buildApp())
+      .post("/agents/pdd-draft/run")
+      .send({ requestId: "req-2", requestedBy: "user-1", input: {} });
+
+    expect(res.status).toBe(502);
+    expect(res.body).toEqual(result);
+  });
+
+  it("forwards an unexpected thrown error to the next error handler", async () => {
+    runPddDraftAgentMock.mockRejectedValue(new Error("unexpected"));
+
+    const app = buildApp();
+    app.use(
+      (
+        err: unknown,
+        _req: express.Request,
+        res: express.Response,
+        // eslint-disable-next-line @typescript-eslint/no-unused-vars
+        _next: express.NextFunction,
+      ) => {
+        res.status(500).json({
+          error: err instanceof Error ? err.message : "internal error",
+        });
+      },
+    );
+
+    const res = await request(app)
+      .post("/agents/pdd-draft/run")
+      .send({ requestId: "req-3", requestedBy: "user-1", input: {} });
+
+    expect(res.status).toBe(500);
+    expect(res.body.error).toBe("unexpected");
+  });
+});

--- a/agent-service/src/agents/pdd-draft/pdd-draft.controller.ts
+++ b/agent-service/src/agents/pdd-draft/pdd-draft.controller.ts
@@ -1,14 +1,32 @@
 import { Router } from "express";
-import type { AgentRunRequest } from "../../shared/types/agent.types.js";
+import type {
+  AgentRunRequest,
+  AgentRunResult,
+} from "../../shared/types/agent.types.js";
 import { runPddDraftAgent } from "./pdd-draft.agent.js";
 
 export const pddDraftRouter = Router();
+
+// runPddDraftAgent resolves (never throws) for every expected outcome —
+// including an LLM or tool failure, which comes back as status: "failed"
+// with a well-formed body rather than an exception. Map that outcome to a
+// status code here instead of letting every case fall through to the
+// generic 500 error handler.
+function statusCodeFor(result: AgentRunResult): number {
+  switch (result.status) {
+    case "drafted":
+    case "needs-approval":
+      return 200;
+    case "failed":
+      return 502;
+  }
+}
 
 pddDraftRouter.post("/run", async (req, res, next) => {
   try {
     const body = req.body as AgentRunRequest;
     const result = await runPddDraftAgent(body);
-    res.json(result);
+    res.status(statusCodeFor(result)).json(result);
   } catch (err) {
     next(err);
   }

--- a/project-portal/project-portal-backend/internal/database/migrations/023_spatial_indexes.up.sql
+++ b/project-portal/project-portal-backend/internal/database/migrations/023_spatial_indexes.up.sql
@@ -1,0 +1,45 @@
+-- Migration: 023_spatial_indexes
+-- Description: Add missing GIST/BRIN spatial indexes for geospatial query patterns (issue #431)
+-- Date: 2026-08-26
+
+-- btree_gist lets us build composite GIST indexes that mix an equality/range
+-- column (uuid, int, bool) with a geography column in a single index scan.
+CREATE EXTENSION IF NOT EXISTS btree_gist;
+
+-- geofence_events: proximity lookups by location, and per-geofence proximity lookups
+CREATE INDEX IF NOT EXISTS idx_geofence_events_location
+    ON geofence_events USING GIST (location);
+
+CREATE INDEX IF NOT EXISTS idx_geofence_events_geofence_location
+    ON geofence_events USING GIST (geofence_id, location);
+
+CREATE INDEX IF NOT EXISTS idx_geofence_events_created_at
+    ON geofence_events USING BRIN (created_at);
+
+-- project_geometries: cover additional spatial query patterns beyond geometry/centroid
+CREATE INDEX IF NOT EXISTS idx_project_geometries_bounding_box
+    ON project_geometries USING GIST (bounding_box);
+
+CREATE INDEX IF NOT EXISTS idx_project_geometries_valid_geometry
+    ON project_geometries USING GIST (is_valid, geometry);
+
+CREATE INDEX IF NOT EXISTS idx_project_geometries_area_hectares
+    ON project_geometries USING BRIN (area_hectares);
+
+CREATE INDEX IF NOT EXISTS idx_project_geometries_created_at
+    ON project_geometries USING BRIN (created_at);
+
+-- administrative_boundaries: admin_level is almost always filtered alongside
+-- the spatial predicate (e.g. "country boundaries that intersect X"), so fold
+-- it into the GIST index rather than relying on a separate btree index.
+CREATE INDEX IF NOT EXISTS idx_admin_boundaries_level_geometry
+    ON administrative_boundaries USING GIST (admin_level, geometry);
+
+-- Note: projects table has no geometry column of its own — its spatial data
+-- lives in project_geometries (1:1 via project_id), which is now fully
+-- indexed above. Duplicating geometry onto projects would just create a
+-- second copy to keep in sync, so we index the existing normalized table
+-- instead of adding a column.
+--
+-- Note: map_tile_cache has no geometry/geography column (tiles are addressed
+-- by zoom/x/y, already indexed), so there is nothing spatial to index there.


### PR DESCRIPTION
## Summary

Wires three Anthropic agent runners to the tool runner and adds PostGIS spatial indexes for geospatial query optimization.

## Related Issue(s)
Closes #431, #573, #574, #575

## Type of Change
- [x] Feature
- [ ] Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Chore

## Description

### 1. PostGIS Spatial Indexes (#431)

Adds GIST/BRIN spatial indexes for geospatial query patterns.

**Changes:**
- `btree_gist` extension for composite GIST indexes
- Indexes on `geofence_events.location` and `geofence_events.geofence_id, location`
- BRIN indexes on `created_at` columns
- Composite GIST index on `administrative_boundaries.admin_level, geometry`

### 2. Compliance Report Agent (#575)

Wires `runComplianceReportAgent` to the Anthropic tool runner.

**Changes:**
- `betaZodOutputFormat` for structured JSON output
- `ComplianceReportOutputSchema` with sections, gaps, and citations
- Tool runner with `MAX_ITERATIONS = 8`
- Audit logging for `needs-approval` and `failed` statuses
- Controller returns 502 for failed outcomes

### 3. Discovery Agent (#574)

Wires `runDiscoveryAgent` to the Anthropic tool runner.

**Changes:**
- `DiscoveryOutputSchema` with recommendations, citations, and notes
- Tool runner integration with `discoveryTools`
- Audit logging for `drafted` and `failed` statuses
- Controller with status code mapping (200 for drafted, 502 for failed)

### 4. PDD Draft Agent (#573)

Wires `runPddDraftAgent` to the Anthropic tool runner.

**Changes:**
- `PddOutputSchema` with sections, incompleteSections, and citations
- Tool runner integration with `pddDraftTools`
- Audit logging for `drafted` and `failed` statuses
- Controller with status code mapping (200 for drafted, 502 for failed)

## Files Changed

| File | Changes |
|------|---------|
| `project-portal-backend/migrations/023_spatial_indexes.up.sql` | Added GIST/BRIN spatial indexes |
| `agent-service/src/agents/compliance-report/` | Full agent implementation with tests |
| `agent-service/src/agents/discovery/` | Full agent implementation with tests |
| `agent-service/src/agents/pdd-draft/` | Full agent implementation with tests |

## Testing Evidence

### Test Coverage

| Issue | Tests |
|-------|-------|
| #431 | Migration applied, indexes created |
| #575 | Compliance agent unit tests (tool wiring, status mapping, audit logging, error handling) |
| #574 | Discovery agent unit tests (tool wiring, status mapping, audit logging, error handling) |
| #573 | PDD agent unit tests (tool wiring, status mapping, audit logging, error handling) |

### Test Commands
```bash
cd agent-service
pnpm test
```
All tests pass.

## Screenshots
N/A - Backend and database changes with no UI impact.

## Checklist
- [x] Code builds successfully
- [x] Tests added/updated where applicable
- [x] Documentation updated if needed
- [x] Linked issue referenced
- [x] Ready for review

Closes #431
Closes #573
Closes #574
Closes #575