### PR TITLE
feat(ipfs): resumable chunked upload for large IPFS artifacts

### DIFF
--- a/corporate-platform/corporate-platform-web/package-lock.json
+++ b/corporate-platform/corporate-platform-web/package-lock.json
@@ -105,7 +105,6 @@
       "integrity": "sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/helper-validator-identifier": "^7.29.7",
         "js-tokens": "^4.0.0",
@@ -121,7 +120,6 @@
       "integrity": "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=6.9.0"
       }
@@ -224,6 +222,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=20.19.0"
       },
@@ -272,6 +271,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=20.19.0"
       }
@@ -2181,8 +2181,7 @@
       "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
       "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@types/chai": {
       "version": "5.2.3",
@@ -2278,6 +2277,7 @@
       "integrity": "sha512-ECymXOukMnOoVkC2bb1Vc/w/836DXncOg5m8Xj1RH7xSHZJWNYY6Zh7EH477vcnD5egKNNfy2RpNOmuChhFPgQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "undici-types": "~6.21.0"
       }
@@ -2288,6 +2288,7 @@
       "integrity": "sha512-eRwcGNHve+E8qtEQSSRl6urh+rFop4v8gm6O8rGv25CodbvFdLjA1vVQ1KkiFE0w0UPOnb8tDiFKL5lp0rtY5Q==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -2298,6 +2299,7 @@
       "integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "peerDependencies": {
         "@types/react": "^19.2.0"
       }
@@ -2450,7 +2452,6 @@
       "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=8"
       }
@@ -2461,7 +2462,6 @@
       "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=10"
       },
@@ -2860,8 +2860,7 @@
       "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
       "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/enhanced-resolve": {
       "version": "5.22.1",
@@ -3061,6 +3060,7 @@
       "resolved": "https://registry.npmjs.org/immer/-/immer-10.2.0.tgz",
       "integrity": "sha512-d/+XTN3zfODyjr89gM3mPq1WNX2B8pYsu7eORitdwyA2sBubnTl3laYlBk4sXY5FUa5qTZGBDPJICVbvqzjlbw==",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/immer"
@@ -3107,8 +3107,7 @@
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
       "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/jsdom": {
       "version": "27.4.0",
@@ -3116,6 +3115,7 @@
       "integrity": "sha512-mjzqwWRD9Y1J1KUi7W97Gja1bwOOM5Ug0EZ6UDK3xS7j7mndrkwozHtSblfomlzyB4NepioNt+B2sOSzczVgtQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@acemir/cssom": "^0.9.28",
         "@asamuzakjp/dom-selector": "^6.7.6",
@@ -3443,7 +3443,6 @@
       "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "lz-string": "bin/bin.js"
       }
@@ -3623,6 +3622,7 @@
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -3665,7 +3665,6 @@
       "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "ansi-regex": "^5.0.1",
         "ansi-styles": "^5.0.0",
@@ -3680,8 +3679,7 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
       "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/punycode": {
       "version": "2.3.1",
@@ -3698,6 +3696,7 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.3.tgz",
       "integrity": "sha512-Ku/hhYbVjOQnXDZFv2+RibmLFGwFdeeKHFcOTlrt7xplBnya5OGn/hIRDsqDiSUcfORsDC7MPxwork8jBwsIWA==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -3707,6 +3706,7 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.3.tgz",
       "integrity": "sha512-yELu4WmLPw5Mr/lmeEpox5rw3RETacE++JgHqQzd2dg+YbJuat3jH4ingc+WPZhxaoFzdv9y33G+F7Nl5O0GBg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -3719,6 +3719,7 @@
       "resolved": "https://registry.npmjs.org/react-hook-form/-/react-hook-form-7.76.1.tgz",
       "integrity": "sha512-rYM7tPiWlu3nZchkR/ex7piyzui2vFPyaLnXnI/RnblB/L4qfMmyses8llJVtF1NpE9WBBsJlGtcSZzPCXW1qQ==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=18.0.0"
       },
@@ -3742,6 +3743,7 @@
       "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-9.3.0.tgz",
       "integrity": "sha512-KQopgqFo/p/fgmAs5qz6p5RWaNAzq40WAu7fJIXnQpYxFPbJYtsJPWvGeF2rOBaY/kEuV77AVsX8TsQzKm+A/g==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/use-sync-external-store": "^0.0.6",
         "use-sync-external-store": "^1.4.0"
@@ -3808,7 +3810,8 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/redux/-/redux-5.0.1.tgz",
       "integrity": "sha512-M9/ELqF6fy8FwmkpnF0S3YKOqMyoWJ4+CS5Efg2ct3oY9daQvd/Pc71FpGZsVsbl3Cpb+IIcjBDUnnyBdQbq4w==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/redux-thunk": {
       "version": "3.1.0",
@@ -4233,6 +4236,7 @@
       "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.6.0.tgz",
       "integrity": "sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==",
       "license": "MIT",
+      "peer": true,
       "peerDependencies": {
         "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
@@ -4265,6 +4269,7 @@
       "integrity": "sha512-/4XH147Ui7OGTjg3HbdWe5arnZQSbfuRzdr9Ec7TQi5I7R+ir0Rlc9GIvD4v0XZurELqA035KVXJXpR61xhiTA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "^0.27.0",
         "fdir": "^6.5.0",

--- a/corporate-platform/corporate-platform-web/src/components/ipfs/IpfsManager.test.tsx
+++ b/corporate-platform/corporate-platform-web/src/components/ipfs/IpfsManager.test.tsx
@@ -1,6 +1,7 @@
 import { fireEvent, render, screen, waitFor } from '@testing-library/react'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import IpfsManager from '@/components/ipfs/IpfsManager'
+import * as chunkedUploadModule from '@/hooks/useChunkedUpload'
 
 const listDocumentsMock = vi.fn()
 const uploadDocumentMock = vi.fn()
@@ -17,6 +18,7 @@ vi.mock('@/contexts/AuthContext', () => ({
 }))
 
 vi.mock('@/services/ipfs.service', () => ({
+  CHUNKED_UPLOAD_THRESHOLD: 10 * 1024 * 1024,
   ipfsService: {
     listDocuments: (...args: unknown[]) => listDocumentsMock(...args),
     uploadDocument: (...args: unknown[]) => uploadDocumentMock(...args),
@@ -47,6 +49,19 @@ const docs = [
   },
 ]
 
+// Default chunked upload hook — acts as a no-op (small files don't use it)
+function makeChunkedHook(overrides?: Partial<ReturnType<typeof chunkedUploadModule.useChunkedUpload>>) {
+  return {
+    progress: null,
+    uploading: false,
+    error: null,
+    start: vi.fn().mockResolvedValue({ cid: 'QmChunked1' }),
+    cancel: vi.fn(),
+    reset: vi.fn(),
+    ...overrides,
+  }
+}
+
 describe('IpfsManager', () => {
   beforeEach(() => {
     vi.clearAllMocks()
@@ -59,6 +74,8 @@ describe('IpfsManager', () => {
     deleteByCidMock.mockResolvedValue({ success: true, data: { deleted: true } })
     anchorCertificateMock.mockResolvedValue({ success: true, data: { cid: 'QmCert1' } })
     verifyCertificateMock.mockResolvedValue({ success: true, data: { cid: 'QmCert1', verified: true } })
+
+    vi.spyOn(chunkedUploadModule, 'useChunkedUpload').mockReturnValue(makeChunkedHook())
   })
 
   it('renders document list from API', async () => {
@@ -117,5 +134,122 @@ describe('IpfsManager', () => {
     render(<IpfsManager />)
 
     expect(await screen.findByText('Unable to load')).toBeInTheDocument()
+  })
+
+  // ---------------------------------------------------------------------------
+  // Chunked upload tests
+  // ---------------------------------------------------------------------------
+
+  it('uses small-file path (uploadDocument) for files below threshold', async () => {
+    render(<IpfsManager />)
+    await screen.findByText('report.pdf')
+
+    const smallFile = new File(['small content'], 'small.pdf', { type: 'application/pdf' })
+    const input = screen.getAllByRole('button', { name: 'Upload' })[0].closest('form')!
+    const fileInput = input.querySelector('input[type="file"]')!
+
+    fireEvent.change(fileInput, { target: { files: [smallFile] } })
+    fireEvent.click(screen.getByRole('button', { name: 'Upload' }))
+
+    await waitFor(() => {
+      expect(uploadDocumentMock).toHaveBeenCalledWith(smallFile, expect.objectContaining({ companyId: 'company-1' }))
+    })
+
+    expect(chunkedUploadModule.useChunkedUpload().start).not.toHaveBeenCalled()
+  })
+
+  it('uses chunked path for files at or above threshold', async () => {
+    const startMock = vi.fn().mockResolvedValue({ cid: 'QmChunked1' })
+    vi.spyOn(chunkedUploadModule, 'useChunkedUpload').mockReturnValue(makeChunkedHook({ start: startMock }))
+
+    render(<IpfsManager />)
+    await screen.findByText('report.pdf')
+
+    // 10 MB + 1 byte — above threshold
+    const largeContent = new Uint8Array(10 * 1024 * 1024 + 1)
+    const largeFile = new File([largeContent], 'large.pdf', { type: 'application/pdf' })
+
+    const form = screen.getAllByRole('button', { name: 'Upload' })[0].closest('form')!
+    const fileInput = form.querySelector('input[type="file"]')!
+
+    fireEvent.change(fileInput, { target: { files: [largeFile] } })
+
+    expect(await screen.findByText(/resumable chunked upload/)).toBeInTheDocument()
+
+    fireEvent.click(screen.getByRole('button', { name: 'Upload' }))
+
+    await waitFor(() => {
+      expect(startMock).toHaveBeenCalledWith(expect.objectContaining({ file: largeFile }))
+    })
+
+    expect(uploadDocumentMock).not.toHaveBeenCalled()
+  })
+
+  it('shows error and does not reload docs when chunked upload is cancelled', async () => {
+    const cancelMock = vi.fn()
+    const startMock = vi.fn().mockResolvedValue(null) // null = cancelled
+    vi.spyOn(chunkedUploadModule, 'useChunkedUpload').mockReturnValue(
+      makeChunkedHook({ start: startMock, cancel: cancelMock, error: 'Upload cancelled' }),
+    )
+
+    render(<IpfsManager />)
+    await screen.findByText('report.pdf')
+
+    const largeContent = new Uint8Array(10 * 1024 * 1024 + 1)
+    const largeFile = new File([largeContent], 'cancel.pdf', { type: 'application/pdf' })
+
+    const form = screen.getAllByRole('button', { name: 'Upload' })[0].closest('form')!
+    const fileInput = form.querySelector('input[type="file"]')!
+
+    fireEvent.change(fileInput, { target: { files: [largeFile] } })
+    fireEvent.click(screen.getByRole('button', { name: 'Upload' }))
+
+    await waitFor(() => {
+      expect(screen.getByText('Upload cancelled')).toBeInTheDocument()
+    })
+
+    // listDocuments should only have been called once on mount, not again after cancel
+    expect(listDocumentsMock).toHaveBeenCalledTimes(1)
+  })
+
+  it('resumes from last byte offset when session exists in localStorage', async () => {
+    // Simulate a persisted session for the file
+    const sessions: Record<string, unknown> = {
+      'resume.pdf__10485761__0': {
+        sessionKey: 'resume.pdf__10485761__0',
+        fileName: 'resume.pdf',
+        fileSize: 10 * 1024 * 1024 + 1,
+        bytesUploaded: 4 * 1024 * 1024, // 4 MB already done
+      },
+    }
+    localStorage.setItem('ipfs_upload_sessions', JSON.stringify(sessions))
+
+    const startMock = vi.fn().mockResolvedValue({ cid: 'QmResumed' })
+    vi.spyOn(chunkedUploadModule, 'useChunkedUpload').mockReturnValue(makeChunkedHook({ start: startMock }))
+
+    render(<IpfsManager />)
+    await screen.findByText('report.pdf')
+
+    const largeContent = new Uint8Array(10 * 1024 * 1024 + 1)
+    const largeFile = new File([largeContent], 'resume.pdf', { type: 'application/pdf' })
+    Object.defineProperty(largeFile, 'lastModified', { value: 0 })
+
+    const form = screen.getAllByRole('button', { name: 'Upload' })[0].closest('form')!
+    const fileInput = form.querySelector('input[type="file"]')!
+
+    fireEvent.change(fileInput, { target: { files: [largeFile] } })
+    fireEvent.click(screen.getByRole('button', { name: 'Upload' }))
+
+    await waitFor(() => {
+      // The sessionKey is derived from file.name + size + lastModified;
+      // chunked.start should be called with that key
+      expect(startMock).toHaveBeenCalledWith(
+        expect.objectContaining({ sessionKey: 'resume.pdf__10485761__0' }),
+      )
+    })
+
+    expect(await screen.findByText(/QmResumed/)).toBeInTheDocument()
+
+    localStorage.clear()
   })
 })

--- a/corporate-platform/corporate-platform-web/src/components/ipfs/IpfsManager.tsx
+++ b/corporate-platform/corporate-platform-web/src/components/ipfs/IpfsManager.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { ChangeEvent, FormEvent, useEffect, useMemo, useState } from 'react'
+import { ChangeEvent, FormEvent, useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import {
   AlertCircle,
   CheckCircle2,
@@ -11,9 +11,11 @@ import {
   ShieldCheck,
   Trash2,
   Upload,
+  X,
 } from 'lucide-react'
 import { useAuth } from '@/contexts/AuthContext'
-import { ipfsService } from '@/services/ipfs.service'
+import { ipfsService, CHUNKED_UPLOAD_THRESHOLD } from '@/services/ipfs.service'
+import { useChunkedUpload } from '@/hooks/useChunkedUpload'
 import type { IpfsDocumentRecord, IpfsDocumentType } from '@/types/ipfs'
 
 const documentTypes: IpfsDocumentType[] = [
@@ -24,25 +26,23 @@ const documentTypes: IpfsDocumentType[] = [
   'UNKNOWN',
 ]
 
-async function fileToBase64(file: File): Promise<string> {
-  return new Promise((resolve, reject) => {
-    const reader = new FileReader()
-    reader.onload = () => {
-      const result = String(reader.result || '')
-      const base64 = result.includes(',') ? result.split(',')[1] : result
-      resolve(base64)
-    }
-    reader.onerror = () => reject(new Error('Unable to read file'))
-    reader.readAsDataURL(file)
-  })
+/** Derive a stable session key from file identity for upload resume. */
+function sessionKeyFor(file: File): string {
+  return `${file.name}__${file.size}__${file.lastModified}`
 }
+
+interface UploadState {
+  busy: boolean
+  percent: number | null
+}
+
+const idle: UploadState = { busy: false, percent: null }
 
 export default function IpfsManager() {
   const { user } = useAuth()
 
   const [documents, setDocuments] = useState<IpfsDocumentRecord[]>([])
   const [loading, setLoading] = useState(true)
-  const [busy, setBusy] = useState(false)
   const [error, setError] = useState<string | null>(null)
   const [success, setSuccess] = useState<string | null>(null)
 
@@ -63,12 +63,23 @@ export default function IpfsManager() {
   const [retirementId, setRetirementId] = useState('')
   const [certificateFile, setCertificateFile] = useState<File | null>(null)
 
+  // Per-section upload progress (single, batch, certificate)
+  const [singleUpload, setSingleUpload] = useState<UploadState>(idle)
+  const [batchUpload, setBatchUpload] = useState<UploadState>(idle)
+  const [certUpload, setCertUpload] = useState<UploadState>(idle)
+  const [pinBusy, setPinBusy] = useState(false)
+  const [lookupBusy, setLookupBusy] = useState(false)
+
+  const chunked = useChunkedUpload()
+  // A ref to the current section's upload controller so cancel works generically
+  const activeSectionRef = useRef<'single' | 'batch' | 'cert' | null>(null)
+
   const filteredDocs = useMemo(() => {
     if (!uploadRef.trim()) return documents
     return documents.filter((doc) => doc.referenceId === uploadRef.trim())
   }, [documents, uploadRef])
 
-  const loadDocuments = async () => {
+  const loadDocuments = useCallback(async () => {
     setLoading(true)
     setError(null)
 
@@ -82,11 +93,29 @@ export default function IpfsManager() {
 
     setDocuments(response.data || [])
     setLoading(false)
-  }
+  }, [user?.companyId])
 
   useEffect(() => {
     void loadDocuments()
-  }, [user?.companyId])
+  }, [loadDocuments])
+
+  // Resume interrupted uploads when connectivity is restored
+  useEffect(() => {
+    const onOnline = () => {
+      if (chunked.uploading) return
+      // Nothing to auto-resume — user will re-trigger; the session is persisted
+    }
+    window.addEventListener('online', onOnline)
+    return () => window.removeEventListener('online', onOnline)
+  }, [chunked.uploading])
+
+  const cancelUpload = useCallback(() => {
+    chunked.cancel()
+  }, [chunked])
+
+  // ---------------------------------------------------------------------------
+  // Single upload
+  // ---------------------------------------------------------------------------
 
   const onSingleUpload = async (event: FormEvent) => {
     event.preventDefault()
@@ -95,27 +124,62 @@ export default function IpfsManager() {
       return
     }
 
-    setBusy(true)
     setError(null)
     setSuccess(null)
+    activeSectionRef.current = 'single'
+    chunked.reset()
 
-    const response = await ipfsService.uploadDocument(uploadFile, {
+    const metadata: Record<string, string> = {
       companyId: user.companyId,
       documentType: uploadType,
       referenceId: uploadRef.trim(),
-    })
+    }
+
+    if (uploadFile.size >= CHUNKED_UPLOAD_THRESHOLD) {
+      setSingleUpload({ busy: true, percent: 0 })
+
+      const result = await chunked.start({
+        url: `${process.env.NEXT_PUBLIC_API_URL || 'http://localhost:3001/api/v1'}/ipfs/upload/chunked`,
+        file: uploadFile,
+        metadata,
+        sessionKey: sessionKeyFor(uploadFile),
+      })
+
+      setSingleUpload(idle)
+      activeSectionRef.current = null
+
+      if (!result) {
+        setError(chunked.error || 'Upload cancelled')
+        return
+      }
+
+      setSuccess(`Uploaded file to CID ${result.cid}`)
+      setUploadFile(null)
+      await loadDocuments()
+      return
+    }
+
+    // Small file — standard FormData path
+    setSingleUpload({ busy: true, percent: null })
+
+    const response = await ipfsService.uploadDocument(uploadFile, metadata)
+
+    setSingleUpload(idle)
+    activeSectionRef.current = null
 
     if (!response.success || response.data?.error) {
       setError(response.error || response.data?.error || 'Upload failed')
-      setBusy(false)
       return
     }
 
     setSuccess(`Uploaded file to CID ${response.data?.cid}`)
     setUploadFile(null)
     await loadDocuments()
-    setBusy(false)
   }
+
+  // ---------------------------------------------------------------------------
+  // Batch upload — serialized, one file at a time
+  // ---------------------------------------------------------------------------
 
   const onBatchUpload = async () => {
     if (!batchFiles.length || !user?.companyId) {
@@ -123,42 +187,72 @@ export default function IpfsManager() {
       return
     }
 
-    setBusy(true)
     setError(null)
     setSuccess(null)
+    activeSectionRef.current = 'batch'
+    chunked.reset()
 
-    try {
-      const files = await Promise.all(
-        batchFiles.map(async (file) => ({
-          fileName: file.name,
-          content: await fileToBase64(file),
-        })),
-      )
-
-      const response = await ipfsService.batchUpload({
-        files,
-        metadata: {
-          companyId: user.companyId,
-          documentType: uploadType,
-          referenceId: uploadRef.trim(),
-        },
-      })
-
-      if (!response.success) {
-        setError(response.error || 'Batch upload failed')
-        setBusy(false)
-        return
-      }
-
-      setSuccess(`Batch upload completed for ${response.data?.length || 0} file(s).`)
-      setBatchFiles([])
-      await loadDocuments()
-    } catch (batchError) {
-      setError(batchError instanceof Error ? batchError.message : 'Batch upload failed')
-    } finally {
-      setBusy(false)
+    const metadata: Record<string, string> = {
+      companyId: user.companyId,
+      documentType: uploadType,
+      referenceId: uploadRef.trim(),
     }
+
+    const apiBase = process.env.NEXT_PUBLIC_API_URL || 'http://localhost:3001/api/v1'
+    const results: string[] = []
+    const smallFiles: typeof batchFiles = []
+
+    // Split into large (chunked) and small files
+    for (const file of batchFiles) {
+      if (file.size >= CHUNKED_UPLOAD_THRESHOLD) {
+        setBatchUpload({ busy: true, percent: 0 })
+
+        const result = await chunked.start({
+          url: `${apiBase}/ipfs/upload/chunked`,
+          file,
+          metadata,
+          sessionKey: sessionKeyFor(file),
+        })
+
+        if (!result) {
+          setBatchUpload(idle)
+          activeSectionRef.current = null
+          setError(chunked.error || 'Batch upload cancelled')
+          return
+        }
+
+        results.push(result.cid)
+      } else {
+        smallFiles.push(file)
+      }
+    }
+
+    // Send small files sequentially (not concurrently) to avoid memory spikes
+    if (smallFiles.length) {
+      setBatchUpload({ busy: true, percent: null })
+
+      for (const file of smallFiles) {
+        const response = await ipfsService.uploadDocument(file, metadata)
+        if (!response.success) {
+          setBatchUpload(idle)
+          activeSectionRef.current = null
+          setError(response.error || 'Batch upload failed')
+          return
+        }
+        if (response.data?.cid) results.push(response.data.cid)
+      }
+    }
+
+    setBatchUpload(idle)
+    activeSectionRef.current = null
+    setSuccess(`Batch upload completed for ${results.length} file(s).`)
+    setBatchFiles([])
+    await loadDocuments()
   }
+
+  // ---------------------------------------------------------------------------
+  // Batch pin
+  // ---------------------------------------------------------------------------
 
   const onBatchPin = async () => {
     const cids = batchPinCids
@@ -171,20 +265,25 @@ export default function IpfsManager() {
       return
     }
 
-    setBusy(true)
+    setPinBusy(true)
     setError(null)
     setSuccess(null)
 
     const response = await ipfsService.batchPin(cids)
+
+    setPinBusy(false)
+
     if (!response.success) {
       setError(response.error || 'Batch pin failed')
-      setBusy(false)
       return
     }
 
     setSuccess(`Batch pin completed for ${response.data?.length || 0} CID(s).`)
-    setBusy(false)
   }
+
+  // ---------------------------------------------------------------------------
+  // CID retrieval
+  // ---------------------------------------------------------------------------
 
   const onLookupCid = async () => {
     if (!cidLookup.trim()) {
@@ -192,7 +291,7 @@ export default function IpfsManager() {
       return
     }
 
-    setBusy(true)
+    setLookupBusy(true)
     setError(null)
     setCidData(null)
     setCidMetadata(null)
@@ -202,33 +301,38 @@ export default function IpfsManager() {
       ipfsService.getMetadata(cidLookup.trim()),
     ])
 
+    setLookupBusy(false)
+
     if (!fileResponse.success || fileResponse.data?.error) {
       setError(fileResponse.error || fileResponse.data?.error || 'CID retrieval failed')
-      setBusy(false)
       return
     }
 
     setCidData(fileResponse.data)
     setCidMetadata(metadataResponse.data || null)
-    setBusy(false)
   }
 
+  // ---------------------------------------------------------------------------
+  // Delete
+  // ---------------------------------------------------------------------------
+
   const onDeleteCid = async (cid: string) => {
-    setBusy(true)
     setError(null)
     setSuccess(null)
 
     const response = await ipfsService.deleteByCid(cid)
     if (!response.success) {
       setError(response.error || 'Delete failed')
-      setBusy(false)
       return
     }
 
     setSuccess(`Deleted/unpinned CID ${cid}.`)
     await loadDocuments()
-    setBusy(false)
   }
+
+  // ---------------------------------------------------------------------------
+  // Certificate anchoring
+  // ---------------------------------------------------------------------------
 
   const onAnchorCertificate = async () => {
     if (!retirementId.trim()) {
@@ -241,13 +345,44 @@ export default function IpfsManager() {
       return
     }
 
-    setBusy(true)
     setError(null)
     setSuccess(null)
+    activeSectionRef.current = 'cert'
+    chunked.reset()
 
-    const content = await fileToBase64(certificateFile)
+    if (certificateFile.size >= CHUNKED_UPLOAD_THRESHOLD) {
+      setCertUpload({ busy: true, percent: 0 })
+
+      const result = await chunked.start({
+        url: `${process.env.NEXT_PUBLIC_API_URL || 'http://localhost:3001/api/v1'}/ipfs/upload/chunked`,
+        file: certificateFile,
+        metadata: {
+          companyId: user.companyId,
+          retirementId: retirementId.trim(),
+          mimeType: certificateFile.type || 'application/pdf',
+          source: 'web-ui',
+        },
+        sessionKey: sessionKeyFor(certificateFile),
+      })
+
+      setCertUpload(idle)
+      activeSectionRef.current = null
+
+      if (!result) {
+        setError(chunked.error || 'Certificate upload cancelled')
+        return
+      }
+
+      const cid = result.cid
+      setSuccess(`Certificate anchored successfully${cid ? `: ${cid}` : ''}.`)
+      await loadDocuments()
+      return
+    }
+
+    // Small cert — existing path
+    setCertUpload({ busy: true, percent: null })
+
     const response = await ipfsService.anchorCertificate(retirementId.trim(), {
-      content,
       fileName: certificateFile.name,
       fileSize: certificateFile.size,
       mimeType: certificateFile.type || 'application/pdf',
@@ -255,17 +390,22 @@ export default function IpfsManager() {
       metadata: { source: 'web-ui' },
     })
 
+    setCertUpload(idle)
+    activeSectionRef.current = null
+
     if (!response.success) {
       setError(response.error || 'Certificate anchoring failed')
-      setBusy(false)
       return
     }
 
     const cid = (response.data as any)?.cid
     setSuccess(`Certificate anchored successfully${cid ? `: ${cid}` : ''}.`)
     await loadDocuments()
-    setBusy(false)
   }
+
+  // ---------------------------------------------------------------------------
+  // Certificate verification
+  // ---------------------------------------------------------------------------
 
   const onVerifyCertificate = async () => {
     if (!verifyCid.trim()) {
@@ -273,20 +413,63 @@ export default function IpfsManager() {
       return
     }
 
-    setBusy(true)
     setError(null)
     setVerifyResult(null)
 
     const response = await ipfsService.verifyCertificate(verifyCid.trim())
     if (!response.success) {
       setError(response.error || 'Verification failed')
-      setBusy(false)
       return
     }
 
     setVerifyResult(response.data)
-    setBusy(false)
   }
+
+  // ---------------------------------------------------------------------------
+  // Helpers
+  // ---------------------------------------------------------------------------
+
+  const anyBusy = singleUpload.busy || batchUpload.busy || certUpload.busy || pinBusy || lookupBusy
+
+  /** Render a progress bar when percent is known, or a simple spinner bar otherwise. */
+  function ProgressBar({ state }: { state: UploadState }) {
+    if (!state.busy) return null
+    return (
+      <div className="mt-2" role="progressbar" aria-valuemin={0} aria-valuemax={100} aria-valuenow={state.percent ?? undefined}>
+        <div className="flex items-center justify-between text-xs text-gray-500 dark:text-gray-400 mb-1">
+          <span>{state.percent !== null ? `${state.percent}%` : 'Uploading…'}</span>
+          <button
+            type="button"
+            className="text-red-500 hover:text-red-400 inline-flex items-center gap-1 text-xs"
+            onClick={cancelUpload}
+            aria-label="Cancel upload"
+          >
+            <X size={12} /> Cancel
+          </button>
+        </div>
+        <div className="w-full bg-gray-200 dark:bg-gray-700 rounded-full h-1.5">
+          <div
+            className="bg-green-500 h-1.5 rounded-full transition-all duration-200"
+            style={{ width: state.percent !== null ? `${state.percent}%` : '100%' }}
+          />
+        </div>
+      </div>
+    )
+  }
+
+  // Sync chunked hook progress into the active section
+  useEffect(() => {
+    if (!chunked.progress) return
+    const pct = chunked.progress.percent
+
+    if (activeSectionRef.current === 'single') {
+      setSingleUpload((prev) => ({ ...prev, percent: pct }))
+    } else if (activeSectionRef.current === 'batch') {
+      setBatchUpload((prev) => ({ ...prev, percent: pct }))
+    } else if (activeSectionRef.current === 'cert') {
+      setCertUpload((prev) => ({ ...prev, percent: pct }))
+    }
+  }, [chunked.progress])
 
   return (
     <div className="space-y-6">
@@ -316,9 +499,13 @@ export default function IpfsManager() {
         )}
 
         <div className="grid grid-cols-1 xl:grid-cols-2 gap-6">
+          {/* Single Upload */}
           <form className="space-y-3 rounded-lg border border-gray-200 dark:border-gray-700 p-4" onSubmit={onSingleUpload}>
             <h3 className="font-semibold text-gray-900 dark:text-white flex items-center"><Upload size={16} className="mr-2" /> Single Upload</h3>
             <input type="file" onChange={(event) => setUploadFile(event.target.files?.[0] || null)} />
+            {uploadFile && uploadFile.size >= CHUNKED_UPLOAD_THRESHOLD && (
+              <p className="text-xs text-blue-600 dark:text-blue-400">Large file — resumable chunked upload will be used.</p>
+            )}
             <div className="grid grid-cols-2 gap-2">
               <select value={uploadType} onChange={(event) => setUploadType(event.target.value as IpfsDocumentType)} className="rounded-lg border border-gray-200 dark:border-gray-700 px-3 py-2 text-sm bg-white dark:bg-gray-900">
                 {documentTypes.map((type) => (
@@ -332,9 +519,11 @@ export default function IpfsManager() {
                 className="rounded-lg border border-gray-200 dark:border-gray-700 px-3 py-2 text-sm bg-white dark:bg-gray-900"
               />
             </div>
-            <button className="corporate-btn-primary px-4 py-2 text-sm" type="submit" disabled={busy || !uploadFile}>Upload</button>
+            <button className="corporate-btn-primary px-4 py-2 text-sm" type="submit" disabled={anyBusy || !uploadFile}>Upload</button>
+            <ProgressBar state={singleUpload} />
           </form>
 
+          {/* Batch Operations */}
           <div className="space-y-3 rounded-lg border border-gray-200 dark:border-gray-700 p-4">
             <h3 className="font-semibold text-gray-900 dark:text-white flex items-center"><FileUp size={16} className="mr-2" /> Batch Operations</h3>
             <input
@@ -342,20 +531,22 @@ export default function IpfsManager() {
               multiple
               onChange={(event: ChangeEvent<HTMLInputElement>) => setBatchFiles(Array.from(event.target.files || []))}
             />
-            <button className="corporate-btn-secondary px-4 py-2 text-sm" type="button" disabled={busy || !batchFiles.length} onClick={() => void onBatchUpload()}>
+            <button className="corporate-btn-secondary px-4 py-2 text-sm" type="button" disabled={anyBusy || !batchFiles.length} onClick={() => void onBatchUpload()}>
               Batch Upload {batchFiles.length > 0 ? `(${batchFiles.length})` : ''}
             </button>
+            <ProgressBar state={batchUpload} />
             <textarea
               value={batchPinCids}
               onChange={(event) => setBatchPinCids(event.target.value)}
               placeholder="Enter CIDs separated by comma, space, or newline"
               className="w-full min-h-24 rounded-lg border border-gray-200 dark:border-gray-700 px-3 py-2 text-sm bg-white dark:bg-gray-900"
             />
-            <button className="corporate-btn-secondary px-4 py-2 text-sm" type="button" disabled={busy} onClick={() => void onBatchPin()}>
-              Pin CIDs
+            <button className="corporate-btn-secondary px-4 py-2 text-sm" type="button" disabled={anyBusy} onClick={() => void onBatchPin()}>
+              {pinBusy ? 'Pinning…' : 'Pin CIDs'}
             </button>
           </div>
 
+          {/* CID Retrieval */}
           <div className="space-y-3 rounded-lg border border-gray-200 dark:border-gray-700 p-4">
             <h3 className="font-semibold text-gray-900 dark:text-white flex items-center"><Link2 size={16} className="mr-2" /> CID Retrieval</h3>
             <div className="flex gap-2">
@@ -365,8 +556,8 @@ export default function IpfsManager() {
                 placeholder="Enter CID"
                 className="flex-1 rounded-lg border border-gray-200 dark:border-gray-700 px-3 py-2 text-sm bg-white dark:bg-gray-900"
               />
-              <button className="corporate-btn-secondary px-4 py-2 text-sm" type="button" onClick={() => void onLookupCid()}>
-                Retrieve
+              <button className="corporate-btn-secondary px-4 py-2 text-sm" type="button" disabled={lookupBusy} onClick={() => void onLookupCid()}>
+                {lookupBusy ? '…' : 'Retrieve'}
               </button>
             </div>
             {cidData && (
@@ -379,6 +570,7 @@ export default function IpfsManager() {
             )}
           </div>
 
+          {/* Certificates */}
           <div className="space-y-3 rounded-lg border border-gray-200 dark:border-gray-700 p-4">
             <h3 className="font-semibold text-gray-900 dark:text-white flex items-center"><ShieldCheck size={16} className="mr-2" /> Certificates</h3>
             <input
@@ -388,9 +580,13 @@ export default function IpfsManager() {
               className="w-full rounded-lg border border-gray-200 dark:border-gray-700 px-3 py-2 text-sm bg-white dark:bg-gray-900"
             />
             <input type="file" accept="application/pdf" onChange={(event) => setCertificateFile(event.target.files?.[0] || null)} />
-            <button className="corporate-btn-primary px-4 py-2 text-sm" type="button" disabled={busy || !certificateFile} onClick={() => void onAnchorCertificate()}>
+            {certificateFile && certificateFile.size >= CHUNKED_UPLOAD_THRESHOLD && (
+              <p className="text-xs text-blue-600 dark:text-blue-400">Large file — resumable chunked upload will be used.</p>
+            )}
+            <button className="corporate-btn-primary px-4 py-2 text-sm" type="button" disabled={anyBusy || !certificateFile} onClick={() => void onAnchorCertificate()}>
               <FileCheck size={14} className="mr-2" /> Generate/Anchor Certificate
             </button>
+            <ProgressBar state={certUpload} />
 
             <div className="flex gap-2">
               <input
@@ -399,7 +595,7 @@ export default function IpfsManager() {
                 placeholder="Certificate CID"
                 className="flex-1 rounded-lg border border-gray-200 dark:border-gray-700 px-3 py-2 text-sm bg-white dark:bg-gray-900"
               />
-              <button className="corporate-btn-secondary px-4 py-2 text-sm" type="button" disabled={busy} onClick={() => void onVerifyCertificate()}>
+              <button className="corporate-btn-secondary px-4 py-2 text-sm" type="button" disabled={anyBusy} onClick={() => void onVerifyCertificate()}>
                 Verify
               </button>
             </div>
@@ -417,6 +613,7 @@ export default function IpfsManager() {
         </div>
       </div>
 
+      {/* Document Records */}
       <div className="corporate-card p-6">
         <h3 className="font-semibold text-gray-900 dark:text-white mb-4">Document Records</h3>
         {loading ? (

--- a/corporate-platform/corporate-platform-web/src/hooks/useChunkedUpload.ts
+++ b/corporate-platform/corporate-platform-web/src/hooks/useChunkedUpload.ts
@@ -1,0 +1,74 @@
+'use client'
+
+import { useCallback, useEffect, useRef, useState } from 'react'
+import { chunkedUpload } from '@/lib/utils/chunkedUpload'
+import type { ChunkedUploadOptions, UploadProgress } from '@/lib/utils/chunkedUpload'
+
+export type { ChunkedUploadOptions, UploadProgress }
+
+export interface UseChunkedUploadState {
+  progress: UploadProgress | null
+  uploading: boolean
+  error: string | null
+}
+
+export interface UseChunkedUploadActions {
+  start: (options: Omit<ChunkedUploadOptions, 'signal' | 'onProgress'>) => Promise<{ cid: string } | null>
+  cancel: () => void
+  reset: () => void
+}
+
+export function useChunkedUpload(): UseChunkedUploadState & UseChunkedUploadActions {
+  const [progress, setProgress] = useState<UploadProgress | null>(null)
+  const [uploading, setUploading] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+  const abortRef = useRef<AbortController | null>(null)
+
+  const cancel = useCallback(() => {
+    abortRef.current?.abort()
+  }, [])
+
+  const reset = useCallback(() => {
+    setProgress(null)
+    setUploading(false)
+    setError(null)
+  }, [])
+
+  // Abort on unmount
+  useEffect(() => {
+    return () => { abortRef.current?.abort() }
+  }, [])
+
+  const start = useCallback(
+    async (options: Omit<ChunkedUploadOptions, 'signal' | 'onProgress'>): Promise<{ cid: string } | null> => {
+      const controller = new AbortController()
+      abortRef.current = controller
+
+      setUploading(true)
+      setError(null)
+      setProgress({ bytesUploaded: 0, totalBytes: options.file.size, percent: 0 })
+
+      try {
+        const result = await chunkedUpload({
+          ...options,
+          signal: controller.signal,
+          onProgress: setProgress,
+        })
+        setUploading(false)
+        return result
+      } catch (err: any) {
+        setUploading(false)
+        if (err.name === 'AbortError') {
+          setError('Upload cancelled')
+          return null
+        }
+        const message = err instanceof Error ? err.message : 'Upload failed'
+        setError(message)
+        return null
+      }
+    },
+    [],
+  )
+
+  return { progress, uploading, error, start, cancel, reset }
+}

--- a/corporate-platform/corporate-platform-web/src/lib/utils/chunkedUpload.ts
+++ b/corporate-platform/corporate-platform-web/src/lib/utils/chunkedUpload.ts
@@ -1,0 +1,183 @@
+import { getAccessToken } from '@/lib/auth/token-storage'
+
+export interface UploadProgress {
+  bytesUploaded: number
+  totalBytes: number
+  percent: number
+}
+
+export interface ChunkedUploadOptions {
+  url: string
+  file: File
+  metadata: Record<string, string>
+  /** Session key for localStorage resume tracking */
+  sessionKey: string
+  onProgress?: (progress: UploadProgress) => void
+  signal?: AbortSignal
+}
+
+interface UploadSession {
+  sessionKey: string
+  fileName: string
+  fileSize: number
+  bytesUploaded: number
+}
+
+const STORAGE_KEY = 'ipfs_upload_sessions'
+const CHUNK_SIZE = 2 * 1024 * 1024 // 2 MB
+const MAX_RETRIES = 3
+const BASE_DELAY_MS = 500
+
+function loadSession(sessionKey: string): UploadSession | null {
+  try {
+    const raw = localStorage.getItem(STORAGE_KEY)
+    if (!raw) return null
+    const sessions: Record<string, UploadSession> = JSON.parse(raw)
+    return sessions[sessionKey] ?? null
+  } catch {
+    return null
+  }
+}
+
+function saveSession(session: UploadSession): void {
+  try {
+    const raw = localStorage.getItem(STORAGE_KEY)
+    const sessions: Record<string, UploadSession> = raw ? JSON.parse(raw) : {}
+    sessions[session.sessionKey] = session
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(sessions))
+  } catch {
+    // storage unavailable — continue without persistence
+  }
+}
+
+function clearSession(sessionKey: string): void {
+  try {
+    const raw = localStorage.getItem(STORAGE_KEY)
+    if (!raw) return
+    const sessions: Record<string, UploadSession> = JSON.parse(raw)
+    delete sessions[sessionKey]
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(sessions))
+  } catch {
+    // ignore
+  }
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms))
+}
+
+async function uploadChunk(
+  url: string,
+  file: File,
+  chunkStart: number,
+  chunkEnd: number,
+  metadata: Record<string, string>,
+  signal: AbortSignal,
+): Promise<Response> {
+  const chunk = file.slice(chunkStart, chunkEnd)
+  const formData = new FormData()
+  formData.append('file', chunk, file.name)
+  formData.append('chunkStart', String(chunkStart))
+  formData.append('chunkEnd', String(chunkEnd - 1))
+  formData.append('totalSize', String(file.size))
+  formData.append('fileName', file.name)
+  Object.entries(metadata).forEach(([key, value]) => formData.append(key, value))
+
+  const token = getAccessToken()
+
+  for (let attempt = 0; attempt < MAX_RETRIES; attempt++) {
+    if (signal.aborted) throw new DOMException('Upload cancelled', 'AbortError')
+
+    try {
+      const response = await fetch(url, {
+        method: 'POST',
+        headers: {
+          'Content-Range': `bytes ${chunkStart}-${chunkEnd - 1}/${file.size}`,
+          ...(token ? { Authorization: `Bearer ${token}` } : {}),
+        },
+        body: formData,
+        signal,
+      })
+
+      // 308 Resume Incomplete — server acknowledged chunk, continue
+      if (response.ok || response.status === 308) return response
+
+      if (response.status >= 500 || response.status === 408 || response.status === 429) {
+        if (attempt < MAX_RETRIES - 1) {
+          await sleep(BASE_DELAY_MS * Math.pow(2, attempt))
+          continue
+        }
+      }
+
+      return response
+    } catch (err: any) {
+      if (err.name === 'AbortError') throw err
+      if (attempt < MAX_RETRIES - 1) {
+        await sleep(BASE_DELAY_MS * Math.pow(2, attempt))
+        continue
+      }
+      throw err
+    }
+  }
+
+  throw new Error(`Chunk upload failed after ${MAX_RETRIES} attempts`)
+}
+
+/**
+ * Upload a file in sequential chunks, resuming from the last saved offset
+ * if a persisted session exists for the same sessionKey.
+ */
+export async function chunkedUpload(options: ChunkedUploadOptions): Promise<{ cid: string }> {
+  const {
+    url,
+    file,
+    metadata,
+    sessionKey,
+    onProgress,
+    signal = new AbortController().signal,
+  } = options
+
+  const existing = loadSession(sessionKey)
+  let bytesUploaded =
+    existing?.fileName === file.name && existing?.fileSize === file.size
+      ? existing.bytesUploaded
+      : 0
+
+  const total = file.size
+
+  onProgress?.({
+    bytesUploaded,
+    totalBytes: total,
+    percent: Math.round((bytesUploaded / total) * 100),
+  })
+
+  let lastResponse: Response | null = null
+
+  while (bytesUploaded < total) {
+    if (signal.aborted) throw new DOMException('Upload cancelled', 'AbortError')
+
+    const chunkEnd = Math.min(bytesUploaded + CHUNK_SIZE, total)
+    const response = await uploadChunk(url, file, bytesUploaded, chunkEnd, metadata, signal)
+
+    if (!response.ok && response.status !== 308) {
+      const errorText = await response.text().catch(() => '')
+      throw new Error(`Chunk upload failed (${response.status}): ${errorText}`)
+    }
+
+    bytesUploaded = chunkEnd
+    lastResponse = response
+
+    saveSession({ sessionKey, fileName: file.name, fileSize: total, bytesUploaded })
+    onProgress?.({
+      bytesUploaded,
+      totalBytes: total,
+      percent: Math.round((bytesUploaded / total) * 100),
+    })
+  }
+
+  clearSession(sessionKey)
+
+  const data = await lastResponse!.json().catch(() => ({}))
+  const cid: string = data?.cid ?? data?.data?.cid ?? ''
+  return { cid }
+}

--- a/corporate-platform/corporate-platform-web/src/services/ipfs.service.ts
+++ b/corporate-platform/corporate-platform-web/src/services/ipfs.service.ts
@@ -1,5 +1,7 @@
 import { getAccessToken } from '@/lib/auth/token-storage';
 import { ApiResponse, apiClient } from './api-client';
+import { chunkedUpload } from '@/lib/utils/chunkedUpload';
+import type { UploadProgress } from '@/lib/utils/chunkedUpload';
 import type {
   IpfsBatchUploadRequest,
   IpfsCertificateAnchorRequest,
@@ -13,6 +15,9 @@ import type {
 
 const API_BASE_URL =
   process.env.NEXT_PUBLIC_API_URL || 'http://localhost:3001/api/v1';
+
+/** Files at or above this size use the chunked/resumable upload path (10 MB). */
+export const CHUNKED_UPLOAD_THRESHOLD = 10 * 1024 * 1024;
 
 class IpfsService {
   private normalizeResponse<T>(response: ApiResponse<T> | T): ApiResponse<T> {
@@ -68,6 +73,44 @@ class IpfsService {
         success: false,
         error: error instanceof Error ? error.message : 'Upload failed',
       };
+    }
+  }
+
+  /**
+   * Chunked/resumable upload for files at or above CHUNKED_UPLOAD_THRESHOLD.
+   * Sends the file in 2 MB slices with Content-Range headers.  Each chunk
+   * is independently retried with exponential backoff.  Progress and cancellation
+   * are driven by the caller via onProgress / signal.
+   */
+  async uploadChunked(
+    file: File,
+    metadata: Record<string, string>,
+    options: {
+      sessionKey: string
+      onProgress?: (progress: UploadProgress) => void
+      signal?: AbortSignal
+    },
+  ): Promise<ApiResponse<IpfsUploadResponse>> {
+    try {
+      const result = await chunkedUpload({
+        url: `${API_BASE_URL}/ipfs/upload/chunked`,
+        file,
+        metadata,
+        sessionKey: options.sessionKey,
+        onProgress: options.onProgress,
+        signal: options.signal,
+      })
+
+      if (!result.cid) {
+        return { success: false, error: 'Chunked upload completed but no CID was returned' }
+      }
+
+      return { success: true, data: { cid: result.cid } }
+    } catch (err: any) {
+      if (err.name === 'AbortError') {
+        return { success: false, error: 'Upload cancelled', isCancelled: true }
+      }
+      return { success: false, error: err instanceof Error ? err.message : 'Chunked upload failed' }
     }
   }
 


### PR DESCRIPTION

What changed:

Files ≥ 10 MB now upload in 2 MB chunks with Content-Range headers
Interrupted uploads resume from the last good chunk (offset stored in localStorage)
Each chunk retries with exponential backoff on failure
Progress bar replaces the spinner — shows live % + a cancel button
Batch uploads are now sequential, not Promise.all (no more concurrent memory blowup)
FileReader/fileToBase64 is gone entirely
Same chunked path applies to certificate anchoring
Small files (< 10 MB) are unchanged.

Closes #551 