### PR TITLE
fix: encrypt sensitive Zustand persisted state

### DIFF
--- a/project-portal/project-portal-web/src/lib/store/encryptedStorage.test.ts
+++ b/project-portal/project-portal-web/src/lib/store/encryptedStorage.test.ts
@@ -1,0 +1,30 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { encryptedStorage } from "./encryptedStorage";
+
+describe("encryptedStorage", () => {
+  const values = new Map<string, string>();
+
+  beforeEach(() => {
+    values.clear();
+    vi.spyOn(localStorage, "getItem").mockImplementation((key) => values.get(key) ?? null);
+    vi.spyOn(localStorage, "setItem").mockImplementation((key, value) => values.set(key, value));
+    vi.spyOn(localStorage, "removeItem").mockImplementation((key) => values.delete(key));
+    vi.spyOn(localStorage, "clear").mockImplementation(() => values.clear());
+    localStorage.clear();
+    sessionStorage.clear();
+  });
+
+  it("does not persist plaintext tokens", async () => {
+    await encryptedStorage.setItem("project-portal-store-v2", JSON.stringify({ token: "jwt-secret", refreshToken: "refresh-secret" }));
+    const raw = localStorage.getItem("project-portal-store-v2");
+    expect(raw).not.toContain("jwt-secret");
+    expect(raw).not.toContain("refresh-secret");
+    await expect(encryptedStorage.getItem("project-portal-store-v2")).resolves.toContain("jwt-secret");
+  });
+
+  it("clears corrupted state gracefully", async () => {
+    localStorage.setItem("project-portal-store-v2", "not-encrypted");
+    await expect(encryptedStorage.getItem("project-portal-store-v2")).resolves.toBeNull();
+    expect(localStorage.getItem("project-portal-store-v2")).toBeNull();
+  });
+});

--- a/project-portal/project-portal-web/src/lib/store/encryptedStorage.ts
+++ b/project-portal/project-portal-web/src/lib/store/encryptedStorage.ts
@@ -1,0 +1,47 @@
+const KEY_SLOT = "project-portal-storage-key-v1";
+
+function bytesToBase64(bytes: Uint8Array): string {
+  return btoa(String.fromCharCode(...bytes));
+}
+
+function base64ToBytes(value: string): Uint8Array {
+  return Uint8Array.from(atob(value), (char) => char.charCodeAt(0));
+}
+
+async function getKey(): Promise<CryptoKey> {
+  const stored = sessionStorage.getItem(KEY_SLOT);
+  const raw = stored ? base64ToBytes(stored) : crypto.getRandomValues(new Uint8Array(32));
+  if (!stored) sessionStorage.setItem(KEY_SLOT, bytesToBase64(raw));
+  return crypto.subtle.importKey("raw", raw as BufferSource, "AES-GCM", false, ["encrypt", "decrypt"]);
+}
+
+export const encryptedStorage = {
+  async getItem(name: string): Promise<string | null> {
+    const encoded = localStorage.getItem(name);
+    if (!encoded) return null;
+    try {
+      const [ivText, dataText] = encoded.split(".");
+      const plain = await crypto.subtle.decrypt(
+        { name: "AES-GCM", iv: base64ToBytes(ivText) as BufferSource },
+        await getKey(),
+        base64ToBytes(dataText) as BufferSource,
+      );
+      return new TextDecoder().decode(plain);
+    } catch {
+      localStorage.removeItem(name);
+      return null;
+    }
+  },
+  async setItem(name: string, value: string): Promise<void> {
+    const iv = crypto.getRandomValues(new Uint8Array(12));
+    const encrypted = await crypto.subtle.encrypt(
+      { name: "AES-GCM", iv: iv as BufferSource },
+      await getKey(),
+      new TextEncoder().encode(value) as BufferSource,
+    );
+    localStorage.setItem(name, `${bytesToBase64(iv)}.${bytesToBase64(new Uint8Array(encrypted))}`);
+  },
+  async removeItem(name: string): Promise<void> {
+    localStorage.removeItem(name);
+  },
+};

--- a/project-portal/project-portal-web/src/lib/store/store.ts
+++ b/project-portal/project-portal-web/src/lib/store/store.ts
@@ -1,6 +1,7 @@
 import { setAuthToken, setUserIdGetter } from "@/lib/api/axios";
 import { create } from "zustand";
-import { persist } from "zustand/middleware";
+import { createJSONStorage, persist } from "zustand/middleware";
+import { encryptedStorage } from "./encryptedStorage";
 import { createAuthSlice } from "./auth/auth.slice";
 import type { AuthSlice } from "./auth/auth.types";
 import type { CollaborationSlice } from "./collaboration/collaboration.types";
@@ -55,13 +56,13 @@ export const useStore = create<StoreState>()(
       ...createReportsSlice(...args),
     }),
     {
-      name: "project-portal-store",
+      name: "project-portal-store-v2",
+      storage: createJSONStorage(() => encryptedStorage),
       partialize: (s: StoreState) => ({
         token: s.token,
-        refreshToken: s.refreshToken,
         expiresIn: s.expiresIn,
         tokenType: s.tokenType,
-        user: s.user,
+        user: s.user ? { id: s.user.id, full_name: s.user.full_name } : null,
         isAuthenticated: s.isAuthenticated,
       }),
       onRehydrateStorage: () => (state?: StoreState) => {


### PR DESCRIPTION
## Summary
- encrypt persisted Zustand state with AES-GCM storage
- remove refresh tokens and minimize persisted user data
- clear unreadable legacy/corrupt state safely

## Verification
- `npm test -- --run src/lib/store/encryptedStorage.test.ts` (2 passed)
- `npx tsc --noEmit`

Closes #539