### PR TITLE
feat: WebSocket-based live comment updates for collaboration

### DIFF
--- a/project-portal/project-portal-web/src/components/collaboration/CommentSection.integration.test.tsx
+++ b/project-portal/project-portal-web/src/components/collaboration/CommentSection.integration.test.tsx
@@ -1,0 +1,76 @@
+import { act, cleanup, render, screen, waitFor } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import CommentSection from './CommentSection';
+import { useStore } from '@/lib/store/store';
+import type { Comment } from '@/lib/store/collaboration/collaboration.types';
+import { subscribeToComments, unsubscribeFromComments } from '@/lib/ws/collaborationSocket';
+
+const handlersByProject = new Map<string, ((comment: Comment) => void)[]>();
+
+vi.mock('@/lib/ws/collaborationSocket', () => ({
+  subscribeToComments: vi.fn((projectId: string, options: { onComment: (comment: Comment) => void }) => {
+    const handlers = handlersByProject.get(projectId) ?? [];
+    handlers.push(options.onComment);
+    handlersByProject.set(projectId, handlers);
+  }),
+  unsubscribeFromComments: vi.fn((projectId: string) => {
+    handlersByProject.delete(projectId);
+  }),
+}));
+
+const comment = (id: string, projectId: string, content: string): Comment => ({
+  id,
+  project_id: projectId,
+  user_id: 'user-2',
+  content,
+  mentions: [],
+  attachments: [],
+  is_resolved: false,
+  created_at: '2026-08-28T12:00:00Z',
+  updated_at: '2026-08-28T12:00:00Z',
+});
+
+function emitCommentCreated(projectId: string, value: Comment) {
+  handlersByProject.get(projectId)?.forEach((handler) => handler(value));
+}
+
+describe('CommentSection live subscription integration', () => {
+  beforeEach(() => {
+    handlersByProject.clear();
+    vi.clearAllMocks();
+    useStore.setState({ comments: [] });
+  });
+
+  afterEach(() => cleanup());
+
+  it('subscribes with the projectId and renders an incoming comment', async () => {
+    render(<CommentSection projectId="project-abc" />);
+    expect(subscribeToComments).toHaveBeenCalledWith('project-abc', expect.objectContaining({ onComment: expect.any(Function) }));
+
+    act(() => emitCommentCreated('project-abc', comment('c-1', 'project-abc', 'This arrived via WebSocket')));
+    await waitFor(() => expect(screen.getByText('This arrived via WebSocket')).toBeInTheDocument());
+  });
+
+  it('ignores events for another project and de-duplicates by comment id', async () => {
+    render(<CommentSection projectId="project-abc" />);
+    act(() => emitCommentCreated('project-other', comment('c-2', 'project-other', 'Should not appear here')));
+    expect(screen.queryByText('Should not appear here')).not.toBeInTheDocument();
+
+    const duplicate = comment('c-3', 'project-abc', 'Duplicate check');
+    act(() => {
+      emitCommentCreated('project-abc', duplicate);
+      emitCommentCreated('project-abc', duplicate);
+    });
+    await waitFor(() => expect(screen.getAllByText('Duplicate check')).toHaveLength(1));
+    expect(useStore.getState().comments).toHaveLength(1);
+  });
+
+  it('unsubscribes on unmount and resubscribes when the project changes', () => {
+    const { rerender, unmount } = render(<CommentSection projectId="project-abc" />);
+    rerender(<CommentSection projectId="project-xyz" />);
+    expect(unsubscribeFromComments).toHaveBeenCalledWith('project-abc');
+    expect(subscribeToComments).toHaveBeenCalledWith('project-xyz', expect.anything());
+    unmount();
+    expect(unsubscribeFromComments).toHaveBeenCalledWith('project-xyz');
+  });
+});

--- a/project-portal/project-portal-web/src/components/collaboration/CommentSection.tsx
+++ b/project-portal/project-portal-web/src/components/collaboration/CommentSection.tsx
@@ -6,6 +6,7 @@ import { useStore } from '@/lib/store/store';
 import { useRootComments } from '@/lib/store/collaboration/collaboration.selectors';
 import CommentForm from './CommentForm';
 import CommentThread from './CommentThread';
+import { subscribeToComments, unsubscribeFromComments } from '@/lib/ws/collaborationSocket';
 
 interface CommentSectionProps {
   projectId: string;
@@ -15,10 +16,13 @@ export default function CommentSection({ projectId }: CommentSectionProps) {
   const fetchComments = useStore((s) => s.fetchComments);
   const loading = useStore((s) => s.collaborationLoading.comments);
   const rootComments = useRootComments();
+  const receiveComment = useStore((s) => s.receiveComment);
 
   useEffect(() => {
     fetchComments(projectId);
-  }, [projectId, fetchComments]);
+    subscribeToComments(projectId, { onComment: receiveComment });
+    return () => unsubscribeFromComments(projectId);
+  }, [projectId, fetchComments, receiveComment]);
 
   return (
     <div className="space-y-4">

--- a/project-portal/project-portal-web/src/components/collaboration/CommentThread.test.tsx
+++ b/project-portal/project-portal-web/src/components/collaboration/CommentThread.test.tsx
@@ -1,0 +1,67 @@
+import { act, render, screen } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import CommentThread from './CommentThread';
+import { useStore } from '@/lib/store/store';
+import { subscribeToComments } from '@/lib/ws/collaborationSocket';
+import type { Comment } from '@/lib/store/collaboration/collaboration.types';
+
+class FakeWebSocket {
+  static readonly OPEN = 1;
+  readyState = FakeWebSocket.OPEN;
+  onopen: (() => void) | null = null;
+  onmessage: ((event: { data: string }) => void) | null = null;
+  onclose: (() => void) | null = null;
+  onerror: (() => void) | null = null;
+  send = vi.fn();
+  close = vi.fn(() => this.onclose?.());
+  emit(message: unknown) {
+    this.onmessage?.({ data: JSON.stringify(message) });
+  }
+}
+
+const comment: Comment = {
+  id: 'comment-1',
+  project_id: 'project-1',
+  user_id: 'user-2',
+  content: 'A teammate joined the conversation',
+  mentions: [],
+  attachments: [],
+  is_resolved: false,
+  created_at: '2026-08-28T12:00:00Z',
+  updated_at: '2026-08-28T12:00:00Z',
+};
+
+describe('CommentThread live updates', () => {
+  beforeEach(() => {
+    useStore.setState({ comments: [] });
+  });
+
+  it('renders a comment received through the project socket without refetching', () => {
+    const socket = new FakeWebSocket();
+    const unsubscribe = subscribeToComments('project-1', {
+      createWebSocket: () => socket as unknown as WebSocket,
+      onComment: (receivedComment) => useStore.getState().receiveComment(receivedComment),
+    });
+    socket.onopen?.();
+    act(() => socket.emit({ event: 'comment.created', data: comment }));
+    render(<CommentThread comment={comment} />);
+
+    expect(screen.getByText(comment.content)).toBeInTheDocument();
+    unsubscribe();
+  });
+
+  it('does not render the same optimistic and socket comment twice', () => {
+    useStore.getState().receiveComment(comment);
+    const socket = new FakeWebSocket();
+    const unsubscribe = subscribeToComments('project-1', {
+      createWebSocket: () => socket as unknown as WebSocket,
+      onComment: (receivedComment) => useStore.getState().receiveComment(receivedComment),
+    });
+    act(() => socket.emit({ type: 'comment.created', project_id: 'project-1', comment }));
+    render(<CommentThread comment={comment} />);
+
+    expect(screen.getAllByText(comment.content)).toHaveLength(1);
+    expect(useStore.getState().comments).toHaveLength(1);
+    unsubscribe();
+  });
+});

--- a/project-portal/project-portal-web/src/lib/store/collaboration/collaboration.types.ts
+++ b/project-portal/project-portal-web/src/lib/store/collaboration/collaboration.types.ts
@@ -220,6 +220,7 @@ export interface CollaborationSlice {
   inviteUser: (projectId: string, data: InviteUserRequest) => Promise<ProjectInvitation | null>;
   removeMember: (projectId: string, userId: string) => Promise<boolean>;
   createComment: (data: CreateCommentRequest) => Promise<Comment | null>;
+  receiveComment: (comment: Comment) => void;
   createTask: (data: CreateTaskRequest) => Promise<Task | null>;
   updateTask: (taskId: string, data: UpdateTaskRequest) => Promise<Task | null>;
   createResource: (data: CreateResourceRequest) => Promise<SharedResource | null>;

--- a/project-portal/project-portal-web/src/lib/store/collaboration/collaborationSlice.ts
+++ b/project-portal/project-portal-web/src/lib/store/collaboration/collaborationSlice.ts
@@ -210,7 +210,9 @@ export const createCollaborationSlice: StateCreator<CollaborationSlice> = (set, 
     try {
       const comment = await createCommentApi(data);
       set((s) => ({
-        comments: [...s.comments, comment],
+        comments: s.comments.some((existing) => existing.id === comment.id)
+          ? s.comments.map((existing) => existing.id === comment.id ? comment : existing)
+          : [...s.comments, comment],
         collaborationLoading: { ...s.collaborationLoading, createComment: false },
       }));
       return comment;
@@ -221,6 +223,14 @@ export const createCollaborationSlice: StateCreator<CollaborationSlice> = (set, 
       });
       return null;
     }
+  },
+
+  receiveComment: (comment: Comment) => {
+    set((s) => ({
+      comments: s.comments.some((existing) => existing.id === comment.id)
+        ? s.comments.map((existing) => existing.id === comment.id ? comment : existing)
+        : [...s.comments, comment],
+    }));
   },
 
   createTask: async (data: CreateTaskRequest): Promise<Task | null> => {

--- a/project-portal/project-portal-web/src/lib/ws/collaborationSocket.test.ts
+++ b/project-portal/project-portal-web/src/lib/ws/collaborationSocket.test.ts
@@ -1,0 +1,110 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  subscribeToComments,
+  unsubscribeFromComments,
+} from './collaborationSocket';
+import type { Comment } from '@/lib/store/collaboration/collaboration.types';
+
+const sockets: MockSocket[] = [];
+
+class MockSocket {
+  static readonly OPEN = 1;
+  readyState = 0;
+  onopen: (() => void) | null = null;
+  onclose: (() => void) | null = null;
+  onmessage: ((event: { data: string }) => void) | null = null;
+  onerror: (() => void) | null = null;
+  send = vi.fn();
+  close = vi.fn(() => {
+    this.readyState = 3;
+    this.onclose?.();
+  });
+
+  open() {
+    this.readyState = 1;
+    this.onopen?.();
+  }
+
+  drop() {
+    this.readyState = 3;
+    this.onclose?.();
+  }
+}
+
+const comment: Comment = {
+  id: 'comment-1',
+  project_id: 'project-123',
+  user_id: 'user-1',
+  content: 'Live comment',
+  mentions: [],
+  attachments: [],
+  is_resolved: false,
+  created_at: '2026-08-28T12:00:00Z',
+  updated_at: '2026-08-28T12:00:00Z',
+};
+
+describe('collaborationSocket', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    sockets.length = 0;
+  });
+
+  afterEach(() => {
+    unsubscribeFromComments('project-123');
+    unsubscribeFromComments('project-456');
+    vi.useRealTimers();
+  });
+
+  function subscribe(projectId = 'project-123', onComment = vi.fn()) {
+    subscribeToComments(projectId, {
+      createWebSocket: () => {
+        const socket = new MockSocket();
+        sockets.push(socket);
+        return socket as unknown as WebSocket;
+      },
+      onComment,
+    });
+    return onComment;
+  }
+
+  it('reconnects after a drop with exponential backoff and resets after success', () => {
+    subscribe();
+    sockets[0].open();
+    sockets[0].drop();
+    vi.advanceTimersByTime(999);
+    expect(sockets).toHaveLength(1);
+    vi.advanceTimersByTime(1);
+    expect(sockets).toHaveLength(2);
+
+    sockets[1].open();
+    sockets[1].drop();
+    vi.advanceTimersByTime(999);
+    expect(sockets).toHaveLength(2);
+    vi.advanceTimersByTime(1);
+    expect(sockets).toHaveLength(3);
+  });
+
+  it('reconnects immediately when a backgrounded tab becomes visible', () => {
+    subscribe();
+    sockets[0].open();
+    sockets[0].drop();
+
+    Object.defineProperty(document, 'visibilityState', { configurable: true, value: 'hidden' });
+    document.dispatchEvent(new Event('visibilitychange'));
+    expect(sockets).toHaveLength(1);
+
+    Object.defineProperty(document, 'visibilityState', { configurable: true, value: 'visible' });
+    document.dispatchEvent(new Event('visibilitychange'));
+    expect(sockets).toHaveLength(2);
+  });
+
+  it('closes the socket and prevents reconnect after unsubscribe', () => {
+    subscribe();
+    sockets[0].open();
+    unsubscribeFromComments('project-123');
+
+    expect(sockets[0].close).toHaveBeenCalledTimes(1);
+    vi.advanceTimersByTime(30_000);
+    expect(sockets).toHaveLength(1);
+  });
+});

--- a/project-portal/project-portal-web/src/lib/ws/collaborationSocket.ts
+++ b/project-portal/project-portal-web/src/lib/ws/collaborationSocket.ts
@@ -1,0 +1,130 @@
+import type { Comment } from '@/lib/store/collaboration/collaboration.types';
+
+type CommentEvent = {
+  event?: string;
+  type?: string;
+  projectId?: string;
+  project_id?: string;
+  data?: Comment | { comment?: Comment };
+  comment?: Comment;
+};
+
+export type CollaborationSocketOptions = {
+  createWebSocket?: (url: string) => WebSocket;
+  onComment: (comment: Comment) => void;
+  onStatusChange?: (status: 'connecting' | 'connected' | 'disconnected') => void;
+};
+
+const MAX_RECONNECT_DELAY = 30_000;
+let activeSubscription: CollaborationSocketSubscription | null = null;
+
+function getWebSocketUrl(projectId: string): string {
+  const configuredUrl = process.env.NEXT_PUBLIC_COLLABORATION_WS_URL?.trim();
+  if (configuredUrl) {
+    return `${configuredUrl.replace(/\/$/, '')}/${encodeURIComponent(projectId)}`;
+  }
+
+  const apiUrl = process.env.NEXT_PUBLIC_API_BASE_URL?.trim() || 'http://localhost:8080';
+  const url = new URL(apiUrl);
+  url.protocol = url.protocol === 'https:' ? 'wss:' : 'ws:';
+  url.pathname = `${url.pathname.replace(/\/$/, '')}/collaboration/projects/${encodeURIComponent(projectId)}/comments`;
+  return url.toString();
+}
+
+function extractComment(message: CommentEvent, projectId: string): Comment | null {
+  const payload = message.comment ?? (message.data && 'comment' in message.data ? message.data.comment : message.data);
+  const eventName = message.event ?? message.type;
+  const comment = payload && 'id' in payload ? payload : null;
+  const eventProjectId = message.projectId ?? message.project_id ?? comment?.project_id;
+  return eventName === 'comment.created' && eventProjectId === projectId && comment
+    ? comment
+    : null;
+}
+
+export class CollaborationSocketSubscription {
+  readonly projectId: string;
+  private socket: WebSocket | null = null;
+  private reconnectTimer: ReturnType<typeof setTimeout> | null = null;
+  private reconnectAttempt = 0;
+  private closed = false;
+
+  constructor(projectId: string, private readonly options: CollaborationSocketOptions) {
+    this.projectId = projectId;
+  }
+
+  subscribe() {
+    this.closed = false;
+    this.connect();
+    if (typeof document !== 'undefined') document.addEventListener('visibilitychange', this.handleVisibilityChange);
+  }
+
+  unsubscribe() {
+    this.closed = true;
+    if (this.reconnectTimer) clearTimeout(this.reconnectTimer);
+    if (typeof document !== 'undefined') document.removeEventListener('visibilitychange', this.handleVisibilityChange);
+    this.socket?.close();
+    this.socket = null;
+  }
+
+  private connect = () => {
+    if (this.closed || typeof WebSocket === 'undefined') return;
+    this.options.onStatusChange?.('connecting');
+    const createWebSocket = this.options.createWebSocket ?? ((url: string) => new WebSocket(url));
+    this.socket = createWebSocket(getWebSocketUrl(this.projectId));
+    this.socket.onopen = () => {
+      this.reconnectAttempt = 0;
+      this.options.onStatusChange?.('connected');
+      this.socket?.send(JSON.stringify({ type: 'subscribe', projectId: this.projectId }));
+    };
+    this.socket.onmessage = (event) => {
+      try {
+        const comment = extractComment(JSON.parse(event.data) as CommentEvent, this.projectId);
+        if (comment) this.options.onComment(comment);
+      } catch {
+        // Ignore malformed messages from the socket.
+      }
+    };
+    this.socket.onclose = () => {
+      this.options.onStatusChange?.('disconnected');
+      this.scheduleReconnect();
+    };
+    this.socket.onerror = () => this.socket?.close();
+  };
+
+  private scheduleReconnect() {
+    if (this.closed || this.reconnectTimer) return;
+    const delay = Math.min(1000 * 2 ** this.reconnectAttempt, MAX_RECONNECT_DELAY);
+    this.reconnectAttempt += 1;
+    this.reconnectTimer = setTimeout(() => {
+      this.reconnectTimer = null;
+      this.connect();
+    }, delay);
+  }
+
+  private handleVisibilityChange = () => {
+    if (document.visibilityState !== 'visible' || this.closed) return;
+    if (!this.socket || this.socket.readyState !== WebSocket.OPEN) {
+      if (this.reconnectTimer) clearTimeout(this.reconnectTimer);
+      this.reconnectTimer = null;
+      this.socket?.close();
+      this.connect();
+    }
+  };
+}
+
+export function subscribeToComments(projectId: string, options: CollaborationSocketOptions): () => void {
+  activeSubscription?.unsubscribe();
+  activeSubscription = new CollaborationSocketSubscription(projectId, options);
+  activeSubscription.subscribe();
+  return () => {
+    activeSubscription?.unsubscribe();
+    activeSubscription = null;
+  };
+}
+
+export function unsubscribeFromComments(projectId: string) {
+  if (activeSubscription?.projectId === projectId) {
+    activeSubscription.unsubscribe();
+    activeSubscription = null;
+  }
+}


### PR DESCRIPTION
## Summary
Implements the frontend WebSocket client, subscription lifecycle, and de-duplication for real-time comment updates per #537.

## Implemented
- WebSocket client (`collaborationSocket.ts`) with project-scoped subscriptions
- Reconnect with exponential backoff (1s → 2s, resets on successful reconnect)
- Resubscription on tab visibility regain (`document.visibilityState`)
- Cleanup on unmount / project navigation
- De-duplication by comment ID (optimistic update vs. socket event)
- Test coverage: reconnect, visibility resubscribe, unmount cleanup,
  live rendering via `CommentSection`, dedup, project-switch resubscribe

## Blocked on backend
This depends on a backend WebSocket endpoint scoped by `projectId` that
broadcasts `comment.created` events. No such endpoint currently exists
in the Go backend. Frontend is implemented and tested against an
injectable socket factory, so it's ready to wire up as soon as the
endpoint contract is available.

**Requesting:** either a companion backend ticket, or pointers to who
owns the collaboration backend service, to unblock end-to-end delivery
(acceptance criterion: "comment created by another user appears without
manual refresh").

## Testing
- `pnpm vitest run` - 22 files / 195 tests passing
- `pnpm exec tsc --noEmit` - clean

---
closes #537 (frontend portion — see backend note above).