### PR TITLE
Fix: Secure refresh token rotation and reuse detection (#543)

### DIFF
--- a/corporate-platform/corporate-platform-backend/prisma/schema.prisma
+++ b/corporate-platform/corporate-platform-backend/prisma/schema.prisma
@@ -495,8 +495,12 @@ model Session {
   ipAddress    String?
   expiresAt    DateTime
   isValid      Boolean   @default(true)
-  createdAt    DateTime  @default(now())
-  lastUsedAt   DateTime?
+  createdAt            DateTime  @default(now())
+  lastUsedAt           DateTime?
+  previousRefreshToken String?
+  deviceId             String?
+  failedAttempts       Int       @default(0)
+  lockedUntil          DateTime?
 
   @@index([refreshToken])
   @@index([expiresAt])

--- a/corporate-platform/corporate-platform-backend/script.js
+++ b/corporate-platform/corporate-platform-backend/script.js
@@ -1,0 +1,159 @@
+const fs = require('fs');
+const content = fs.readFileSync('src/auth/auth.service.ts', 'utf8');
+
+const newRefresh = \  async refresh(
+    dto: RefreshTokenDto,
+    metadata?: RequestMetadata,
+  ): Promise<AuthResponse> {
+    let payload: JwtPayload;
+    try {
+      payload = this.jwtService.verify<JwtPayload>(dto.refreshToken);
+    } catch {
+      throw new InvalidRefreshTokenError();
+    }
+
+    const session = await this.prisma.session.findUnique({
+      where: { id: payload.sessionId },
+    });
+
+    if (!session || !session.isValid) {
+      throw new InvalidRefreshTokenError();
+    }
+
+    if (session.lockedUntil && session.lockedUntil > new Date()) {
+      throw new SessionLockedError();
+    }
+
+    if (session.expiresAt <= new Date()) {
+      throw new SessionExpiredError();
+    }
+
+    // Context mismatch check
+    if (
+      metadata &&
+      (metadata.ipAddress !== session.ipAddress ||
+        metadata.userAgent !== session.userAgent)
+    ) {
+      await this.securityService.logEvent({
+        eventType: SecurityEvents.SuspiciousPatternDetected,
+        companyId: payload.companyId,
+        userId: payload.sub,
+        status: 'warning',
+        statusCode: 401,
+      });
+      // Optionally block or just flag. We just flagged it.
+    }
+
+    const isCurrentMatch = await bcrypt.compare(
+      dto.refreshToken,
+      session.refreshToken,
+    );
+
+    let isPreviousMatch = false;
+    if (!isCurrentMatch && session.previousRefreshToken) {
+      isPreviousMatch = await bcrypt.compare(
+        dto.refreshToken,
+        session.previousRefreshToken,
+      );
+    }
+
+    if (isPreviousMatch) {
+      // Reuse detected!
+      await this.prisma.session.update({
+        where: { id: session.id },
+        data: { isValid: false },
+      });
+
+      // Optionally invalidate all sessions
+      await this.prisma.session.updateMany({
+        where: { userId: session.userId },
+        data: { isValid: false },
+      });
+
+      await this.securityService.logEvent({
+        eventType: SecurityEvents.AuthRefreshTokenReuse,
+        companyId: payload.companyId,
+        userId: payload.sub,
+        status: 'failure',
+        statusCode: 401,
+      });
+
+      throw new RefreshTokenReuseError();
+    }
+
+    if (!isCurrentMatch) {
+      // Increment failed attempts
+      const failedAttempts = session.failedAttempts + 1;
+      const lockedUntil =
+        failedAttempts >= 5 ? new Date(Date.now() + 15 * 60 * 1000) : null;
+
+      await this.prisma.session.update({
+        where: { id: session.id },
+        data: { failedAttempts, lockedUntil },
+      });
+
+      await this.securityService.logEvent({
+        eventType: SecurityEvents.AuthRefreshFailed,
+        companyId: payload.companyId,
+        userId: payload.sub,
+        status: 'failure',
+        statusCode: 401,
+      });
+
+      throw new InvalidRefreshTokenError();
+    }
+
+    const user = await this.prisma.user.findUnique({
+      where: { id: payload.sub },
+    });
+
+    if (!user) {
+      throw new UserNotFoundError(payload.sub);
+    }
+
+    if (!user.isActive) {
+      throw new AccountInactiveError();
+    }
+
+    const { accessToken, refreshToken } = this.generateTokens(user, session.id);
+    const hashedRefreshToken = await bcrypt.hash(refreshToken, 10);
+
+    await this.prisma.\([
+      this.prisma.session.update({
+        where: { id: session.id },
+        data: {
+          previousRefreshToken: session.refreshToken,
+          refreshToken: hashedRefreshToken,
+          lastUsedAt: new Date(),
+          expiresAt: this.computeRefreshExpiry(session.createdAt),
+          failedAttempts: 0,
+          lockedUntil: null,
+          deviceId: metadata?.deviceId || session.deviceId,
+        },
+      }),
+      this.prisma.user.update({
+        where: { id: user.id },
+        data: {
+          refreshToken: hashedRefreshToken,
+        },
+      }),
+    ]);
+
+    await this.securityService.logEvent({
+      eventType: SecurityEvents.AuthRefreshSuccess,
+      companyId: payload.companyId,
+      userId: payload.sub,
+      status: 'success',
+      statusCode: 200,
+    });
+
+    return {
+      user: this.toAuthUser(user),
+      accessToken,
+      refreshToken,
+    };
+  }\;
+
+const replaced = content.replace(/  async refresh\(dto: RefreshTokenDto\): Promise<AuthResponse> \{[\s\S]*?    return \{\n      user: this\.toAuthUser\(user\),\n      accessToken,\n      refreshToken,\n    \};\n  \}/, newRefresh);
+
+fs.writeFileSync('src/auth/auth.service.ts', replaced);

--- a/corporate-platform/corporate-platform-backend/src/auth/README.md
+++ b/corporate-platform/corporate-platform-backend/src/auth/README.md
@@ -1,0 +1,20 @@
+# Authentication Module
+
+## Refresh Token Rotation & Reuse Detection
+
+The refresh token system employs **Automatic Reuse Detection** to protect against token theft.
+
+### Token Rotation
+- Each successful call to /api/v1/auth/refresh will invalidate the provided refresh token and return a new one.
+- You must save the new efreshToken securely on the client.
+
+### Reuse Detection
+- If a leaked refresh token is reused (i.e. presented to the API after it has already been rotated), the API will return a \RefreshTokenReuseError\ (HTTP 401, error code: \AUTH_010\).
+- As a security measure, **all active sessions for your user account** will be immediately invalidated. You will need to log in again.
+
+### Maximum Lifetime
+- Sessions have an absolute maximum lifetime of 30 days. No amount of refreshing can extend a session beyond 30 days from its initial creation.
+- Once the 30-day limit is hit, you must re-authenticate.
+
+### Rate Limiting
+- To prevent brute-forcing, sessions are temporarily locked (15 minutes) after 5 consecutive failed refresh attempts. A \SessionLockedError\ will be returned.

--- a/corporate-platform/corporate-platform-backend/src/auth/auth.controller.ts
+++ b/corporate-platform/corporate-platform-backend/src/auth/auth.controller.ts
@@ -55,7 +55,7 @@ export class AuthController {
   @LoginRateLimit()
   @Post('login')
   async login(@Req() req: Request, @Body() dto: LoginDto) {
-    return this.authService.login(dto, this.getMetadata(req));
+    return this.authService.login(dto, this.getMetadata(req, dto.deviceId));
   }
 
   /**
@@ -65,8 +65,8 @@ export class AuthController {
   @Post('refresh')
   @UseGuards(RateLimitGuard)
   @RefreshRateLimit()
-  async refresh(@Body() dto: RefreshTokenDto) {
-    return this.authService.refresh(dto);
+  async refresh(@Req() req: Request, @Body() dto: RefreshTokenDto) {
+    return this.authService.refresh(dto, this.getMetadata(req, dto.deviceId));
   }
 
   /**
@@ -152,13 +152,14 @@ export class AuthController {
     return this.authService.terminateSession(user.sub, sessionId);
   }
 
-  private getMetadata(req: Request) {
+  private getMetadata(req: Request, deviceId?: string) {
     return {
       ipAddress:
         (req.headers['x-forwarded-for'] as string) ||
         req.socket.remoteAddress ||
         undefined,
       userAgent: req.headers['user-agent'],
+      deviceId,
     };
   }
 }

--- a/corporate-platform/corporate-platform-backend/src/auth/auth.service.spec.ts
+++ b/corporate-platform/corporate-platform-backend/src/auth/auth.service.spec.ts
@@ -1,0 +1,143 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { AuthService } from './auth.service';
+import { PrismaService } from '../shared/database/prisma.service';
+import { JwtService } from '@nestjs/jwt';
+import { SecurityService } from '../security/security.service';
+import * as bcrypt from 'bcrypt';
+import {
+  InvalidRefreshTokenError,
+  RefreshTokenReuseError,
+  SessionLockedError,
+} from '../shared/exceptions/error-classes';
+import { SecurityEvents } from '../security/constants/security-events.constants';
+
+jest.mock('bcrypt');
+
+describe('AuthService Refresh Token Reuse', () => {
+  let service: AuthService;
+  let prisma: jest.Mocked<PrismaService>;
+  let jwt: jest.Mocked<JwtService>;
+  let security: jest.Mocked<SecurityService>;
+
+  beforeEach(async () => {
+    const prismaMock = {
+      session: {
+        findUnique: jest.fn(),
+        update: jest.fn(),
+        updateMany: jest.fn(),
+      },
+      user: {
+        findUnique: jest.fn(),
+        update: jest.fn(),
+      },
+      $transaction: jest.fn((promises) => Promise.all(promises)),
+    };
+
+    const jwtMock = {
+      verify: jest.fn(),
+      sign: jest.fn(),
+    };
+
+    const securityMock = {
+      logEvent: jest.fn(),
+    };
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        AuthService,
+        { provide: PrismaService, useValue: prismaMock },
+        { provide: JwtService, useValue: jwtMock },
+        { provide: SecurityService, useValue: securityMock },
+      ],
+    }).compile();
+
+    service = module.get<AuthService>(AuthService);
+    prisma = module.get(PrismaService);
+    jwt = module.get(JwtService);
+    security = module.get(SecurityService);
+  });
+
+  it('should detect reuse and invalidate sessions', async () => {
+    (jwt.verify as jest.Mock).mockReturnValue({ sessionId: 'session-1', sub: 'user-1' });
+
+    (prisma.session.findUnique as jest.Mock).mockResolvedValue({
+      id: 'session-1',
+      userId: 'user-1',
+      isValid: true,
+      expiresAt: new Date(Date.now() + 10000),
+      refreshToken: 'current-hash',
+      previousRefreshToken: 'old-hash',
+      lockedUntil: null,
+      failedAttempts: 0,
+    } as any);
+
+    (bcrypt.compare as jest.Mock)
+      .mockResolvedValueOnce(false) // current does not match
+      .mockResolvedValueOnce(true); // previous DOES match
+
+    await expect(
+      service.refresh({ refreshToken: 'old-token' }),
+    ).rejects.toThrow(RefreshTokenReuseError);
+
+    expect(prisma.session.update).toHaveBeenCalledWith({
+      where: { id: 'session-1' },
+      data: { isValid: false },
+    });
+
+    expect(prisma.session.updateMany).toHaveBeenCalledWith({
+      where: { userId: 'user-1' },
+      data: { isValid: false },
+    });
+
+    expect(security.logEvent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        eventType: SecurityEvents.AuthRefreshTokenReuse,
+      }),
+    );
+  });
+
+  it('should lock session after 5 failed attempts', async () => {
+    (jwt.verify as jest.Mock).mockReturnValue({ sessionId: 'session-1', sub: 'user-1' });
+
+    (prisma.session.findUnique as jest.Mock).mockResolvedValue({
+      id: 'session-1',
+      isValid: true,
+      expiresAt: new Date(Date.now() + 10000),
+      refreshToken: 'current-hash',
+      previousRefreshToken: 'old-hash',
+      lockedUntil: null,
+      failedAttempts: 4, // Next failure makes it 5
+    } as any);
+
+    (bcrypt.compare as jest.Mock).mockResolvedValue(false); // neither matches
+
+    await expect(
+      service.refresh({ refreshToken: 'bad-token' }),
+    ).rejects.toThrow(InvalidRefreshTokenError);
+
+    expect(prisma.session.update).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: { id: 'session-1' },
+        data: expect.objectContaining({
+          failedAttempts: 5,
+          lockedUntil: expect.any(Date),
+        }),
+      }),
+    );
+  });
+
+  it('should reject locked sessions', async () => {
+    (jwt.verify as jest.Mock).mockReturnValue({ sessionId: 'session-1', sub: 'user-1' });
+
+    (prisma.session.findUnique as jest.Mock).mockResolvedValue({
+      id: 'session-1',
+      isValid: true,
+      expiresAt: new Date(Date.now() + 10000),
+      lockedUntil: new Date(Date.now() + 10000), // currently locked
+    } as any);
+
+    await expect(
+      service.refresh({ refreshToken: 'any-token' }),
+    ).rejects.toThrow(SessionLockedError);
+  });
+});

--- a/corporate-platform/corporate-platform-backend/src/auth/auth.service.ts
+++ b/corporate-platform/corporate-platform-backend/src/auth/auth.service.ts
@@ -21,11 +21,14 @@ import {
   EmailAlreadyInUseError,
   ValidationError,
   AccountInactiveError,
+  RefreshTokenReuseError,
+  SessionLockedError,
 } from '../shared/exceptions/error-classes';
 
 interface RequestMetadata {
   ipAddress?: string;
   userAgent?: string;
+  deviceId?: string;
 }
 
 type User = {
@@ -209,7 +212,10 @@ export class AuthService {
     return response;
   }
 
-  async refresh(dto: RefreshTokenDto): Promise<AuthResponse> {
+  async refresh(
+    dto: RefreshTokenDto,
+    metadata?: RequestMetadata,
+  ): Promise<AuthResponse> {
     let payload: JwtPayload;
     try {
       payload = this.jwtService.verify<JwtPayload>(dto.refreshToken);
@@ -225,15 +231,86 @@ export class AuthService {
       throw new InvalidRefreshTokenError();
     }
 
+    if (session.lockedUntil && session.lockedUntil > new Date()) {
+      throw new SessionLockedError();
+    }
+
     if (session.expiresAt <= new Date()) {
       throw new SessionExpiredError();
     }
 
-    const matches = await bcrypt.compare(
+    // Context mismatch check
+    if (
+      metadata &&
+      (metadata.ipAddress !== session.ipAddress ||
+        metadata.userAgent !== session.userAgent)
+    ) {
+      await this.securityService.logEvent({
+        eventType: SecurityEvents.SuspiciousPatternDetected,
+        companyId: payload.companyId,
+        userId: payload.sub,
+        status: 'warning',
+        statusCode: 401,
+      });
+      // Optionally block or just flag. We just flagged it.
+    }
+
+    const isCurrentMatch = await bcrypt.compare(
       dto.refreshToken,
       session.refreshToken,
     );
-    if (!matches) {
+
+    let isPreviousMatch = false;
+    if (!isCurrentMatch && session.previousRefreshToken) {
+      isPreviousMatch = await bcrypt.compare(
+        dto.refreshToken,
+        session.previousRefreshToken,
+      );
+    }
+
+    if (isPreviousMatch) {
+      // Reuse detected!
+      await this.prisma.session.update({
+        where: { id: session.id },
+        data: { isValid: false },
+      });
+
+      // Invalidate all sessions
+      await this.prisma.session.updateMany({
+        where: { userId: session.userId },
+        data: { isValid: false },
+      });
+
+      await this.securityService.logEvent({
+        eventType: SecurityEvents.AuthRefreshTokenReuse,
+        companyId: payload.companyId,
+        userId: payload.sub,
+        status: 'failure',
+        statusCode: 401,
+      });
+
+      throw new RefreshTokenReuseError();
+    }
+
+    if (!isCurrentMatch) {
+      // Increment failed attempts
+      const failedAttempts = session.failedAttempts + 1;
+      const lockedUntil =
+        failedAttempts >= 5 ? new Date(Date.now() + 15 * 60 * 1000) : null;
+
+      await this.prisma.session.update({
+        where: { id: session.id },
+        data: { failedAttempts, lockedUntil },
+      });
+
+      await this.securityService.logEvent({
+        eventType: SecurityEvents.AuthRefreshFailed,
+        companyId: payload.companyId,
+        userId: payload.sub,
+        status: 'failure',
+        statusCode: 401,
+      });
+
       throw new InvalidRefreshTokenError();
     }
 
@@ -256,9 +333,13 @@ export class AuthService {
       this.prisma.session.update({
         where: { id: session.id },
         data: {
+          previousRefreshToken: session.refreshToken,
           refreshToken: hashedRefreshToken,
           lastUsedAt: new Date(),
-          expiresAt: this.computeRefreshExpiry(),
+          expiresAt: this.computeRefreshExpiry(session.createdAt),
+          failedAttempts: 0,
+          lockedUntil: null,
+          deviceId: metadata?.deviceId || session.deviceId,
         },
       }),
       this.prisma.user.update({
@@ -268,6 +349,14 @@ export class AuthService {
         },
       }),
     ]);
+
+    await this.securityService.logEvent({
+      eventType: SecurityEvents.AuthRefreshSuccess,
+      companyId: payload.companyId,
+      userId: payload.sub,
+      status: 'success',
+      statusCode: 200,
+    });
 
     return {
       user: this.toAuthUser(user),
@@ -382,6 +471,7 @@ export class AuthService {
       id: session.id,
       userAgent: session.userAgent,
       ipAddress: session.ipAddress,
+      deviceId: session.deviceId,
       expiresAt: session.expiresAt,
       isValid: session.isValid,
       createdAt: session.createdAt,
@@ -504,8 +594,15 @@ export class AuthService {
     return { accessToken, refreshToken, payload };
   }
 
-  private computeRefreshExpiry() {
-    return new Date(Date.now() + 7 * 24 * 60 * 60 * 1000);
+  private computeRefreshExpiry(createdAt?: Date) {
+    const rollingExpiry = new Date(Date.now() + 7 * 24 * 60 * 60 * 1000);
+    if (createdAt) {
+      const absoluteExpiry = new Date(
+        createdAt.getTime() + 30 * 24 * 60 * 60 * 1000,
+      );
+      return rollingExpiry < absoluteExpiry ? rollingExpiry : absoluteExpiry;
+    }
+    return rollingExpiry;
   }
 
   private async createSession(userId: string, metadata: RequestMetadata) {
@@ -514,6 +611,7 @@ export class AuthService {
         userId,
         userAgent: metadata.userAgent,
         ipAddress: metadata.ipAddress,
+        deviceId: metadata.deviceId,
         refreshToken: '',
         expiresAt: this.computeRefreshExpiry(),
       },

--- a/corporate-platform/corporate-platform-backend/src/auth/dto/login.dto.ts
+++ b/corporate-platform/corporate-platform-backend/src/auth/dto/login.dto.ts
@@ -1,4 +1,10 @@
-import { IsEmail, IsNotEmpty, IsString, MinLength } from 'class-validator';
+import {
+  IsEmail,
+  IsNotEmpty,
+  IsString,
+  MinLength,
+  IsOptional,
+} from 'class-validator';
 
 export class LoginDto {
   @IsEmail()
@@ -9,4 +15,8 @@ export class LoginDto {
   @IsNotEmpty()
   @MinLength(8)
   password: string;
+
+  @IsOptional()
+  @IsString()
+  deviceId?: string;
 }

--- a/corporate-platform/corporate-platform-backend/src/auth/dto/refresh-token.dto.ts
+++ b/corporate-platform/corporate-platform-backend/src/auth/dto/refresh-token.dto.ts
@@ -1,7 +1,11 @@
-import { IsNotEmpty, IsString } from 'class-validator';
+import { IsNotEmpty, IsString, IsOptional } from 'class-validator';
 
 export class RefreshTokenDto {
   @IsString()
   @IsNotEmpty()
   refreshToken: string;
+
+  @IsOptional()
+  @IsString()
+  deviceId?: string;
 }

--- a/corporate-platform/corporate-platform-backend/src/cart/services/checkout.service.spec.ts
+++ b/corporate-platform/corporate-platform-backend/src/cart/services/checkout.service.spec.ts
@@ -204,7 +204,9 @@ describe('CheckoutService', () => {
         transactionHash: 'tx_abc',
       });
 
-      mockAvailabilityService.decrementWithin.mockResolvedValue({ newAmount: 4000 });
+      mockAvailabilityService.decrementWithin.mockResolvedValue({
+        newAmount: 4000,
+      });
       mockPrisma.order.update.mockResolvedValue({
         id: 'order1',
         orderNumber: 'ORD-2026-0001',

--- a/corporate-platform/corporate-platform-backend/src/cart/services/reservation.service.spec.ts
+++ b/corporate-platform/corporate-platform-backend/src/cart/services/reservation.service.spec.ts
@@ -98,7 +98,9 @@ describe('ReservationService', () => {
     );
 
     await expect(
-      service.reserveCredits('cart-1', [{ creditId: 'credit-1', quantity: 30 }]),
+      service.reserveCredits('cart-1', [
+        { creditId: 'credit-1', quantity: 30 },
+      ]),
     ).rejects.toThrow(ConflictException);
   });
 
@@ -116,7 +118,9 @@ describe('ReservationService', () => {
     );
 
     await expect(
-      service.reserveCredits('cart-1', [{ creditId: 'credit-1', quantity: 90 }]),
+      service.reserveCredits('cart-1', [
+        { creditId: 'credit-1', quantity: 90 },
+      ]),
     ).resolves.toBeUndefined();
 
     expect(store.reservations[0].quantity).toBe(90);
@@ -151,7 +155,10 @@ describe('ReservationService', () => {
     expect(results.filter((r) => r.status === 'fulfilled')).toHaveLength(1);
     expect(results.filter((r) => r.status === 'rejected')).toHaveLength(1);
 
-    const totalHeld = store.reservations.reduce((sum, r) => sum + r.quantity, 0);
+    const totalHeld = store.reservations.reduce(
+      (sum, r) => sum + r.quantity,
+      0,
+    );
     expect(totalHeld).toBeLessThanOrEqual(100);
     expect(totalHeld).toBe(60);
   });
@@ -168,9 +175,9 @@ describe('ReservationService', () => {
       ]),
     ]);
 
-    expect(
-      store.reservations.reduce((sum, r) => sum + r.quantity, 0),
-    ).toBe(100);
+    expect(store.reservations.reduce((sum, r) => sum + r.quantity, 0)).toBe(
+      100,
+    );
   });
 
   it('releases a cart’s reservations and logs the release', async () => {

--- a/corporate-platform/corporate-platform-backend/src/credit/interfaces/availability.interface.ts
+++ b/corporate-platform/corporate-platform-backend/src/credit/interfaces/availability.interface.ts
@@ -16,7 +16,9 @@ export type PrismaTxClient = {
     updateMany: (args: unknown) => Promise<{ count: number }>;
   };
   creditReservation: {
-    aggregate: (args: unknown) => Promise<{ _sum: { quantity: number | null } }>;
+    aggregate: (
+      args: unknown,
+    ) => Promise<{ _sum: { quantity: number | null } }>;
   };
   creditAvailabilityLog: { create: (args: unknown) => Promise<unknown> };
   $queryRaw?: (...args: any[]) => Promise<unknown>;

--- a/corporate-platform/corporate-platform-backend/src/credit/services/availability.service.spec.ts
+++ b/corporate-platform/corporate-platform-backend/src/credit/services/availability.service.spec.ts
@@ -11,7 +11,11 @@ describe('AvailabilityService', () => {
 
   beforeEach(async () => {
     prisma = {
-      credit: { findFirst: jest.fn(), update: jest.fn(), updateMany: jest.fn() },
+      credit: {
+        findFirst: jest.fn(),
+        update: jest.fn(),
+        updateMany: jest.fn(),
+      },
       creditReservation: { aggregate: jest.fn() },
       creditAvailabilityLog: { create: jest.fn() },
       $transaction: jest.fn((cb) => cb(prisma)),
@@ -208,9 +212,16 @@ describe('AvailabilityService – concurrency', () => {
   it('records every movement on CreditAvailabilityLog with its change type', async () => {
     await build([credit(100)]);
 
-    await service.decrementAvailability('credit-1', 10, 'user-1', 'retire', undefined, {
-      changeType: AvailabilityChangeType.RETIRE,
-    });
+    await service.decrementAvailability(
+      'credit-1',
+      10,
+      'user-1',
+      'retire',
+      undefined,
+      {
+        changeType: AvailabilityChangeType.RETIRE,
+      },
+    );
 
     expect(store.availabilityLogs).toEqual([
       expect.objectContaining({
@@ -225,17 +236,14 @@ describe('AvailabilityService – concurrency', () => {
   });
 
   it('treats units held by an active cart reservation as unavailable', async () => {
-    await build(
-      [credit(100)],
-      [
-        {
-          cartId: 'cart-1',
-          creditId: 'credit-1',
-          quantity: 80,
-          expiresAt: new Date(Date.now() + 60_000),
-        },
-      ] as any,
-    );
+    await build([credit(100)], [
+      {
+        cartId: 'cart-1',
+        creditId: 'credit-1',
+        quantity: 80,
+        expiresAt: new Date(Date.now() + 60_000),
+      },
+    ] as any);
 
     await expect(
       service.decrementAvailability(
@@ -262,17 +270,14 @@ describe('AvailabilityService – concurrency', () => {
   });
 
   it('ignores expired reservations when computing headroom', async () => {
-    await build(
-      [credit(100)],
-      [
-        {
-          cartId: 'cart-stale',
-          creditId: 'credit-1',
-          quantity: 90,
-          expiresAt: new Date(Date.now() - 60_000),
-        },
-      ] as any,
-    );
+    await build([credit(100)], [
+      {
+        cartId: 'cart-stale',
+        creditId: 'credit-1',
+        quantity: 90,
+        expiresAt: new Date(Date.now() - 60_000),
+      },
+    ] as any);
 
     await expect(
       service.decrementAvailability(
@@ -287,17 +292,14 @@ describe('AvailabilityService – concurrency', () => {
   });
 
   it("excludes a cart's own reservation from its headroom", async () => {
-    await build(
-      [credit(100)],
-      [
-        {
-          cartId: 'cart-1',
-          creditId: 'credit-1',
-          quantity: 100,
-          expiresAt: new Date(Date.now() + 60_000),
-        },
-      ] as any,
-    );
+    await build([credit(100)], [
+      {
+        cartId: 'cart-1',
+        creditId: 'credit-1',
+        quantity: 100,
+        expiresAt: new Date(Date.now() + 60_000),
+      },
+    ] as any);
 
     await expect(
       service.decrementAvailability(

--- a/corporate-platform/corporate-platform-backend/src/credit/services/availability.service.ts
+++ b/corporate-platform/corporate-platform-backend/src/credit/services/availability.service.ts
@@ -238,7 +238,8 @@ export class AvailabilityService {
     const newAmount = headroom.availableAmount - claim.amount;
     // `status` is non-nullable in the schema, so a fully-consumed credit flips
     // to 'reserved' and anything else keeps whatever it had (never null).
-    const newStatus = newAmount === 0 ? 'reserved' : (headroom.status ?? undefined);
+    const newStatus =
+      newAmount === 0 ? 'reserved' : (headroom.status ?? undefined);
 
     const guardedWhere: any = {
       id: claim.creditId,

--- a/corporate-platform/corporate-platform-backend/src/credit/testing/in-memory-prisma.ts
+++ b/corporate-platform/corporate-platform-backend/src/credit/testing/in-memory-prisma.ts
@@ -59,7 +59,11 @@ function matches(row: Record<string, any>, where: Where | undefined): boolean {
 
     const value = row[key];
 
-    if (condition !== null && typeof condition === 'object' && !(condition instanceof Date)) {
+    if (
+      condition !== null &&
+      typeof condition === 'object' &&
+      !(condition instanceof Date)
+    ) {
       return Object.entries(condition as Record<string, any>).every(
         ([operator, operand]) => {
           switch (operator) {
@@ -319,7 +323,9 @@ export class InMemoryPrisma {
           matches(candidate, where),
         );
         if (!row) {
-          throw new Error(`Credit not found for update: ${JSON.stringify(where)}`);
+          throw new Error(
+            `Credit not found for update: ${JSON.stringify(where)}`,
+          );
         }
         const next = { ...row, ...this.applyData(row, data) };
         if (ctx) ctx.creditWrites.set(row.id, next);
@@ -393,7 +399,10 @@ export class InMemoryPrisma {
         );
         const predicate = (row: ReservationRow) => matches(row, where);
         if (ctx) ctx.reservationDeletes.push(predicate);
-        else this.reservations = this.reservations.filter((row) => !predicate(row));
+        else
+          this.reservations = this.reservations.filter(
+            (row) => !predicate(row),
+          );
         return { count: targets.length };
       },
     };

--- a/corporate-platform/corporate-platform-backend/src/security/constants/security-events.constants.ts
+++ b/corporate-platform/corporate-platform-backend/src/security/constants/security-events.constants.ts
@@ -24,6 +24,9 @@ export const SecurityEvents = {
   RateLimitExceeded: 'rate-limit.exceeded',
   IdempotentRequest: 'idempotent.request',
   SuspiciousPatternDetected: 'suspicious.pattern.detected',
+  AuthRefreshSuccess: 'auth.refresh.success',
+  AuthRefreshFailed: 'auth.refresh.failed',
+  AuthRefreshTokenReuse: 'auth.refresh.token.reuse',
 } as const;
 
 export type SecurityEventType =
@@ -67,4 +70,7 @@ export const EventSeverityMap: Record<
   [SecurityEvents.RateLimitExceeded]: SecuritySeverity.Critical,
   [SecurityEvents.IdempotentRequest]: SecuritySeverity.Info,
   [SecurityEvents.SuspiciousPatternDetected]: SecuritySeverity.Critical,
+  [SecurityEvents.AuthRefreshSuccess]: SecuritySeverity.Info,
+  [SecurityEvents.AuthRefreshFailed]: SecuritySeverity.Warning,
+  [SecurityEvents.AuthRefreshTokenReuse]: SecuritySeverity.Critical,
 };

--- a/corporate-platform/corporate-platform-backend/src/shared/exceptions/domain-error.ts
+++ b/corporate-platform/corporate-platform-backend/src/shared/exceptions/domain-error.ts
@@ -88,6 +88,8 @@ export const ErrorCodes = {
   AUTH_007: 'AUTH_007', // Invalid refresh token
   AUTH_008: 'AUTH_008', // Session expired
   AUTH_009: 'AUTH_009', // Invalid password reset token
+  AUTH_010: 'AUTH_010', // Refresh token reuse detected
+  AUTH_011: 'AUTH_011', // Session locked
 
   // Validation (VALIDATION)
   VALIDATION_001: 'VALIDATION_001', // General validation error

--- a/corporate-platform/corporate-platform-backend/src/shared/exceptions/error-classes.ts
+++ b/corporate-platform/corporate-platform-backend/src/shared/exceptions/error-classes.ts
@@ -72,6 +72,30 @@ export class AccountInactiveError extends DomainError {
   }
 }
 
+export class RefreshTokenReuseError extends DomainError {
+  constructor(details?: Record<string, unknown>) {
+    super(
+      'RefreshTokenReuseError',
+      ErrorCodes.AUTH_010,
+      'Refresh token reuse detected',
+      401,
+      details,
+    );
+  }
+}
+
+export class SessionLockedError extends DomainError {
+  constructor(details?: Record<string, unknown>) {
+    super(
+      'SessionLockedError',
+      ErrorCodes.AUTH_011,
+      'Session locked due to too many failed refresh attempts',
+      403,
+      details,
+    );
+  }
+}
+
 export class InvalidRefreshTokenError extends DomainError {
   constructor(details?: Record<string, unknown>) {
     super(

--- a/corporate-platform/corporate-platform-backend/src/stellar/soroban/reconciliation/soroban-reconciliation.service.spec.ts
+++ b/corporate-platform/corporate-platform-backend/src/stellar/soroban/reconciliation/soroban-reconciliation.service.spec.ts
@@ -69,7 +69,9 @@ function buildPrisma(rows: ContractCallRow[]) {
   };
 }
 
-function pendingCall(overrides: Partial<ContractCallRow> = {}): ContractCallRow {
+function pendingCall(
+  overrides: Partial<ContractCallRow> = {},
+): ContractCallRow {
   return {
     id: 'call-1',
     transactionHash: 'tx_abc',
@@ -175,13 +177,11 @@ describe('SorobanReconciliationService', () => {
     soroban.getTransaction.mockResolvedValue({ status: 'NOT_FOUND' });
 
     await service.reconcilePending();
-    const firstDelay =
-      prisma.rows[0].nextRetryAt!.getTime() - Date.now();
+    const firstDelay = prisma.rows[0].nextRetryAt!.getTime() - Date.now();
 
     prisma.rows[0].nextRetryAt = null; // make it due again
     await service.reconcilePending();
-    const secondDelay =
-      prisma.rows[0].nextRetryAt!.getTime() - Date.now();
+    const secondDelay = prisma.rows[0].nextRetryAt!.getTime() - Date.now();
 
     expect(prisma.rows[0].retryCount).toBe(2);
     expect(secondDelay).toBeGreaterThan(firstDelay);


### PR DESCRIPTION
Closes #543

Implements secure refresh token rotation and reuse detection.
- Adds previousRefreshToken and deviceId to Session.
- Detects reuse, invalidates all sessions for the user, and logs AuthRefreshTokenReuse.
- Rate limits failed refresh attempts on a per-session basis (ailedAttempts, lockedUntil).
- Validates metadata context (IP/User-Agent).
- Enforces 30-day absolute maximum lifetime for sessions.